### PR TITLE
fix: add missing abi registry in tests

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -679,6 +679,7 @@ mod tests {
             decode_transfers: false,
             transaction_name: Some("Custom Transaction Title".to_string()),
             metadata: None,
+            abi_registry: None,
         };
         let payload = transaction_to_visual_sign(tx, options).unwrap();
 
@@ -905,6 +906,7 @@ mod tests {
                     decode_transfers: true,
                     transaction_name: Some("Test Transaction".to_string()),
                     metadata: None,
+                    abi_registry: None,
                 }
             ),
             Ok(SignablePayload::new(

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -34,6 +34,7 @@ fn test_with_fixtures() {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            abi_registry: None,
         };
 
         let result = transaction_string_to_visual_sign(transaction_hex, options);
@@ -78,6 +79,7 @@ fn test_ethereum_charset_validation() {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            abi_registry: None,
         };
 
         let result = transaction_string_to_visual_sign(transaction_hex, options);

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -372,6 +372,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("Solana Transaction".to_string()),
+                abi_registry: None,
             },
         );
 
@@ -454,6 +455,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("V0 Transaction".to_string()),
+                abi_registry: None,
             },
         );
 
@@ -620,6 +622,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("Legacy Transfer Test".to_string()),
+                abi_registry: None,
             },
         );
 
@@ -663,6 +666,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("V0 Transfer Test".to_string()),
+                abi_registry: None,
             },
         );
 
@@ -789,6 +793,7 @@ mod tests {
                         metadata: None,
                         decode_transfers: true,
                         transaction_name: Some("Manual V0 Transfer Test".to_string()),
+                        abi_registry: None,
                     },
                 );
 
@@ -939,6 +944,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("TokenKeg Test".to_string()),
+                abi_registry: None,
             },
         );
 

--- a/src/chain_parsers/visualsign-solana/src/lib.rs
+++ b/src/chain_parsers/visualsign-solana/src/lib.rs
@@ -32,6 +32,7 @@ mod tests {
                         metadata: None,
                         decode_transfers: true,
                         transaction_name: Some(description.to_string()),
+                        abi_registry: None,
                     },
                 )
                 .unwrap_or_else(|e| panic!("Failed to convert {description} to payload: {e:?}"));
@@ -88,6 +89,7 @@ mod tests {
                     metadata: None,
                     decode_transfers: true,
                     transaction_name: Some("Unicode Escape Test".to_string()),
+                    abi_registry: None,
                 },
             )
             .expect("Should convert to payload successfully");

--- a/src/chain_parsers/visualsign-solana/src/utils/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/utils/mod.rs
@@ -143,6 +143,7 @@ pub mod test_utils {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: None,
+                abi_registry: None,
             },
         )
         .expect("Failed to visualize tx commands")

--- a/src/chain_parsers/visualsign-sui/src/utils/test_helpers.rs
+++ b/src/chain_parsers/visualsign-sui/src/utils/test_helpers.rs
@@ -72,6 +72,7 @@ pub fn payload_from_b64(data: &str) -> SignablePayload {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            abi_registry: None,
         },
     )
     .expect("Failed to visualize tx commands")
@@ -85,6 +86,7 @@ pub fn payload_from_b64_with_context(data: &str, context: &str) -> SignablePaylo
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            abi_registry: None,
         },
     ) {
         Ok(payload) => payload,

--- a/src/visualsign/src/vsptrait.rs
+++ b/src/visualsign/src/vsptrait.rs
@@ -284,6 +284,7 @@ mod tests {
             decode_transfers: true,
             transaction_name: Some("Custom Transaction".to_string()),
             metadata: None,
+            abi_registry: None,
         };
 
         let result = converter.to_visual_sign_payload(transaction, options);


### PR DESCRIPTION
## Description

Tests failed to compile after `abi_registry` field was added to `VisualSignOptions` struct.

<img width="1061" height="459" alt="image" src="https://github.com/user-attachments/assets/7893788d-ce99-483b-94c4-ac726381f9ce" />
