### PR TITLE
refactor(cli): extract generic load_mappings helper to deduplicate ABI/IDL builders

### DIFF
--- a/src/parser/cli/src/ethereum.rs
+++ b/src/parser/cli/src/ethereum.rs
@@ -51,42 +51,15 @@ impl crate::ChainPlugin for EthereumPlugin {
 
 /// Load ABI JSON files and create `HashMap` for `EthereumMetadata.abi_mappings`
 fn build_abi_mappings_from_files(abi_json_mappings: &[String]) -> (HashMap<String, Abi>, usize) {
-    let mut mappings = HashMap::new();
-    let mut valid_count = 0;
-
-    for mapping in abi_json_mappings {
-        match mapping_parser::parse_mapping(mapping) {
-            Ok(components) => match mapping_parser::load_json_file(&components.path) {
-                Ok(json) => {
-                    let abi = Abi {
-                        value: json,
-                        signature: None,
-                    };
-                    mappings.insert(components.identifier.clone(), abi);
-                    valid_count += 1;
-                    eprintln!(
-                        "  Loaded ABI '{}' from {} and mapped to {}",
-                        components.name, components.path, components.identifier
-                    );
-                }
-                Err(e) => {
-                    eprintln!(
-                        "  Warning: Failed to load ABI '{}' from '{}': {e}",
-                        components.name, components.path
-                    );
-                }
-            },
-            Err(e) => {
-                eprintln!("Error parsing ABI mapping: {e}");
-                eprintln!("Expected format: Name:/path/to/abi.json:ContractAddress");
-                eprintln!(
-                    "Example: UniswapV2:/home/user/uniswap.json:0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
-                );
-            }
-        }
-    }
-
-    (mappings, valid_count)
+    mapping_parser::load_mappings(
+        abi_json_mappings,
+        "ABI",
+        "UniswapV2:/home/user/uniswap.json:0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+        |_components, json| Abi {
+            value: json,
+            signature: None,
+        },
+    )
 }
 
 /// Creates Ethereum chain metadata from the network argument.

--- a/src/parser/cli/src/mapping_parser.rs
+++ b/src/parser/cli/src/mapping_parser.rs
@@ -38,6 +38,52 @@ pub fn parse_mapping(mapping_str: &str) -> Result<MappingComponents, String> {
     })
 }
 
+/// Load JSON files from CLI mapping strings and build a `HashMap`.
+///
+/// Each mapping string is parsed, the JSON file is loaded, and `build_value` converts
+/// the loaded JSON + components into the target value type. The identifier from the
+/// mapping becomes the HashMap key.
+///
+/// Returns the populated map and the count of successfully loaded entries.
+pub fn load_mappings<V>(
+    mappings: &[String],
+    kind: &str,
+    example: &str,
+    build_value: impl Fn(&MappingComponents, String) -> V,
+) -> (std::collections::HashMap<String, V>, usize) {
+    let mut map = std::collections::HashMap::new();
+    let mut valid_count = 0;
+
+    for mapping in mappings {
+        match parse_mapping(mapping) {
+            Ok(components) => match load_json_file(&components.path) {
+                Ok(json) => {
+                    let value = build_value(&components, json);
+                    map.insert(components.identifier.clone(), value);
+                    valid_count += 1;
+                    eprintln!(
+                        "  Loaded {kind} '{}' from {} and mapped to {}",
+                        components.name, components.path, components.identifier
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  Warning: Failed to load {kind} '{}' from '{}': {e}",
+                        components.name, components.path
+                    );
+                }
+            },
+            Err(e) => {
+                eprintln!("Error parsing {kind} mapping: {e}");
+                eprintln!("Expected format: Name:/path/to/file.json:Identifier");
+                eprintln!("Example: {example}");
+            }
+        }
+    }
+
+    (map, valid_count)
+}
+
 /// Load and validate JSON file from path
 pub fn load_json_file(path: &str) -> Result<String, String> {
     let json_content =

--- a/src/parser/cli/src/solana.rs
+++ b/src/parser/cli/src/solana.rs
@@ -51,45 +51,18 @@ impl crate::ChainPlugin for SolanaPlugin {
 }
 
 fn build_idl_mappings_from_files(idl_json_mappings: &[String]) -> (HashMap<String, Idl>, usize) {
-    let mut mappings = HashMap::new();
-    let mut valid_count = 0;
-
-    for mapping in idl_json_mappings {
-        match mapping_parser::parse_mapping(mapping) {
-            Ok(components) => match mapping_parser::load_json_file(&components.path) {
-                Ok(idl_json) => {
-                    let idl = Idl {
-                        value: idl_json,
-                        idl_type: Some(SolanaIdlType::Anchor as i32),
-                        idl_version: None,
-                        signature: None,
-                        program_name: Some(components.name.clone()),
-                    };
-                    mappings.insert(components.identifier.clone(), idl);
-                    valid_count += 1;
-                    eprintln!(
-                        "  Loaded IDL '{}' from {} and mapped to {}",
-                        components.name, components.path, components.identifier
-                    );
-                }
-                Err(e) => {
-                    eprintln!(
-                        "  Warning: Failed to load IDL '{}' from '{}': {e}",
-                        components.name, components.path
-                    );
-                }
-            },
-            Err(e) => {
-                eprintln!("Error parsing IDL mapping: {e}");
-                eprintln!("Expected format: Name:/path/to/idl.json:ProgramId");
-                eprintln!(
-                    "Example: JupiterSwap:/home/user/jupiter.json:JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
-                );
-            }
-        }
-    }
-
-    (mappings, valid_count)
+    mapping_parser::load_mappings(
+        idl_json_mappings,
+        "IDL",
+        "JupiterSwap:/home/user/jupiter.json:JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+        |components, json| Idl {
+            value: json,
+            idl_type: Some(SolanaIdlType::Anchor as i32),
+            idl_version: None,
+            signature: None,
+            program_name: Some(components.name.clone()),
+        },
+    )
 }
 
 /// Creates Solana chain metadata from IDL mappings.


### PR DESCRIPTION
## Summary

- Add `mapping_parser::load_mappings()` — a generic helper that handles the parse-mapping → load-JSON → insert loop, parameterized by a value-builder closure
- Simplify `build_abi_mappings_from_files` (Ethereum) and `build_idl_mappings_from_files` (Solana) to thin wrappers (~40 lines removed)

## Stack
| # | Branch | PR |
|---|--------|----|
| 1 | `stack/wire-abi/01-remove-abi-registry-from-options` | #210 |
| 2 | `stack/wire-abi/02-proto-abi-mappings` | #211 |
| 3 | `stack/wire-abi/03-load-mappings-refactor` | 👈 current |

🤖 Generated with [Claude Code](https://claude.com/claude-code)