### PR TITLE
Housekeeping things before Open Source

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -28,6 +28,12 @@ overflow-checks = true
 panic = 'unwind'
 incremental = true
 
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+repository = "https://github.com/anchorageoss/visualsign-parser"
+
 [workspace.dependencies]
 # See https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table
 qos_client = { git = "https://github.com/tkhq/qos.git", rev = "90dec56fc06926b7fb7439175c58789492ec82c6", default-features = false }

--- a/src/visualsign/Cargo.toml
+++ b/src/visualsign/Cargo.toml
@@ -2,6 +2,10 @@
 name = "visualsign"
 version = "0.1.0"
 edition = "2021"
+description = "Visualsign package defines the structures helper methods to create VisualSign payloads for Anchorage's Open Source VisualSign"
+# Inherit from root
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde_json = { version = "1.0" }


### PR DESCRIPTION
I want to at least claim https://crates.io/crates/visualsign - I don't think a lot of users will use this directly but I can see folks pulling it to do validation before pushing to our repository. And other house keeping things.