### PR TITLE
Fix default value in CLI: ephemeral_file should default to `EPHEMERAL_KEY_FILE`

### DIFF
--- a/src/parser/app/src/cli.rs
+++ b/src/parser/app/src/cli.rs
@@ -1,6 +1,6 @@
 //! CLI for the parser app
 use qos_core::{
-    QUORUM_FILE, SEC_APP_SOCK,
+    EPHEMERAL_KEY_FILE, SEC_APP_SOCK,
     cli::{EPHEMERAL_FILE_OPT, USOCK},
     handles::EphemeralKeyHandle,
     io::SocketAddress,
@@ -50,7 +50,7 @@ impl GetParserForOptions for ParserParser {
                     "path to file where the Ephemeral Key secret should be retrieved from. Use default for production.",
                 )
                 .takes_value(true)
-                .default_value(QUORUM_FILE),
+                .default_value(EPHEMERAL_KEY_FILE),
             )
     }
 }


### PR DESCRIPTION
Very straightforward fix; this was most likely a typo!