### PR TITLE
removes broken verification link in parser-cli docs

### DIFF
--- a/docs/parser-cli.mdx
+++ b/docs/parser-cli.mdx
@@ -250,4 +250,3 @@ When `allow_signed_transactions` is enabled:
 
 - [Field Types Reference](./field-types) - Understanding VisualSign JSON fields
 - [Chain Modules](./chain-modules) - Building parsers for specific chains
-- [Verification](./verification) - Testing and validating parser output


### PR DESCRIPTION
## Summary
- Removed broken link to non-existent `/verification` page from parser-cli.mdx Next Steps section

## Test plan
- [x] Verified the link was causing a 404 error
- [x] Removed the broken link
- [x] Confirmed remaining links in Next Steps section are valid

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)