### PR TITLE
[Feature:CLI] Add developer-only signed transaction support for CLI tools

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -34,6 +34,7 @@ fn test_with_fixtures() {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            developer_config: None,
         };
 
         let result = transaction_string_to_visual_sign(transaction_hex, options);
@@ -78,6 +79,7 @@ fn test_ethereum_charset_validation() {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            developer_config: None,
         };
 
         let result = transaction_string_to_visual_sign(transaction_hex, options);

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -372,6 +372,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("Solana Transaction".to_string()),
+                developer_config: None,
             },
         );
 
@@ -454,6 +455,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("V0 Transaction".to_string()),
+                developer_config: None,
             },
         );
 
@@ -620,6 +622,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("Legacy Transfer Test".to_string()),
+                developer_config: None,
             },
         );
 
@@ -663,6 +666,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("V0 Transfer Test".to_string()),
+                developer_config: None,
             },
         );
 
@@ -789,6 +793,7 @@ mod tests {
                         metadata: None,
                         decode_transfers: true,
                         transaction_name: Some("Manual V0 Transfer Test".to_string()),
+                        developer_config: None,
                     },
                 );
 
@@ -939,6 +944,7 @@ mod tests {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: Some("TokenKeg Test".to_string()),
+                developer_config: None,
             },
         );
 

--- a/src/chain_parsers/visualsign-solana/src/lib.rs
+++ b/src/chain_parsers/visualsign-solana/src/lib.rs
@@ -32,6 +32,7 @@ mod tests {
                         metadata: None,
                         decode_transfers: true,
                         transaction_name: Some(description.to_string()),
+                        developer_config: None,
                     },
                 )
                 .unwrap_or_else(|e| panic!("Failed to convert {description} to payload: {e:?}"));
@@ -88,6 +89,7 @@ mod tests {
                     metadata: None,
                     decode_transfers: true,
                     transaction_name: Some("Unicode Escape Test".to_string()),
+                    developer_config: None,
                 },
             )
             .expect("Should convert to payload successfully");

--- a/src/chain_parsers/visualsign-solana/src/presets/swig_wallet/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/swig_wallet/mod.rs
@@ -2236,6 +2236,7 @@ mod tests {
                     decode_transfers: true,
                     transaction_name: Some(description.to_string()),
                     metadata: None,
+                    developer_config: None,
                 },
             )
             .expect("visualization should succeed")

--- a/src/chain_parsers/visualsign-solana/src/utils/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/utils/mod.rs
@@ -143,6 +143,7 @@ pub mod test_utils {
                 metadata: None,
                 decode_transfers: true,
                 transaction_name: None,
+                developer_config: None,
             },
         )
         .expect("Failed to visualize tx commands")

--- a/src/chain_parsers/visualsign-sui/src/utils/test_helpers.rs
+++ b/src/chain_parsers/visualsign-sui/src/utils/test_helpers.rs
@@ -72,6 +72,7 @@ pub fn payload_from_b64(data: &str) -> SignablePayload {
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            developer_config: None,
         },
     )
     .expect("Failed to visualize tx commands")
@@ -85,6 +86,7 @@ pub fn payload_from_b64_with_context(data: &str, context: &str) -> SignablePaylo
             decode_transfers: true,
             transaction_name: None,
             metadata: None,
