### PR TITLE
ci: label-triggered stagex builds and cache/credential fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
         with:
           components: clippy, rustfmt
+          cache: false
 
       - name: Cache Rust dependencies
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -12,16 +12,15 @@ on:
       - "images/**"
       - "Makefile"
   pull_request:
-    paths:
-      - ".github/**"
-      - "src/**"
-      - "images/**"
-      - "Makefile"
+    types: [labeled]
   workflow_dispatch: # Allows manual invocation
 
 jobs:
   parser:
     name: Build parser images
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'stagex'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -47,7 +46,6 @@ jobs:
         uses: ./.github/actions/docker-setup
         with:
           dockerHub: ${{ secrets.DOCKERHUB_API_KEY }}
-          ghcr: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ matrix.target.name }}
         shell: bash
@@ -57,6 +55,10 @@ jobs:
       - name: Load artifact to Docker
         run: |
           env -C out/${{ matrix.target.name }} tar -cf - . | docker load
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload to GHCR
         run: |


### PR DESCRIPTION
## Summary

- **stagex.yml**: PR image builds now require the `stagex` label instead of auto-triggering on path changes. Push to main/tags with path filtering unchanged. GHCR credentials moved after build step so build runs without registry write access.
- **main.yml**: Disable `setup-rust-toolchain` built-in cache (`Swatinem/rust-cache`) which fails because `Cargo.toml` is in `src/`, not the repo root. The manual `actions/cache` step already handles caching correctly.

## Test plan

- [ ] Verify adding `stagex` label triggers the build on a PR
- [ ] Verify push to main with relevant path changes still triggers the build
- [ ] Verify GHCR push still works on push to main
- [ ] Verify `Continuous Integration` no longer shows `Cargo.toml` not found errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)