### PR TITLE
Add *.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 out
+*.log


### PR DESCRIPTION
## Summary
Add `*.log` pattern to `.gitignore` to prevent log files from being accidentally committed to the repository.

## What is the change
Added `*.log` to the `.gitignore` file.

## Why this change
noticed during #132 that a log file is generated when running the `visualsign-parser` cli.
The log file is created by the setup_logger() function in https://github.com/anchorageoss/visualsign-parser/blob/main/src/parser/cli/src/logger.rs#L20, which calls File::create("visualsign-parser-cli.log") 

lets ignore these files from version control so 1) we don't accidently commit these and 2) new contributors don't need to reason about whether or not to commit / be worried about `git add .`

<img width="2048" height="845" alt="canvas - 2025-12-23T205816 157" src="https://github.com/user-attachments/assets/40aa7acf-f7b3-4037-92b9-281fffe2592a" />
<img width="1758" height="372" alt="image" src="https://github.com/user-attachments/assets/3df9eb3a-9e87-49eb-9911-3bb8f50c92cb" />


## How is it tested?
Created a test log file and verified it is ignored by git plus above
```
touch test.log
git status  # confirms test.log is not shown as untracked
```

## Rollback steps
Revert the commit or remove the `*.log` line from `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)