+            developer_config: None,
         },
     ) {
         Ok(payload) => payload,

--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -31,6 +31,7 @@ pub fn parse(
         decode_transfers: true,
         transaction_name: None,
         metadata: parse_request.chain_metadata.clone(),
+        developer_config: None, // Production API: only accept unsigned transactions
     };
     let registry = create_registry();
     let proto_chain = ProtoChain::from_i32(parse_request.chain)

--- a/src/parser/cli/src/cli.rs
+++ b/src/parser/cli/src/cli.rs
@@ -6,7 +6,7 @@ use generated::parser::{
 };
 use parser_app::registry::create_registry;
 use visualsign::registry::Chain;
-use visualsign::vsptrait::VisualSignOptions;
+use visualsign::vsptrait::{DeveloperConfig, VisualSignOptions};
 use visualsign::{SignablePayload, SignablePayloadField};
 use visualsign_ethereum::networks::parse_network;
 
@@ -311,6 +311,9 @@ impl Cli {
             decode_transfers: true,
             transaction_name: None,
             metadata,
+            developer_config: Some(DeveloperConfig {
+                allow_signed_transactions: true,
+            }),
         };
 
         parse_and_display(

--- a/src/visualsign/src/vsptrait.rs
+++ b/src/visualsign/src/vsptrait.rs
@@ -5,12 +5,21 @@ use crate::SignablePayload;
 pub use crate::errors::{TransactionParseError, VisualSignError};
 pub use generated::parser::ChainMetadata;
 
+/// Developer-only configuration options. Not for production API use.
+#[derive(Default, Debug, Clone)]
+pub struct DeveloperConfig {
+    /// Allow decoding signed transactions by extracting the unsigned portion.
+    /// Only enable for CLI/developer tools.
+    pub allow_signed_transactions: bool,
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct VisualSignOptions {
     pub decode_transfers: bool,
     pub transaction_name: Option<String>,
     pub metadata: Option<ChainMetadata>,
-    // Add more options as needed - we can extend this struct later
+    /// Developer-only options. None for production API use.
+    pub developer_config: Option<DeveloperConfig>,
 }
 
 pub trait VisualSignConverter<T: Transaction> {
@@ -259,6 +268,7 @@ mod tests {
             decode_transfers: true,
             transaction_name: Some("Custom Transaction".to_string()),
             metadata: None,
+            developer_config: None,
         };
 
         let result = converter.to_visual_sign_payload(transaction, options);
@@ -342,5 +352,6 @@ mod tests {
         let options = VisualSignOptions::default();
         assert!(!options.decode_transfers);
         assert!(options.transaction_name.is_none());
+        assert!(options.developer_config.is_none());
     }
 }


### PR DESCRIPTION
This adds a feature to CLI that allows accepting raw tx from Etherscan which are already signed. I was finding myself using some adhoc tools not available on visualsign-parser to do this decoding but I also don't want to make visualsign-parser an "everything tool" that does decoding of signed tx too. That task is best left to indexers. 
Given it's likely we'll add more "quality of life" tooling for developers in the future, this is implemented by passing a `developer_config` flag in visualsignOptions, this isn't even intended to be exposed over RPC. It makes sense for CLI to have access to it though. We want faster feedback loop so that you can do something like

* Go to Etherscan.io to [Uniswap Router](https://etherscan.io/address/0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad) 
* Find an Arbitrary tx like this one https://etherscan.io/tx/0x2f8a097524cef0690429b3cbf7458bdc8f6da6ef34937b0f83e3b746dbd78102
* Click on Get Raw Tx Hex
<img width="659" height="482" alt="image" src="https://github.com/user-attachments/assets/a0c2c102-cbd1-4274-ab9e-53b551bbc683" />
* Paste it in
```
cargo run --quiet -p parser_cli -- --chain ethereum -t <raw tx> --output human
```

compare with

signed tx: `cargo run --quiet -p parser_cli -- --chain ethereum -t 0x02f9043801588477359400847a1e5be18303e05c943fc91a3afd70395cd496c647d5a6cc9d4b2b7fad870b5e620f480000b903c43593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000692a575a00000000000000000000000000000000000000000000000000000000000000040b080604000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f48000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f480000000000000000000000000000000000000000000000000000000002109cfe602600000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c800000000000000000000000000000000000000000000000000000000000000060000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c00000000000000000000000000000000000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000060000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000d27f4bbd67bd4ad1674c9c2c5a75ca8c3e389f3b0000000000000000000000000000000000000000000000000000020f4aae6130c080a0e25b5930432fd92177b2f62f7edbd4c029cee52fc196bc91f2071b7a2ac565f6a05e67015b7153d1330fe7f975d3ab6d0ab6b606ef1e40f685b110dfbb62d4439d` 

vs raw tx: 
```
0x02f903f501588477359400847a1e5be18303e05c943fc91a3afd70395cd496c647d5a6cc9d4b2b7fad870b5e620f480000b903c43593564c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000692a575a00000000000000000000000000000000000000000000000000000000000000040b080604000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f48000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f480000000000000000000000000000000000000000000000000000000002109cfe602600000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c800000000000000000000000000000000000000000000000000000000000000060000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c00000000000000000000000000000000000000000000000000000000000000190000000000000000000000000000000000000000000000000000000000000060000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000d27f4bbd67bd4ad1674c9c2c5a75ca8c3e389f3b0000000000000000000000000000000000000000000000000000020f4aae6130c0
```
for the same tx.. the output should be 

```
┌─ Transaction: Ethereum Transaction
│  Version: 0
│  Type: EthereumTx
│
└─ Fields:
   ├─ Network: Ethereum Mainnet
   ├─ To: 0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD
   ├─ Value: 0.0032 ETH
   ├─ Gas Limit: 254044
   ├─ Gas Price: 2.048809953 gwei
   ├─ Max Priority Fee Per Gas: 2 gwei
   ├─ Nonce: 88
   └─ Universal Router
         Title: Universal Router Execute
         Detail: 4 commands, deadline 2025-11-29 02:15:54 UTC
         📖 Expanded View:
         ├─ Command 1
         │     Title: WrapEth
         │     Detail: Input: 0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f480000
         ├─ Command 2
         │     Title: V2SwapExactIn
         │     Detail: Input: 0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000b5e620f480000000000000000000000000000000000000000000000000000000002109cfe602600000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80
         ├─ Command 3
         │     Title: PayPortion
         │     Detail: Input: 0x000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000000000fee13a103a10d593b9ae06b3e05f2e7e1c0000000000000000000000000000000000000000000000000000000000000019
         ├─ Command 4
         │     Title: Sweep
         │     Detail: Input: 0x000000000000000000000000255494b830bd4fe7220b3ec4842cba75600b6c80000000000000000000000000d27f4bbd67bd4ad1674c9c2c5a75ca8c3e389f3b0000000000000000000000000000000000000000000000000000020f4aae6130
         └─ Deadline: 2025-11-29 02:15:54 UTC


Run with `--condensed-only` to see what users see on hardware wallets
``