### PR TITLE
docs: fix broken AWS Nitro Enclaves documentation links

### DIFF
--- a/docs/wallet-integration/self-hosted-tee/attestation.mdx
+++ b/docs/wallet-integration/self-hosted-tee/attestation.mdx
@@ -328,6 +328,6 @@ nitro-cli verify-attestation --document attestation.cbor
 
 ## Resources
 
-- [AWS Nitro Enclaves Documentation](https://docs.aws.amazon.com/enclaves/)
+- [AWS Nitro Enclaves Documentation](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
 - [CBOR RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html)
 - [VisualSign Verifier Library](https://github.com/anchorageoss/awsnitroverifier)

--- a/docs/wallet-integration/self-hosted-tee/security-model.mdx
+++ b/docs/wallet-integration/self-hosted-tee/security-model.mdx
@@ -224,5 +224,5 @@ When the parser is updated, PCR values change. Wallets should:
 
 ## Resources
 
-- [AWS Nitro Enclaves Documentation](https://docs.aws.amazon.com/enclaves/)
+- [AWS Nitro Enclaves Documentation](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
 - [VisualSign Verifier Library](https://github.com/anchorageoss/awsnitroverifier)


### PR DESCRIPTION
## Summary
Fixes #157
you can validate this by clicking on the old link and seeing the non-exisent documentation site
<img width="3406" height="1096" alt="image" src="https://github.com/user-attachments/assets/d09e817a-a2ce-4240-a091-553bc576aebe" />


 and then clicking on the new one
https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html
<img width="3406" height="1096" alt="Screenshot 2026-02-03 22 16 31" src="https://github.com/user-attachments/assets/213439bc-64be-45b5-88cd-d472e7e5db3a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)