### PR TITLE
Solana fallback text remove arrows to prevent \u003e artifacts in response

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/instructions.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/instructions.rs
@@ -94,7 +94,7 @@ pub fn decode_transfers(
                     signable_payload_field: visualsign::SignablePayloadField::TextV2 {
                         common: visualsign::SignablePayloadFieldCommon {
                             fallback_text: format!(
-                                "Transfer {}: {} -> {}: {}",
+                                "Transfer {}: From {} To {} For {}",
                                 i + 1,
                                 transfer.from,
                                 transfer.to,
@@ -122,7 +122,7 @@ pub fn decode_transfers(
                     signable_payload_field: visualsign::SignablePayloadField::TextV2 {
                         common: visualsign::SignablePayloadFieldCommon {
                             fallback_text: format!(
-                                "SPL Transfer {}: {} -> {}: {}",
+                                "SPL Transfer {}: From {} To {} For {}",
                                 i + 1,
                                 spl_transfer.from,
                                 spl_transfer.to,

--- a/src/chain_parsers/visualsign-solana/src/core/txtypes/v0.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/txtypes/v0.rs
@@ -47,7 +47,7 @@ pub fn decode_v0_transfers(
                     signable_payload_field: SignablePayloadField::TextV2 {
                         common: SignablePayloadFieldCommon {
                             fallback_text: format!(
-                                "Transfer {}: {} -> {}: {}",
+                                "Transfer {}: From {} To {} For {}",
                                 i + 1,
                                 transfer.from,
                                 transfer.to,
@@ -75,7 +75,7 @@ pub fn decode_v0_transfers(
                     signable_payload_field: SignablePayloadField::TextV2 {
                         common: SignablePayloadFieldCommon {
                             fallback_text: format!(
-                                "SPL Transfer {}: {} -> {}: {}",
+                                "SPL Transfer {}: From {} To {} For {}",
                                 i + 1,
                                 spl_transfer.from,
                                 spl_transfer.to,

--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -164,7 +164,7 @@ async fn parser_solana_native_transfer_e2e() {
                 },
                 {
                     "Type": "text_v2",
-                    "FallbackText": "Transfer 1: HdD2N8HDzNEM6vwAq5mBLiUbgy1P9wyJfbASt93ndDsD -> 8jSCrV9xWkmMRSyf6xH3phL7SretagdqP3LRqkUYUp73: 1000000000",
+                    "FallbackText": "Transfer 1: From HdD2N8HDzNEM6vwAq5mBLiUbgy1P9wyJfbASt93ndDsD To 8jSCrV9xWkmMRSyf6xH3phL7SretagdqP3LRqkUYUp73 For 1000000000",
                     "Label": "Transfer 1",
                     "TextV2": {
                         "Text": "From: HdD2N8HDzNEM6vwAq5mBLiUbgy1P9wyJfbASt93ndDsD\nTo: 8jSCrV9xWkmMRSyf6xH3phL7SretagdqP3LRqkUYUp73\nAmount: 1000000000"

--- a/src/parser/cli/tests/fixtures/solana-json.expected
+++ b/src/parser/cli/tests/fixtures/solana-json.expected
@@ -18,7 +18,7 @@
     },
     {
       "Type": "text_v2",
-      "FallbackText": "Transfer 1: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY -> 7aHWbSHLuxkq9iN62P6zxU5VQWSH87x2hmhqQKm2Qara: 10000000000",
+      "FallbackText": "Transfer 1: From B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY To 7aHWbSHLuxkq9iN62P6zxU5VQWSH87x2hmhqQKm2Qara For 10000000000",
       "Label": "Transfer 1",
       "TextV2": {
         "Text": "From: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY\nTo: 7aHWbSHLuxkq9iN62P6zxU5VQWSH87x2hmhqQKm2Qara\nAmount: 10000000000"
@@ -26,7 +26,7 @@
     },
     {
       "Type": "text_v2",
-      "FallbackText": "Transfer 2: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY -> ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49: 10000",
+      "FallbackText": "Transfer 2: From B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY To ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49 For 10000",
       "Label": "Transfer 2",
       "TextV2": {
         "Text": "From: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY\nTo: ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49\nAmount: 10000"

--- a/src/parser/cli/tests/fixtures/solana-text.expected
+++ b/src/parser/cli/tests/fixtures/solana-text.expected
@@ -20,7 +20,7 @@ SignablePayload {
         },
         TextV2 {
             common: SignablePayloadFieldCommon {
-                fallback_text: "Transfer 1: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY -> 7aHWbSHLuxkq9iN62P6zxU5VQWSH87x2hmhqQKm2Qara: 10000000000",
+                fallback_text: "Transfer 1: From B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY To 7aHWbSHLuxkq9iN62P6zxU5VQWSH87x2hmhqQKm2Qara For 10000000000",
                 label: "Transfer 1",
             },
             text_v2: SignablePayloadFieldTextV2 {
@@ -29,7 +29,7 @@ SignablePayload {
         },
         TextV2 {
             common: SignablePayloadFieldCommon {
-                fallback_text: "Transfer 2: B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY -> ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49: 10000",
+                fallback_text: "Transfer 2: From B46xaUeRM112q7EVbsBJPfWMLs2X64vtZpJVE1ofKZMY To ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49 For 10000",
                 label: "Transfer 2",
             },
             text_v2: SignablePayloadFieldTextV2 {


### PR DESCRIPTION
This was the change I missed checking in #63 - probably need to refactor the tests like I did for Ethereum. I thought I had long done that for Solana and/or reverted it along the way. This should remove remaining issues.

Now Transfer fallback would be shown as `From <address> To <address> For <amount in lowest num>` it's fallback and usually not going to be rendered exactly.