### PR TITLE
Template underlying `TransactionParseError` in `VisualSignError`

### DIFF
--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -117,7 +117,7 @@ async fn parser_e2e() {
 async fn propagates_grpc_errors() {
     async fn test(test_args: TestArgs) {
         let parse_request = ParseRequest {
-            unsigned_payload: "no-no-that-is-not-valid-hex".to_string(),
+            unsigned_payload: "no-no-that-is-not-valid-base64".to_string(),
             chain: Chain::Ethereum as i32,
             chain_metadata: None,
         };
@@ -130,7 +130,10 @@ async fn propagates_grpc_errors() {
             .unwrap_err();
 
         assert_eq!(parse_error.code(), Code::InvalidArgument);
-        assert_eq!(parse_error.message(), "Failed to parse transaction");
+        assert_eq!(
+            parse_error.message(),
+            "Failed to parse transaction: Decode error: Failed to decode transaction: Failed to decode base64: Invalid symbol 45, offset 2."
+        );
     }
 
     integration::Builder::new().execute(test).await

--- a/src/visualsign/src/errors.rs
+++ b/src/visualsign/src/errors.rs
@@ -16,7 +16,7 @@ pub enum TransactionParseError {
 // Our library's custom, top-level error type.
 #[derive(Debug, Eq, PartialEq, Error)]
 pub enum VisualSignError {
-    #[error("Failed to parse transaction")]
+    #[error("Failed to parse transaction: {0}")]
     ParseError(#[from] TransactionParseError),
     #[error("Failed to decode instruction: {0}")]
     DecodeError(String),


### PR DESCRIPTION
Pretty simple PR to surface errors better. I had this on my local machine to debug an issue with Solana parsing. Figured it's worth committing!