### PR TITLE
add anchorageoss/ prefix to the maintainers list

### DIFF
--- a/.github/workflows/add-cla-user.yml
+++ b/.github/workflows/add-cla-user.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.command_check.outputs.should_proceed == 'true'
         id: check
         run: |
-          TEAM_SLUG="maintainers"
+          TEAM_SLUG="anchorageoss/maintainers"
           COMMENTER="${{ github.event.comment.user.login }}"
 
           echo "Checking if user '$COMMENTER' is in team '$TEAM_SLUG'..."


### PR DESCRIPTION
Tested that just `maintainers` doesn't work, adding the prefix 

https://github.com/anchorageoss/visualsign-parser/pull/15#issuecomment-3198730641