### PR TITLE
Fix broken links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ See the [Quickstart](https://visualsign.dev/quickstart) for more examples and th
 Full documentation at **https://visualsign.dev**:
 
 - [Quickstart](https://visualsign.dev/quickstart) — Test your DApp's transactions
-- [Wallet Integration](https://visualsign.dev/getting-started) — Integrate the parser into your wallet
+- [Wallet Integration](https://visualsign.dev/wallet-integration/overview) — Integrate the parser into your wallet
 - [API Reference](https://visualsign.dev/api-reference) — gRPC service definition
 - [Field Types](https://visualsign.dev/field-types) — VisualSign JSON schema
-- [Contributing a Visualization](https://visualsign.dev/contributing/contributing-visualization) — Add support for your protocol
+- [Contributing a Visualization](https://visualsign.dev/contributor-guides/contributing-visualization) — Add support for your protocol
 
 ## Contributing
 
-See the [Contributing guide](https://visualsign.dev/contributing/contributing-visualization) and [About](https://visualsign.dev/about) page for governance details.
+See the [Contributing guide](https://visualsign.dev/contributing) and [About](https://visualsign.dev/about) page for governance details.


### PR DESCRIPTION
## Summary
had broken links in the README left over from Claude'ing.

## Testing
you can click on the old links and see that the links don't work and then click on the new ones and see that they do

## Issue res
_fixes part of the broken links called out in #151_.            #152 should handle the other case

🤖 Generated with [Claude Code](https://claude.com/claude-code)