### PR TITLE
chore: add pepe-anchor to CLA signed users

### DIFF
--- a/.cla-signed-users
+++ b/.cla-signed-users
@@ -8,6 +8,7 @@ guido-peirano-anchor
 diego-rivas-anchor
 lukehalasy-anchorage
 shahan-khatchadourian-anchorage
+pepe-anchor
 # Turnkey
 r-n-o
 Turnalek


### PR DESCRIPTION
## Summary
- Adds `pepe-anchor` to the `.cla-signed-users` file under the Anchorage section

🤖 Generated with [Claude Code](https://claude.com/claude-code)