### PR TITLE
`cla-file-check` GitHub action - check before again and again posting about the CLA that needs signing by the contributor.

### DIFF
--- a/.github/workflows/cla-file-check.yml
+++ b/.github/workflows/cla-file-check.yml
@@ -49,7 +49,7 @@ jobs:
           # Check if github-actions bot has already commented about CLA on this PR
           COMMENTS=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.author.login == "github-actions") | .body')
 
-          if echo "$COMMENTS" | grep -q "Contributor License Agreement"; then
+          if echo "$COMMENTS" | grep -Fq "${{ env.CLA_URL }}"; then
             echo "CLA comment already exists, skipping"
             echo "comment_exists=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Previously, the CLA workflow would post a comment asking the user to sign the CLA on every commit pushed to a PR. This created noise and made PR reviewing harder.

Now the workflow checks if a CLA comment already exists before posting, ensuring users only get notified once per PR.
_above to be verified post-merge via opening a PR via my other GitHub account_
testing of the bash within the new step orchestrated here -> https://github.com/anchorageoss/visualsign-parser/pull/168/changes#r2772045200

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)