### PR TITLE
chore: switch solana_parser dependency to shahan-khatchadourian-anchorage fork

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -10549,7 +10549,7 @@ dependencies = [
 [[package]]
 name = "solana_parser"
 version = "0.1.0"
-source = "git+https://github.com/prasincs/solana-parser.git?rev=8248d99e42ce8a56ad440ed9b2201607feb1a150#8248d99e42ce8a56ad440ed9b2201607feb1a150"
+source = "git+https://github.com/shahan-khatchadourian-anchorage/solana-parser.git?rev=8248d99e42ce8a56ad440ed9b2201607feb1a150#8248d99e42ce8a56ad440ed9b2201607feb1a150"
 dependencies = [
  "bincode",
  "bs58 0.5.1",

--- a/src/chain_parsers/visualsign-solana/Cargo.toml
+++ b/src/chain_parsers/visualsign-solana/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2024"
 [dependencies]
 
 tracing = { workspace = true }
-# Using custom fork for IDL-based instruction parsing features not yet in upstream
+# Using our fork of prasincs/custom-idl-support for IDL-based instruction parsing features
 # Features: parse_instruction_with_idl, CustomIdlConfig, decode_idl_data
-# Tracking: https://github.com/tkhq/solana-parser/pull/20
-solana_parser = { git = "https://github.com/prasincs/solana-parser.git", rev = "8248d99e42ce8a56ad440ed9b2201607feb1a150" }
+# Upstream PR: https://github.com/tkhq/solana-parser/pull/20
+# Fork branch: https://github.com/shahan-khatchadourian-anchorage/solana-parser/tree/prasincs/custom-idl-support
+solana_parser = { git = "https://github.com/shahan-khatchadourian-anchorage/solana-parser.git", rev = "8248d99e42ce8a56ad440ed9b2201607feb1a150" }
 visualsign = { workspace = true }
 generated = { path = "../../generated" }
 serde_json = { workspace = true }


### PR DESCRIPTION
Closes #200.

## Summary

- Updates `solana_parser` git source in `visualsign-solana/Cargo.toml` from `prasincs/solana-parser` to `shahan-khatchadourian-anchorage/solana-parser`
- The `prasincs/custom-idl-support` branch has been pushed to our fork at the same branch name
- Pinned to the same rev (`8248d99e`) — no functional change; all 57 tests pass

## Test plan

- [x] `cargo test -p visualsign-solana` — 57 passed, 0 failed