### PR TITLE
Fix CLA workflow failing on comments with quotes

### DIFF
--- a/.github/workflows/add-cla-user.yml
+++ b/.github/workflows/add-cla-user.yml
@@ -14,19 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug event
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           echo "Event type: ${{ github.event_name }}"
-          echo "Comment body: '${{ github.event.comment.body }}'"
+          echo "Comment body: '$COMMENT_BODY'"
           echo "Commenter: ${{ github.event.comment.user.login }}"
           echo "Issue number: ${{ github.event.issue.number }}"
           echo "Is PR: ${{ github.event.issue.pull_request != null }}"
 
       - name: Check for command early
         id: command_check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
-          # Trim whitespace and normalize the command
-          COMMENT_BODY=$(echo "$COMMENT_BODY" | xargs)
+          # Trim leading/trailing whitespace without xargs (which chokes on quotes)
+          COMMENT_BODY="$(echo "$COMMENT_BODY" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
           echo "Trimmed comment: '$COMMENT_BODY'"
 
           if [[ "$COMMENT_BODY" == "/approve-cla" ]]; then


### PR DESCRIPTION
## Summary
- Pass comment body via `env` var instead of direct `${{ }}` interpolation to avoid shell injection
- Replace `xargs` with `sed` for whitespace trimming since `xargs` treats quotes as special characters and fails on comments like `I'll`

Fixes https://github.com/anchorageoss/visualsign-parser/actions/runs/21718497730/job/62641178844

## Test plan
- [ ] Comment on a PR with a message containing single quotes (e.g. "I'll check this") and verify the workflow doesn't fail
- [ ] Comment `/approve-cla` on a PR and verify it still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)