### PR TITLE
Adds CLA User workflow

### DIFF
--- a/.github/workflows/add-cla-user.yml
+++ b/.github/workflows/add-cla-user.yml
@@ -1,0 +1,52 @@
+name: add-cla-user
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write # To commit the change back to the repo
+  pull-requests: read
+
+jobs:
+  add-user-to-cla-list:
+    # Only run on pull request comments
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for command and maintainer permission
+        id: check
+        uses: actions-ecosystem/action-check-comment@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          comment: "/approve-cla"
+          allowed_actors: ${{ github.repository_owner }}/maintainers
+
+      - name: Add user to file if command is valid
+        if: steps.check.outputs.result == 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }} # Checkout the default branch
+
+      - run: |
+          AUTHOR_USERNAME=$(jq --raw-output .pull_request.user.login "$GITHUB_EVENT_PATH")
+          echo "Adding ${AUTHOR_USERNAME} to .cla-signed-users"
+
+          # Add the username, sort, and remove duplicates
+          (cat .cla-signed-users; echo "${AUTHOR_USERNAME}") | sort -u > .cla-signed-users.tmp
+          mv .cla-signed-users.tmp .cla-signed-users
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .cla-signed-users
+
+          # Only commit if there are actual changes
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: Add @${AUTHOR_USERNAME} to CLA signers list"
+            git push
+          else
+            echo "User is already in the list."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
Adds ability for maintainers to type `/add-cla-user` comment and have the user be added. This is only to be done if the user has Signed our CLA https://ironcladapp.com/public-launch/6896309b0f158de8c7450de6