### PR TITLE
Add a human output mode for CLI

### DIFF
--- a/src/parser/cli/src/cli.rs
+++ b/src/parser/cli/src/cli.rs
@@ -1,139 +1,196 @@
 use crate::chains;
-use chains::{available_chains, parse_chain};
-use clap::{Arg, Command};
+use chains::parse_chain;
+use clap::Parser;
 use parser_app::registry::create_registry;
-use std::fmt::Write;
 use visualsign::vsptrait::VisualSignOptions;
 use visualsign::{SignablePayload, SignablePayloadField};
 
-/// Formats a `SignablePayload` in a human-readable tree format
-fn format_human_readable(payload: &SignablePayload) -> String {
-    let mut output = String::new();
+#[derive(Parser, Debug)]
+#[command(name = "visualsign-parser")]
+#[command(version = "1.0")]
+#[command(about = "Converts raw transactions to visual signing properties")]
+struct Args {
+    #[arg(short, long, help = "Chain type")]
+    chain: String,
 
-    // Header
-    writeln!(&mut output, "┌─ Transaction: {}", payload.title).unwrap();
-    if let Some(subtitle) = &payload.subtitle {
-        writeln!(&mut output, "│  Subtitle: {subtitle}").unwrap();
-    }
-    writeln!(&mut output, "│  Version: {}", payload.version).unwrap();
-    if !payload.payload_type.is_empty() {
-        writeln!(&mut output, "│  Type: {}", payload.payload_type).unwrap();
-    }
-    output.push_str("│\n");
+    #[arg(
+        short,
+        long,
+        value_name = "RAW_TX",
+        help = "Raw transaction hex string"
+    )]
+    transaction: String,
 
-    // Fields
-    if !payload.fields.is_empty() {
-        output.push_str("└─ Fields:\n");
-        for (i, field) in payload.fields.iter().enumerate() {
-            let is_last = i == payload.fields.len() - 1;
-            let prefix = if is_last { "   └─" } else { "   ├─" };
-            let continuation = if is_last { "      " } else { "   │  " };
+    #[arg(short, long, default_value = "text", help = "Output format")]
+    output: OutputFormat,
 
-            format_field(field, &mut output, prefix, continuation);
-        }
-    }
-
-    output
+    #[arg(
+        long,
+        help = "Show only condensed view (what hardware wallets display)"
+    )]
+    condensed_only: bool,
 }
 
