### PR TITLE
Fix panics on malformed transaction data in legacy instruction decoding

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/accounts/decode.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/accounts/decode.rs
@@ -809,4 +809,45 @@ mod tests {
             _ => panic!("Expected PreviewLayout field"),
         }
     }
+
+    /// Malformed legacy message: header counts exceed account keys length.
+    /// Must not panic (saturating_sub prevents underflow).
+    #[test]
+    fn test_decode_accounts_inconsistent_header_no_panic() {
+        let account1 = Pubkey::new_unique();
+
+        // num_required_signatures (5) > account_keys.len() (1),
+        // num_readonly_signed_accounts (3) > num_required_signatures would be too,
+        // num_readonly_unsigned_accounts (2) > total non-signers (0).
+        let message = create_test_message(5, 3, 2, vec![account1]);
+
+        // Must not panic — the saturating_sub ensures graceful degradation.
+        let accounts = decode_accounts(&message).unwrap();
+        assert_eq!(accounts.len(), 1);
+    }
+
+    /// Malformed V0 message: header counts exceed account keys length.
+    /// Must not panic (saturating_sub prevents underflow).
+    #[test]
+    fn test_decode_v0_accounts_inconsistent_header_no_panic() {
+        use solana_sdk::message::{MessageHeader, v0::Message as V0Message};
+
+        let account1 = Pubkey::new_unique();
+
+        let v0_message = V0Message {
+            header: MessageHeader {
+                num_required_signatures: 10,
+                num_readonly_signed_accounts: 8,
+                num_readonly_unsigned_accounts: 5,
+            },
+            account_keys: vec![account1],
+            recent_blockhash: Hash::new_unique(),
+            instructions: vec![],
+            address_table_lookups: vec![],
+        };
+
+        // Must not panic — the saturating_sub ensures graceful degradation.
+        let accounts = decode_v0_accounts(&v0_message).unwrap();
+        assert_eq!(accounts.len(), 1);
+    }
 }

--- a/src/chain_parsers/visualsign-solana/src/core/instructions.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/instructions.rs
@@ -27,12 +27,15 @@ pub fn decode_instructions(
 
     if account_keys.is_empty() {
         return Err(VisualSignError::ParseError(
-            TransactionParseError::DecodeError("Transaction has no account keys".to_string()),
+            TransactionParseError::DecodeError(
+                "Legacy transaction has no account keys".to_string(),
+            ),
         ));
     }
 
-    // Convert compiled instructions to full instructions, skipping any with
-    // out-of-bounds account indices (same approach as v0 transaction handling).
+    // Convert compiled instructions to full instructions. Instructions with an
+    // out-of-bounds program_id_index are skipped entirely, while individual
+    // out-of-bounds account indices are silently omitted (same approach as v0 transaction handling).
     let instructions: Vec<Instruction> = message
         .instructions
         .iter()


### PR DESCRIPTION
## Summary

Fixes two panic sites in the legacy transaction path found by cargo-fuzz targets introduced in PR #204.

### Bug 1: Unchecked array indexing in `instructions.rs`

`decode_instructions` indexes into `account_keys` using `program_id_index` and account indices from compiled instructions without bounds checks. Malformed transactions where these indices exceed the account keys array cause index-out-of-bounds panics.

```
thread panicked at src/core/instructions.rs:33:37:
index out of bounds: the len is 2 but the index is 255
```

**Fix:** Use `filter_map` with bounds checks, matching the pattern already used in `v0.rs` (lines 137-165). Instructions with out-of-bounds `program_id_index` are skipped; accounts with out-of-bounds indices are dropped from the instruction. An explicit `Err` is returned for empty account keys.

### Bug 2: Arithmetic underflow in `accounts/decode.rs`

`decode_accounts` and `decode_v0_accounts` subtract header values (`num_readonly_signed_accounts`, `num_readonly_unsigned_accounts`) from array lengths without checking that the header values are consistent. Malformed transactions where header counts exceed the actual account keys length cause underflow panics in debug builds and wrapping in release builds.

```
thread panicked at src/core/accounts/decode.rs:27:45:
attempt to subtract with overflow
```

**Fix:** Replace bare subtraction with `saturating_sub`. On inconsistent headers, the writable/readonly classification degrades gracefully (accounts may be misclassified as writable or readonly) rather than panicking.

### Silent failure trade-offs

Both fixes align with the existing v0 transaction handling strategy: **silently skip or degrade** on malformed data rather than returning errors. This is the pragmatic choice for a visualization tool — showing partial results is better than crashing — but it has risks:

| Scenario | Current behavior (after fix) | Risk |
|----------|------------------------------|------|
| Instruction with OOB program_id_index | Instruction silently dropped | User sees fewer instructions than the transaction contains |
| Instruction with OOB account index | Account silently dropped from instruction | Named accounts may be missing from the display |
| Inconsistent message header | Accounts misclassified as writable/readonly | Signer/writable badges may be wrong |

**Future option:** These could be surfaced as `VisualSignError` variants or as warning fields in the `SignablePayload` output, so callers can distinguish "clean parse" from "degraded parse". This would require a new error variant or a warnings field in the output type.

## Test plan

- [x] All 98 existing tests pass (`cargo test -p visualsign-solana`)
- [x] `cargo +nightly fuzz run fuzz_transaction_string -- -max_total_time=30` — ~420,000 runs, zero crashes
- [x] `cargo +nightly fuzz run fuzz_versioned_transaction -- -max_total_time=30` — ~510,000 runs, zero crashes
- [x] `cargo clippy -p visualsign-solana --tests -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)