### PR TITLE
fix: replace Unicode arrow with ASCII in Jupiter swap formatting

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
@@ -253,7 +253,7 @@ fn format_jupiter_swap_instruction(instruction: &JupiterSwapInstruction) -> Stri
             };
 
             format!(
-                "{}: {} {} → {} {} (slippage: {}bps)",
+                "{}: From {} {} To {} {} (slippage: {}bps)",
                 instruction_type,
                 format_token_amount(in_token),
                 format_token_symbol(in_token),


### PR DESCRIPTION
Replace Unicode arrow character (→ U+2192) with ASCII "From...To" pattern to fix charset validation errors. This ensures all output remains ASCII-only and passes the restricted character validation in SignablePayload.

The format now matches the standard transfer pattern used elsewhere in the codebase (e.g., "From X To Y For Z").

Fixes: #65 

🤖 Generated with [Claude Code](https://claude.ai/code)