### PR TITLE
update the Cargo.lock to src/Cargo.lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,11 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: install protoc


### PR DESCRIPTION
I noticed that the CI was still not finding the hashed values for Cargo.lock because `**/Cargo.lock` doesn't work.. making it more specific to `src/Cargo.lock`