### PR TITLE
test: add comprehensive charset validation tests

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/lib.rs
+++ b/src/chain_parsers/visualsign-solana/src/lib.rs
@@ -14,12 +14,10 @@ mod tests {
     #[test]
     fn test_solana_charset_validation() {
         // Test that Solana parser produces ASCII-only output for various transaction types
-        let test_cases = vec![
-            (
-                "Jupiter swap (previously had Unicode arrow)",
-                "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAkSTXq/T5ciKTTbZJhKN+HNd2Q3/i8mDBxbxpek3krZ664CMz4dTWd4gwDq6aKU/sqHgTzleVA7bTCOy59kSOO+0EPkGS7bWuT/2yiCuaADtj/v6d+KwyTj46OQM2MjIq6hTqzVdwLTW8t+UsWMrwHEvc/r814OmVR9yLVQZujbWvpTh0XSNlF7uoIvuHyKD/16mBElrNa/eT8vB1KVUaN8IoaTvZbN4b7iiv8Q8cl5bDecNqCXzTS1Xmsmh5b2UVZniTbtX0AYG5QKiSDC10m0caM6frmEVukpjEWOk7F/0OzFKL0A0HdMWTIMuQj4xBuP3csLyGzVO/MXtPu6woNViO2O9ocxd1YSDcIwhrzHY3a9ewvycRH5q662TcQqdxD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkOA2hfjpCQU+RYEhxm9adq7cdwaqEcgviqlSqPK3h5qVJNNVq4xx0JIWWE9kFLvpQK5lvS5UCde3W3QfWYLIxYjJclj04kifG7PRApFI4NgwtaE5na/xCEBI572Nvp+Fm0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6Mb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hXuFhKBWRymmouYdcNxL6PjM1Bkcio0R+AtqA/P3C3jAFDwYABgALCQwBAQkCAAYMAgAAAEBCDwAAAAAADAEGAREKFQwABgUKEQoQCg0MAAQGAwUHCAECDiTlF8uXeuOtKgEAAAARAWQAAUBCDwAAAAAAtEADAAAAAAAyAAAMAwYAAAEJ",
-            ),
-        ];
+        let test_cases = vec![(
+            "Jupiter swap (previously had Unicode arrow)",
+            "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAkSTXq/T5ciKTTbZJhKN+HNd2Q3/i8mDBxbxpek3krZ664CMz4dTWd4gwDq6aKU/sqHgTzleVA7bTCOy59kSOO+0EPkGS7bWuT/2yiCuaADtj/v6d+KwyTj46OQM2MjIq6hTqzVdwLTW8t+UsWMrwHEvc/r814OmVR9yLVQZujbWvpTh0XSNlF7uoIvuHyKD/16mBElrNa/eT8vB1KVUaN8IoaTvZbN4b7iiv8Q8cl5bDecNqCXzTS1Xmsmh5b2UVZniTbtX0AYG5QKiSDC10m0caM6frmEVukpjEWOk7F/0OzFKL0A0HdMWTIMuQj4xBuP3csLyGzVO/MXtPu6woNViO2O9ocxd1YSDcIwhrzHY3a9ewvycRH5q662TcQqdxD6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTjwabiFf+q4GE+2h/Y0YYwDXaxDncGus7VZig8AAAAAABBt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkOA2hfjpCQU+RYEhxm9adq7cdwaqEcgviqlSqPK3h5qVJNNVq4xx0JIWWE9kFLvpQK5lvS5UCde3W3QfWYLIxYjJclj04kifG7PRApFI4NgwtaE5na/xCEBI572Nvp+Fm0P/on9df2SnTAmx8pWHneSwmrNt/J3VFLMhqns4zl6Mb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11hXuFhKBWRymmouYdcNxL6PjM1Bkcio0R+AtqA/P3C3jAFDwYABgALCQwBAQkCAAYMAgAAAEBCDwAAAAAADAEGAREKFQwABgUKEQoQCg0MAAQGAwUHCAECDiTlF8uXeuOtKgEAAAARAWQAAUBCDwAAAAAAtEADAAAAAAAyAAAMAwYAAAEJ",
+        )];
 
         for (description, tx_data) in test_cases {
             // Parse the transaction
@@ -35,7 +33,9 @@ mod tests {
                         transaction_name: Some(description.to_string()),
                     },
                 )
-                .unwrap_or_else(|e| panic!("Failed to convert {} to payload: {:?}", description, e));
+                .unwrap_or_else(|e| {
+                    panic!("Failed to convert {} to payload: {:?}", description, e)
+                });
 
             // Test charset validation
             let validation_result = payload.validate_charset();

--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -444,9 +444,21 @@ async fn parser_charset_validation_all_chains() {
                 .unwrap_or_else(|e| panic!("{} should produce valid JSON: {:?}", description, e));
 
             // Verify required fields exist
-            assert!(parsed_json["Fields"].is_array(), "{} should have Fields array", description);
-            assert!(parsed_json["Title"].is_string(), "{} should have Title", description);
-            assert!(parsed_json["Version"].is_string(), "{} should have Version", description);
+            assert!(
+                parsed_json["Fields"].is_array(),
+                "{} should have Fields array",
+                description
+            );
+            assert!(
+                parsed_json["Title"].is_string(),
+                "{} should have Title",
+                description
+            );
+            assert!(
+                parsed_json["Version"].is_string(),
+                "{} should have Version",
+                description
+            );
 
             tracing::debug!("✅ {} passed charset validation", description);
         }


### PR DESCRIPTION
Follow-up of #66 
Add integration test that validates ASCII-only output across all chain parsers (Solana, Ethereum, Sui). This ensures no Unicode characters slip through in the SignablePayload JSON output.

Also add unit test in Solana module to catch charset violations early, including the specific Jupiter swap transaction that previously contained the Unicode arrow character.

Tests verify:
- No unicode escape sequences (\u) in JSON
- All output is valid ASCII
- JSON parses correctly

🤖 Generated with [Claude Code](https://claude.ai/code)