### PR TITLE
Increase build timeout to 60

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -22,7 +22,7 @@ jobs:
   parser:
     name: Build parser images
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Our builds have been timing out since we merged visualsign-ethereum and sui. 
[Example](https://github.com/anchorageoss/visualsign-parser/actions/runs/16608950290/job/46987726581)
I briefly considered using something like `Swatinem/rust-cache@v2` but maybe using something like an intermediate stageX image is a better option to retain reproducibility?