### PR TITLE
Add support to closeAccount Token 2022 instruction

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/token_2022/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/token_2022/mod.rs
@@ -88,6 +88,11 @@ enum Token2022Instruction {
         mint: String,
         freeze_authority: String,
     },
+    CloseAccount {
+        account: String,
+        destination: String,
+        owner: String,
+    },
     SetAuthority {
         account: String,
         authority_type: u8,
@@ -220,6 +225,17 @@ fn parse_token_2022_instruction(
                     account: accounts[0].pubkey.to_string(),
                     mint: accounts[1].pubkey.to_string(),
                     freeze_authority: accounts[2].pubkey.to_string(),
+                });
+            }
+            TokenInstruction::CloseAccount => {
+                if accounts.len() < 3 {
+                    return Err("Invalid closeAccount: insufficient accounts".to_string());
+                }
+
+                return Ok(Token2022Instruction::CloseAccount {
+                    account: accounts[0].pubkey.to_string(),
+                    destination: accounts[1].pubkey.to_string(),
+                    owner: accounts[2].pubkey.to_string(),
                 });
             }
             _ => {
@@ -456,6 +472,26 @@ fn create_token_2022_preview_layout(
                 create_text_field("Token Account", account)?,
                 create_text_field("Mint", mint)?,
                 create_text_field("Freeze Authority", freeze_authority)?,
+                create_text_field("Program ID", &instruction.program_id.to_string())?,
+                create_raw_data_field(&instruction.data, Some(hex::encode(&instruction.data)))?,
+            ];
+
+            (title, condensed, expanded)
+        }
+        Token2022Instruction::CloseAccount {
+            account,
+            destination,
+            owner,
+        } => {
+            let title = "Close Account".to_string();
+
+            let condensed = vec![create_text_field("Action", "Close Account")?];
+
+            let expanded = vec![
+                create_text_field("Instruction", "Close Account")?,
+                create_text_field("Token Account", account)?,
+                create_text_field("Destination", destination)?,
+                create_text_field("Owner", owner)?,
                 create_text_field("Program ID", &instruction.program_id.to_string())?,
                 create_raw_data_field(&instruction.data, Some(hex::encode(&instruction.data)))?,
             ];

--- a/src/chain_parsers/visualsign-solana/src/presets/token_2022/tests/fixture_test.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/token_2022/tests/fixture_test.rs
@@ -305,6 +305,11 @@ fn test_thaw_real_transaction() {
 }
 
 #[test]
+fn test_close_account_real_transaction() {
+    test_real_transaction("close_account", "CloseAccount");
+}
+
+#[test]
 fn test_encode_pause_resume_instructions() {
     // Helper test to generate correct base58 encodings for Pause and Resume
     let pause_bytes = [44u8, 1u8];
@@ -345,6 +350,22 @@ fn test_encode_set_authority_instruction() {
     assert_eq!(decoded[0], 6);
     assert_eq!(decoded[1], 0);
     assert_eq!(decoded[2], 1);
+}
+
+#[test]
+fn test_encode_close_account_instruction() {
+    // Helper test to generate correct base58 encoding for CloseAccount
+    // CloseAccount is instruction variant 9 (0x09)
+    let close_account_bytes = [9u8];
+
+    let close_account_b58 = bs58::encode(&close_account_bytes).into_string();
+
+    println!("CloseAccount [9] base58: {close_account_b58}");
+
+    // Verify it decodes correctly
+    let decoded = bs58::decode(&close_account_b58).into_vec().unwrap();
+    assert_eq!(decoded, close_account_bytes);
+    assert_eq!(decoded[0], 9);
 }
 
 #[test]

--- a/src/chain_parsers/visualsign-solana/tests/fixtures/token_2022/close_account.json
+++ b/src/chain_parsers/visualsign-solana/tests/fixtures/token_2022/close_account.json
@@ -1,0 +1,38 @@
+{
+  "description": "Token 2022 CloseAccount instruction - closing a token account and reclaiming rent",
+  "source": "http://localnet/tx",
+  "signature": "test_signature_close_account",
+  "cluster": "mainnet-beta",
+  "full_transaction_note": "This is a test fixture for Token 2022 CloseAccount instruction. This will close a token account and send the rent-exempt balance to the destination account.",
+  "instruction_index": 0,
+  "instruction_data": "A",
+  "program_id": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  "accounts": [
+    {
+      "pubkey": "FzHhqxHPNXrzoNRwVmDRcNprTcx5YAdLyuRNC5FYthi8",
+      "signer": false,
+      "writable": true,
+      "description": "Token account to close"
+    },
+    {
+      "pubkey": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+      "signer": false,
+      "writable": true,
+      "description": "Destination account (receives rent)"
+    },
+    {
+      "pubkey": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+      "signer": true,
+      "writable": false,
+      "description": "Account owner"
+    }
+  ],
+  "expected_fields": {
+    "instruction": "Close Account",
+    "token_account": "FzHhqxHPNXrzoNRwVmDRcNprTcx5YAdLyuRNC5FYthi8",
+    "destination": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+    "owner": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+    "program_id": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+  }
+}
+


### PR DESCRIPTION
Adding parsing for closeAccount Token-2022 program instruction

**Test Close Account instruction:**

```
$ cargo run --quiet -p parser_cli -- --chain solana -t "AYRMrl4a2v8wB84p9jtpuDHoraqH2K9TbACqHJF5VxYlnJuop2zHFb8HtCieTrcQieb8yL/FifwcXYDNy6FRHwQBAAIEtWJBq4hctUN6Co6qxyHR+mzV7HesyzHO49cRlWUgP4uq+ftSJxlCHfdbp8OL9K8GF3sj2OH7CVr566gpsSdZaAMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAABt324e51j94YQl285GzN2rYa/E2DuQ0n/r35KNihi/wX4TUpnBgwo3LHY994V2Z6ScAjHM06p8waSHg1gYFovgIDAwEAAAEJAgAFAlIGAAA="^C
user@w-diegorivas-mhlyvh2a:~/.../visualsign-parser/src$ cargo run --quiet -p parser_cli -- --chain solana -t "AYRMrl4a2v8wB84p9jtpuDHoraqH2K9TbACqHJF5VxYlnJuop2zHFb8HtCieTrcQieb8yL/FifwcXYDNy6FRHwQBAAIEtWJBq4hctUN6Co6qxyHR+mzV7HesyzHO49cRlWUgP4uq+ftSJxlCHfdbp8OL9K8GF3sj2OH7CVr566gpsSdZaAMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAABt324e51j94YQl285GzN2rYa/E2DuQ0n/r35KNihi/wX4TUpnBgwo3LHY994V2Z6ScAjHM06p8waSHg1gYFovgIDAwEAAAEJAgAFAlIGAAA="  --output human
Handling instruction 0 with visualizer Payments("Token2022")
Handling instruction 1 with visualizer Payments("ComputeBudget")
┌─ Transaction: Solana Transaction
│  Version: 0
│  Type: SolanaTx
│
└─ Fields:
   ├─ Network: Solana
   ├─ Instruction 1
   │     Title: Close Account
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Action: Close Account
   │     📖 Expanded View:
   │     ├─ Instruction: Close Account
   │     ├─ Token Account: CWRPqUrwYtwwWQdkrbt9HxNCw6q2oLFWpa3zpidtTyTd
   │     ├─ Destination: DD3h8ReufLEwxrC7b5g5eLVAWsc2vAjpH2JJcpxaYeSe
   │     ├─ Owner: DD3h8ReufLEwxrC7b5g5eLVAWsc2vAjpH2JJcpxaYeSe
   │     ├─ Program ID: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
   │     └─ Raw Data: 09
   ├─ Instruction 2
   │     Title: Set Compute Unit Limit: 1618 units
   │     Detail: 
   │     📋 Condensed View:
   │     └─ Instruction: Set Compute Unit Limit: 1618 units
   │     📖 Expanded View:
   │     ├─ Program ID: ComputeBudget111111111111111111111111111111
   │     ├─ Field: Unknown
   │     └─ Raw Data: 0252060000
   └─ Accounts
         Title: Accounts
         Detail: 4 accounts
         📋 Condensed View:
         ├─ Signers: 1 Signer
         ├─ Writable: 1 Writable
         └─ Read Only: 2 Read Only
         📖 Expanded View:
         ├─ Account: DD3h8ReufLEwxrC7b5g5eLVAWsc2vAjpH2JJcpxaYeSe, Signer, Writable
         ├─ Account: CWRPqUrwYtwwWQdkrbt9HxNCw6q2oLFWpa3zpidtTyTd, Writable
         ├─ Account: ComputeBudget111111111111111111111111111111
         └─ Account: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb


Run with `--condensed-only` to see what users see on hardware wallets
```