### PR TITLE
Fix gRPC status error handling

### DIFF
--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -39,12 +39,7 @@ pub fn parse(
 
     let signable_payload_str = registry
         .convert_transaction(&registry_chain, request_payload.as_str(), options)
-        .map_err(|e| {
-            GrpcError::new(
-                Code::InvalidArgument,
-                &format!("Failed to parse transaction: {e}"),
-            )
-        })?;
+        .map_err(|e| GrpcError::new(Code::InvalidArgument, &format!("{e}")))?;
 
     // Convert SignablePayload to String (assuming you want JSON)
     let signable_payload = serde_json::to_string(&signable_payload_str).map_err(|e| {

--- a/src/parser/app/src/service.rs
+++ b/src/parser/app/src/service.rs
@@ -63,7 +63,7 @@ impl RequestProcessor for Processor {
                 .input
                 .ok_or({
                     qos_parser_response::Output::Status(Status {
-                        code: Code::Internal as i32,
+                        code: Code::InvalidArgument as i32,
                         message: "missing request input".to_string(),
                         details: vec![],
                     })
@@ -80,8 +80,8 @@ impl RequestProcessor for Processor {
                         .map(qos_parser_response::Output::ParseResponse)
                         .map_err(|e| {
                             qos_parser_response::Output::Status(Status {
-                                code: Code::Internal as i32,
-                                message: format!("{e:?}"),
+                                code: e.code as i32,
+                                message: e.message,
                                 details: vec![],
                             })
                         }) {


### PR DESCRIPTION
Currently all status errors are surfaced as "Internal" errors, which translates into 500 errors at the gateway level. Figured out why. That's not the gateway's fault: it was the app all along!

This PR fixes this and adds a test to make sure it doesn't regress by accident.