### PR TITLE
docs: fix broken contributing guide link on about page

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -73,7 +73,7 @@ Being a partner or contractor does not grant administrative rights over reposito
 VisualSign is open source and welcomes contributions:
 
 - [GitHub: visualsign-parser](https://github.com/anchorageoss/visualsign-parser) — Core transaction parser
-- [Contributing guide](/contributing/contributing-visualization) — How to add visualization support for your DApp
+- [Contributing guide](/contributor-guides/contributing-visualization) — How to add visualization support for your DApp
 - [Wallet integration guide](https://github.com/anchorageoss/visualsign-turnkeyclient/blob/main/WALLET_INTEGRATION_GUIDE.md) — For wallet developers
 
 ## License


### PR DESCRIPTION
## Summary

Fixes #151

The 'Get involved' section on the about page had a broken link to the contributing guide.

## Problem

The link `/contributing/contributing-visualization` was returning a 404 because the actual page is located at `/contributor-guides/contributing-visualization`.

## Changes

- Updated the link in `docs/about.mdx` from `/contributing/contributing-visualization` to `/contributor-guides/contributing-visualization`

## Verification

Confirmed the correct path by checking:
- The navigation structure in `docs/docs.json`
- The existing correct links in `CONTRIBUTING.md`
- The actual file location at `docs/contributor-guides/contributing-visualization.mdx`