### PR TITLE
Parse slippage and platform fee bps from instruction data

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
@@ -719,8 +719,8 @@ mod tests {
             } => {
                 assert_eq!(slippage_bps, 50, "Slippage should be 50 bps");
                 assert_eq!(platform_fee_bps, 100, "Platform fee should be 100 bps");
-                println!("✅ Correctly parsed slippage: {} bps", slippage_bps);
-                println!("✅ Correctly parsed platform fee: {} bps", platform_fee_bps);
+                println!("✅ Correctly parsed slippage: {slippage_bps} bps");
+                println!("✅ Correctly parsed platform fee: {platform_fee_bps} bps");
             }
             _ => panic!("Expected Route instruction"),
         }
@@ -735,7 +735,7 @@ mod tests {
             formatted.contains("platform fee: 100bps"),
             "Formatted string should contain platform fee when non-zero"
         );
-        println!("✅ Formatted output: {}", formatted);
+        println!("✅ Formatted output: {formatted}");
 
         // Test expanded fields include platform fee
         let fields = create_jupiter_swap_expanded_fields(


### PR DESCRIPTION
Currently, we're hardcoding slippage to 50 bps without parsing the field from the instruction data and is incorrectly showing the value at visualization.

In this PR, we're parsing the slippage bps and platform fee bps from instruction data to be utilized in visualization. The tests have been updated to work with a slippage of 10 bps (different from the hard coded 50). The platform fee field will only be included in visualization if it's greater than 0. I've added an additional test to verify the visualization with a non-zero platform fee

I used this [transaction](https://solscan.io/tx/441ttot8CzpgsiRHvAHnNTCBwbSnPuhuy43pCjzZU9BKwBuJeW8f4TMU7FYLeqBst6WJeMEHprdQxr4thxqZSxRs) as a reference where slippage bps is showing as u16 right after the amounts.