-/// Formats a single field with tree-like indentation
-fn format_field(
-    field: &SignablePayloadField,
-    output: &mut String,
-    prefix: &str,
-    continuation: &str,
-) {
-    match field {
-        SignablePayloadField::TextV2 { common, text_v2 } => {
-            writeln!(output, "{} {}: {}", prefix, common.label, text_v2.text).unwrap();
+#[derive(Debug, Clone, Copy)]
+enum OutputFormat {
+    Text,
+    Json,
+    Human,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(OutputFormat::Text),
+            "json" => Ok(OutputFormat::Json),
+            "human" => Ok(OutputFormat::Human),
+            _ => Err(format!("Invalid output format: {s}")),
         }
-        SignablePayloadField::PreviewLayout {
-            common,
-            preview_layout,
-        } => {
-            writeln!(output, "{} {}", prefix, common.label).unwrap();
+    }
+}
 
-            if let Some(title) = &preview_layout.title {
-                writeln!(output, "{}   Title: {}", continuation, title.text).unwrap();
-            }
-            if let Some(subtitle) = &preview_layout.subtitle {
-                writeln!(output, "{}   Detail: {}", continuation, subtitle.text).unwrap();
-            }
+struct HumanReadableFormatter<'a> {
+    payload: &'a SignablePayload,
+    condensed_only: bool,
+}
 
-            // Condensed view (if present)
-            if let Some(condensed_layout) = &preview_layout.condensed {
-                if !condensed_layout.fields.is_empty() {
-                    writeln!(output, "{continuation}   📋 Condensed View:").unwrap();
-                    for (i, nested_field) in condensed_layout.fields.iter().enumerate() {
-                        let is_last_nested = i == condensed_layout.fields.len() - 1;
-                        let nested_prefix = format!(
-                            "{}   {}",
-                            continuation,
-                            if is_last_nested { "└─" } else { "├─" }
-                        );
-                        let nested_continuation = format!(
-                            "{}   {}",
-                            continuation,
-                            if is_last_nested { "   " } else { "│  " }
-                        );
-                        format_field(
-                            &nested_field.signable_payload_field,
-                            output,
-                            &nested_prefix,
-                            &nested_continuation,
-                        );
+impl<'a> HumanReadableFormatter<'a> {
+    fn new(payload: &'a SignablePayload, condensed_only: bool) -> Self {
+        Self {
+            payload,
+            condensed_only,
+        }
+    }
+
+    fn format_field(
+        &self,
+        field: &SignablePayloadField,
+        writer: &mut dyn std::fmt::Write,
+        prefix: &str,
+        continuation: &str,
+    ) -> std::fmt::Result {
+        match field {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                writeln!(writer, "{} {}: {}", prefix, common.label, text_v2.text)?;
+            }
+            SignablePayloadField::PreviewLayout {
+                common,
+                preview_layout,
+            } => {
+                writeln!(writer, "{} {}", prefix, common.label)?;
+
+                if let Some(title) = &preview_layout.title {
+                    writeln!(writer, "{}   Title: {}", continuation, title.text)?;
+                }
+                if let Some(subtitle) = &preview_layout.subtitle {
+                    writeln!(writer, "{}   Detail: {}", continuation, subtitle.text)?;
+                }
+
+                // Condensed view (if present)
+                if let Some(condensed_layout) = &preview_layout.condensed {
+                    if !condensed_layout.fields.is_empty() {
+                        writeln!(writer, "{continuation}   📋 Condensed View:")?;
+                        for (i, nested_field) in condensed_layout.fields.iter().enumerate() {
+                            let is_last_nested = i == condensed_layout.fields.len() - 1;
+                            let nested_prefix = format!(
+                                "{}   {}",
+                                continuation,
+                                if is_last_nested { "└─" } else { "├─" }
+                            );
+                            let nested_continuation = format!(
+                                "{}   {}",
+                                continuation,
+                                if is_last_nested { "   " } else { "│  " }
+                            );
+                            self.format_field(
+                                &nested_field.signable_payload_field,
+                                writer,
+                                &nested_prefix,
+                                &nested_continuation,
+                            )?;
+                        }
+                    }
+                }
+
+                // Expanded view (if present, only show if not condensed_only)
+                if !self.condensed_only {
+                    if let Some(expanded_layout) = &preview_layout.expanded {
+                        if !expanded_layout.fields.is_empty() {
+                            writeln!(writer, "{continuation}   📖 Expanded View:")?;
+                            for (i, nested_field) in expanded_layout.fields.iter().enumerate() {
+                                let is_last_nested = i == expanded_layout.fields.len() - 1;
+                                let nested_prefix = format!(
+                                    "{}   {}",
+                                    continuation,
+                                    if is_last_nested { "└─" } else { "├─" }
+                                );
+                                let nested_continuation = format!(
+                                    "{}   {}",
+                                    continuation,
+                                    if is_last_nested { "   " } else { "│  " }
+                                );
+                                self.format_field(
+                                    &nested_field.signable_payload_field,
+                                    writer,
+                                    &nested_prefix,
+                                    &nested_continuation,
+                                )?;
+                            }
+                        }
                     }
                 }
             }
-
-            // Expanded view (if present)
-            if let Some(expanded_layout) = &preview_layout.expanded {
-                if !expanded_layout.fields.is_empty() {
-                    writeln!(output, "{continuation}   📖 Expanded View:").unwrap();
-                    for (i, nested_field) in expanded_layout.fields.iter().enumerate() {
-                        let is_last_nested = i == expanded_layout.fields.len() - 1;
-                        let nested_prefix = format!(
-                            "{}   {}",
-                            continuation,
-                            if is_last_nested { "└─" } else { "├─" }
-                        );
-                        let nested_continuation = format!(
-                            "{}   {}",
-                            continuation,
-                            if is_last_nested { "   " } else { "│  " }
-                        );
-                        format_field(
-                            &nested_field.signable_payload_field,
-                            output,
-                            &nested_prefix,
-                            &nested_continuation,
-                        );
-                    }
-                }
+            SignablePayloadField::AmountV2 { common, amount_v2 } => {
+                writeln!(
+                    writer,
+                    "{} {}: {} {}",
+                    prefix,
+                    common.label,
+                    amount_v2.amount,
+                    amount_v2.abbreviation.as_deref().unwrap_or("")
+                )?;
+            }
+            SignablePayloadField::AddressV2 { common, address_v2 } => {
+                writeln!(
+                    writer,
+                    "{} {}: {}",
+                    prefix, common.label, address_v2.address
+                )?;
+            }
+            _ => {
+                writeln!(writer, "{} Field: {}", prefix, common_label(field))?;
             }
         }
-        SignablePayloadField::AmountV2 { common, amount_v2 } => {
-            writeln!(
-                output,
-                "{} {}: {} {}",
-                prefix,
-                common.label,
-                amount_v2.amount,
-                amount_v2.abbreviation.as_deref().unwrap_or("")
-            )
-            .unwrap();
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for HumanReadableFormatter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "┌─ Transaction: {}", self.payload.title)?;
+        if let Some(subtitle) = &self.payload.subtitle {
+            writeln!(f, "│  Subtitle: {subtitle}")?;
         }
-        SignablePayloadField::AddressV2 { common, address_v2 } => {
-            writeln!(
-                output,
-                "{} {}: {}",
-                prefix, common.label, address_v2.address
-            )
-            .unwrap();
+        writeln!(f, "│  Version: {}", self.payload.version)?;
+        if !self.payload.payload_type.is_empty() {
+            writeln!(f, "│  Type: {}", self.payload.payload_type)?;
         }
-        _ => {
-            writeln!(output, "{} Field: {}", prefix, common_label(field)).unwrap();
+        f.write_str("│\n")?;
+
+        if !self.payload.fields.is_empty() {
+            f.write_str("└─ Fields:\n")?;
+            for (i, field) in self.payload.fields.iter().enumerate() {
+                let is_last = i == self.payload.fields.len() - 1;
+                let prefix = if is_last { "   └─" } else { "   ├─" };
+                let continuation = if is_last { "      " } else { "   │  " };
+
+                self.format_field(field, f, prefix, continuation)?;
+            }
         }
+
+        Ok(())
     }
 }
 
@@ -148,29 +205,37 @@ fn common_label(field: &SignablePayloadField) -> String {
     }
 }
 
-fn parse_and_display(chain: &str, raw_tx: &str, options: VisualSignOptions, output_format: &str) {
+fn parse_and_display(
+    chain: &str,
+    raw_tx: &str,
+    options: VisualSignOptions,
+    output_format: OutputFormat,
+    condensed_only: bool,
+) {
     let registry_chain = parse_chain(chain);
 
     let registry = create_registry();
     let signable_payload_str = registry.convert_transaction(&registry_chain, raw_tx, options);
     match signable_payload_str {
         Ok(payload) => match output_format {
-            "json" => {
+            OutputFormat::Json => {
                 if let Ok(json_output) = serde_json::to_string_pretty(&payload) {
                     println!("{json_output}");
                 } else {
                     eprintln!("Error: Failed to serialize output as JSON");
                 }
             }
-            "text" => {
+            OutputFormat::Text => {
                 println!("{payload:#?}");
             }
-            "human" => {
-                let human_output = format_human_readable(&payload);
-                println!("{human_output}");
-            }
-            _ => {
-                eprintln!("Error: Unsupported output format '{output_format}'");
+            OutputFormat::Human => {
+                let formatter = HumanReadableFormatter::new(&payload, condensed_only);
+                println!("{formatter}");
+                if !condensed_only {
+                    eprintln!(
+                        "\nRun with `--condensed-only` to see what users see on hardware wallets"
+                    );
+                }
             }
         },
         Err(err) => {
@@ -188,55 +253,19 @@ impl Cli {
     ///
     /// Executes the CLI application, parsing command line arguments and processing the transaction
     pub fn execute() {
-        let chains = available_chains();
-        let chain_help = format!("Chain type ({})", chains.join(", "));
-
-        let matches = Command::new("visualsign-parser")
-            .version("1.0")
-            .about("Converts raw transactions to visual signing properties")
-            .arg(
-                Arg::new("chain")
-                    .short('c')
-                    .long("chain")
-                    .value_name("CHAIN")
-                    .help(&chain_help)
-                    .value_parser(chains.clone())
-                    .required(true),
-            )
-            .arg(
-                Arg::new("transaction")
-                    .short('t')
-                    .long("transaction")
-                    .value_name("RAW_TX")
-                    .help("Raw transaction hex string")
-                    .required(true),
-            )
-            .arg(
-                Arg::new("output")
-                    .short('o')
-                    .long("output")
-                    .value_name("FORMAT")
-                    .help("Output format")
-                    .value_parser(["text", "json", "human"])
-                    .default_value("text"),
-            )
-            .get_matches();
-
-        let chain = matches
-            .get_one::<String>("chain")
-            .expect("Chain is required");
-        let raw_tx = matches
-            .get_one::<String>("transaction")
-            .expect("Transaction is required");
-        let output_format = matches
-            .get_one::<String>("output")
-            .expect("Output format has default value");
+        let args = Args::parse();
 
         let options = VisualSignOptions {
             decode_transfers: true,
             transaction_name: None,
         };
 
-        parse_and_display(chain, raw_tx, options, output_format);
+        parse_and_display(
+            &args.chain,
+            &args.transaction,
+            options,
+            args.output,
+            args.condensed_only,
+        );
     }
 }


### PR DESCRIPTION
Makes a tree-like output for easier debugging in CLI. Reading the JSON and tracking things down was taking a lot of effort..so this will allow debugging complex transactions like this Uniswap more easily to understand what's expanded/collapsed

```
target/debug/parser_cli --chain ethereum -t 0x02f904cf0181b78477359400847c17b3e383045307943fc91a3afd70395cd496c647d5a6cc9d4b2b7fad80b904a424856bc30000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000040a08060c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000032000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000016000000000000000000000000072b658bd674f9c2b4954682f517c17d14476e417000000000000000000000000ffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000006940571900000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fc91a3afd70395cd496c647d5a6cc9d4b2b7fad000000000000000000000000000000000000000000000000000000006918d12100000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000412eb0933411b0970637515316fb50511bea7908d3f85808074ceed3bf881562bc06da5178104470e54fb5be96075169b30799c30f30975317ae14113ffdb84bc81c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000285aaa58c1a1a183d0000000000000000000000000000000000000000000000000009cf200e607a0800000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000200000000000000000000000072b658bd674f9c2b4954682f517c17d14476e417000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c000000000000000000000000000000000000000000000000000000000000001900000000000000000000000000000000000000000000000000000000000000400000000000000000000000008419e7eda8577dfc49591a49cad965a0fc6716cf0000000000000000000000000000000000000000000000000009c8d8ef9ef49bc0 --output human`
┌─ Transaction: Ethereum Transaction
│  Version: 0
│  Type: EthereumTx
│
└─ Fields:
   ├─ Network: Ethereum Mainnet
   ├─ To: 0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD
   ├─ Value: 0 ETH
   ├─ Gas Limit: 283399
   ├─ Gas Price: 2.081928163 gwei
   ├─ Max Priority Fee Per Gas: 2 gwei
   ├─ Nonce: 183
   └─ Universal Router
         Title: Uniswap Universal Router Execute
         Detail: 4 commands
         📖 Expanded View:
         ├─ Permit2 Permit
         │     Title: Permit2 Permit
         │     Detail: Permit 0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD to spend Unlimited Amount of 0x72b658bd674f9c2b4954682f517c17d14476e417
         │     📖 Expanded View:
         │     ├─ Token: 0x72b658bd674f9c2b4954682f517c17d14476e417
         │     ├─ Amount: 1461501637330902918203684832716283019655932542975
         │     ├─ Spender: 0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad
         │     ├─ Expires: 2025-12-15 18:44 UTC
         │     └─ Sig Deadline: 2025-11-15 19:14 UTC
         ├─ Command 2
         │     Title: V2 Swap Exact In
         │     Detail: Swap 46525180921656252477 0x72b658bd674f9c2b4954682f517c17d14476e417 for >=0.002761011377502728 WETH via V2 (1 hops)
         ├─ Command 3
         │     Title: Pay Portion
         │     Detail: Pay 0.2500% of WETH to 0x000000fee13a103a10d593b9ae06b3e05f2e7e1c
         └─ Command 4
               Title: Unwrap WETH
               Detail: Unwrap >=0.002754108849058971 WETH to ETH for 0x8419e7eda8577dfc49591a49cad965a0fc6716cf
 ````
 
 solana
 
 ```
 cargo run -p parser_cli -- --chain solana -o human --condensed-only  -t "AAEACRJNer9PlyIpNNtkmEo34c13ZDf+LyYMHFvGl6TeStnrrgIzPh1NZ3iDAOrpopT+yoeBPOV5UDttMI7Ln2RI477QQ+QZLtta5P/bKIK5oAO2P+/p34rDJOPjo5AzYyMirqFOrNV3AtNby35SxYyvAcS9z+vzXg6ZVH3ItVBm6Nta+lOHRdI2UXu6gi+4fIoP/XqYESWs1r95Py8HUpVRo3wihpO9ls3hvuKK/xDxyXlsN5w2oJfNNLVeayaHlvZRVmeJNu1fQBgblAqJIMLXSbRxozp+uYRW6SmMRY6TsX/Q7MUovQDQd0xZMgy5CPjEG4/dywvIbNU78xe0+7rCg1WI7Y72hzF3VhINwjCGvMdjdr17C/JxEfmrrrZNxCp3EPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR51VvyMcBu7nTFbs5oFQf9sbLeo/SOUQKxzaJWvBOPBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQ4DaF+OkJBT5FgSHGb1p2rtx3BqoRyC+KqVKo8reHmpUk01WrjHHQkhZYT2QUu+lArmW9LlQJ17dbdB9ZgsjFiMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WbQ/+if11/ZKdMCbHylYed5LCas238ndUUsyGqezjOXoxvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWFe4WEoFZHKaai5h1w3Evo+MzUGRyKjRH4C2oD8/cLeMAUPBgAGAAsJDAEBCQIABgwCAAAAQEIPAAAAAAAMAQYBEQoVDAAGBQoRChAKDQwABAYDBQcIAQIOJOUXy5d6460qAQAAABEBZAABQEIPAAAAAAC0QAMAAAAAADIAAAwDBgAAAQk="  
   Compiling parser_cli v0.1.0 (/home/user/projects/visualsign-parser-cli-human/src/parser/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.31s
     Running `target/debug/parser_cli --chain solana -o human --condensed-only -t AAEACRJNer9PlyIpNNtkmEo34c13ZDf+LyYMHFvGl6TeStnrrgIzPh1NZ3iDAOrpopT+yoeBPOV5UDttMI7Ln2RI477QQ+QZLtta5P/bKIK5oAO2P+/p34rDJOPjo5AzYyMirqFOrNV3AtNby35SxYyvAcS9z+vzXg6ZVH3ItVBm6Nta+lOHRdI2UXu6gi+4fIoP/XqYESWs1r95Py8HUpVRo3wihpO9ls3hvuKK/xDxyXlsN5w2oJfNNLVeayaHlvZRVmeJNu1fQBgblAqJIMLXSbRxozp+uYRW6SmMRY6TsX/Q7MUovQDQd0xZMgy5CPjEG4/dywvIbNU78xe0+7rCg1WI7Y72hzF3VhINwjCGvMdjdr17C/JxEfmrrrZNxCp3EPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR51VvyMcBu7nTFbs5oFQf9sbLeo/SOUQKxzaJWvBOPBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAEG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQ4DaF+OkJBT5FgSHGb1p2rtx3BqoRyC+KqVKo8reHmpUk01WrjHHQkhZYT2QUu+lArmW9LlQJ17dbdB9ZgsjFiMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WbQ/+if11/ZKdMCbHylYed5LCas238ndUUsyGqezjOXoxvp6877brTo9ZfNqq8l0MbG75MLS9uDkfKYCA0UvXWFe4WEoFZHKaai5h1w3Evo+MzUGRyKjRH4C2oD8/cLeMAUPBgAGAAsJDAEBCQIABgwCAAAAQEIPAAAAAAAMAQYBEQoVDAAGBQoRChAKDQwABAYDBQcIAQIOJOUXy5d6460qAQAAABEBZAABQEIPAAAAAAC0QAMAAAAAADIAAAwDBgAAAQk=`
Handling instruction 0 with visualizer Payments("AssociatedTokenAccount")
Handling instruction 1 with visualizer Payments("System")
Handling instruction 2 with visualizer Payments("UnknownProgram")
Handling instruction 3 with visualizer Dex("Jupiter")
Handling instruction 4 with visualizer Payments("UnknownProgram")
┌─ Transaction: Solana Transaction
│  Version: 0
│  Type: SolanaTx
│
└─ Fields:
   ├─ Network: Solana
   ├─ Transfer 1: From: 6DSxAQ2HdBLGYwa3AQf6hXXjNZ762p761ANxBDqrao5P
To: AEdS5zTyeygvEbnsi5oszJLfu8mRwPmSFPyuPT1tDxMR
Amount: 1000000
   ├─ Instruction 1
   │     Title: Create Associated Token Account (Idempotent)
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Instruction: Create Associated Token Account (Idempotent)
   ├─ Instruction 2
   │     Title: Transfer: 1000000 lamports
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Instruction: Transfer: 1000000 lamports
   ├─ Instruction 3
   │     Title: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   ├─ Instruction 4
   │     Title: Jupiter Swap: From 1000000 Toke...Q5DA To 213172 USDC (slippage: 50bps)
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Instruction: Jupiter Swap: From 1000000 Toke...Q5DA To 213172 USDC (slippage: 50bps)
   ├─ Instruction 5
   │     Title: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   └─ Accounts
         Title: Accounts
         Detail: 18 accounts
         📋 Condensed View:
         ├─ Signers: 1 Signer
         ├─ Writable: 8 Writable
         └─ Read Only: 9 Read Only
 ````