### PR TITLE
poc: decode Drift protocol hack transaction

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/drift/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/drift/config.rs
@@ -1,0 +1,22 @@
+use super::DRIFT_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct DriftConfig;
+
+impl SolanaIntegrationConfig for DriftConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(DRIFT_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/drift/drift.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/drift/drift.json
@@ -1,0 +1,20139 @@
+{
+  "version": "2.162.0",
+  "name": "drift",
+  "instructions": [
+    {
+      "name": "initializeUser",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializeUserStats",
+      "accounts": [
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeSignedMsgUserOrders",
+      "accounts": [
+        {
+          "name": "signedMsgUserOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "numOrders",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "resizeSignedMsgUserOrders",
+      "accounts": [
+        {
+          "name": "signedMsgUserOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "numOrders",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initializeSignedMsgWsDelegates",
+      "accounts": [
+        {
+          "name": "signedMsgWsDelegates",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "delegates",
+          "type": {
+            "vec": "publicKey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "changeSignedMsgWsDelegateStatus",
+      "accounts": [
+        {
+          "name": "signedMsgWsDelegates",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "delegate",
+          "type": "publicKey"
+        },
+        {
+          "name": "add",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "initializeFuelOverflow",
+      "accounts": [
+        {
+          "name": "fuelOverflow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "sweepFuel",
+      "accounts": [
+        {
+          "name": "fuelOverflow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "resetFuelSeason",
+      "accounts": [
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeReferrerName",
+      "accounts": [
+        {
+          "name": "referrerName",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "transferDeposit",
+      "accounts": [
+        {
+          "name": "fromUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "toUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "transferPools",
+      "accounts": [
+        {
+          "name": "fromUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "toUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "depositFromSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "depositToSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "borrowFromSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "borrowToSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "depositFromMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "depositToMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "borrowFromMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "borrowToMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "depositAmount",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "borrowAmount",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "transferPerpPosition",
+      "accounts": [
+        {
+          "name": "fromUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "toUser",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": {
+            "option": "i64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "depositIntoIsolatedPerpPosition",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "transferIsolatedPerpPositionDeposit",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawFromIsolatedPerpPosition",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "placePerpOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancelOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancelOrderByUserId",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "userOrderId",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "cancelOrders",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "marketType",
+          "type": {
+            "option": {
+              "defined": "MarketType"
+            }
+          }
+        },
+        {
+          "name": "marketIndex",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "direction",
+          "type": {
+            "option": {
+              "defined": "PositionDirection"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancelOrdersByIds",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "orderIds",
+          "type": {
+            "vec": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "modifyOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u32"
+          }
+        },
+        {
+          "name": "modifyOrderParams",
+          "type": {
+            "defined": "ModifyOrderParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "modifyOrderByUserId",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "userOrderId",
+          "type": "u8"
+        },
+        {
+          "name": "modifyOrderParams",
+          "type": {
+            "defined": "ModifyOrderParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeAndTakePerpOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        },
+        {
+          "name": "successCondition",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeAndMakePerpOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "taker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "takerStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        },
+        {
+          "name": "takerOrderId",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "placeAndMakeSignedMsgPerpOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "taker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "takerStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "takerSignedMsgUserOrders",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        },
+        {
+          "name": "signedMsgOrderUuid",
+          "type": {
+            "array": [
+              "u8",
+              8
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeSignedMsgTakerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "signedMsgUserOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "ixSysvar",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "the supplied Sysvar could be anything else.",
+            "The Instruction Sysvar has not been implemented",
+            "in the Anchor framework yet, so this is the safe approach."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "signedMsgOrderParamsMessageBytes",
+          "type": "bytes"
+        },
+        {
+          "name": "isDelegateSigner",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "placeSpotOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeAndTakeSpotOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        },
+        {
+          "name": "fulfillmentType",
+          "type": {
+            "option": {
+              "defined": "SpotFulfillmentType"
+            }
+          }
+        },
+        {
+          "name": "makerOrderId",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeAndMakeSpotOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "taker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "takerStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "OrderParams"
+          }
+        },
+        {
+          "name": "takerOrderId",
+          "type": "u32"
+        },
+        {
+          "name": "fulfillmentType",
+          "type": {
+            "option": {
+              "defined": "SpotFulfillmentType"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeOrders",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "vec": {
+              "defined": "OrderParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "placeScaleOrders",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "ScaleOrderParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "beginSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "outSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amountIn",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "endSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "outSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "limitPrice",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "reduceOnly",
+          "type": {
+            "option": {
+              "defined": "SwapReduceOnly"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateUserName",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateUserCustomMarginRatio",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "marginRatio",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateUserPerpPositionCustomMarginRatio",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "marginRatio",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateUserMarginTradingEnabled",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "marginTradingEnabled",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateUserPoolId",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "poolId",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateUserDelegate",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "delegate",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "updateUserReduceOnly",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateUserProtectedMakerOrders",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "protectedMakerModeConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        },
+        {
+          "name": "protectedMakerOrders",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "deleteUser",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "forceDeleteUser",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deleteSignedMsgUserOrders",
+      "accounts": [
+        {
+          "name": "signedMsgUserOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "reclaimRent",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "enableUserHighLeverageMode",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "highLeverageModeConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "subAccountId",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "fillPerpOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "fillerStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u32"
+          }
+        },
+        {
+          "name": "makerOrderId",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "revertFill",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "fillerStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "fillSpotOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "fillerStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderId",
+          "type": {
+            "option": "u32"
+          }
+        },
+        {
+          "name": "fulfillmentType",
+          "type": {
+            "option": {
+              "defined": "SpotFulfillmentType"
+            }
+          }
+        },
+        {
+          "name": "makerOrderId",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "triggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderId",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "forceCancelOrders",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateUserIdle",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "filler",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "logUserBalances",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "disableUserHighLeverageMode",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "highLeverageModeConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "disableMaintenance",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateUserStatsReferrerStatus",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "adminUpdateUserStatsPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "settlePnl",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "settleMultiplePnls",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndexes",
+          "type": {
+            "vec": "u16"
+          }
+        },
+        {
+          "name": "mode",
+          "type": {
+            "defined": "SettlePnlMode"
+          }
+        }
+      ]
+    },
+    {
+      "name": "settleFundingPayment",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "settleExpiredMarket",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "liquidatePerp",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liquidatorMaxBaseAssetAmount",
+          "type": "u64"
+        },
+        {
+          "name": "limitPrice",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "liquidatePerpWithFill",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "liquidateSpot",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "assetMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liabilityMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liquidatorMaxLiabilityTransfer",
+          "type": "u128"
+        },
+        {
+          "name": "limitPrice",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "liquidateSpotWithSwapBegin",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liabilitySpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "assetSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liabilityTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "assetTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "assetMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liabilityMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "swapAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "liquidateSpotWithSwapEnd",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liabilitySpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "assetSpotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liabilityTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "assetTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "assetMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liabilityMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "liquidateBorrowForPerpPnl",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liquidatorMaxLiabilityTransfer",
+          "type": "u128"
+        },
+        {
+          "name": "limitPrice",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "liquidatePerpPnlForDeposit",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "liquidatorMaxPnlTransfer",
+          "type": "u128"
+        },
+        {
+          "name": "limitPrice",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "setUserStatusToBeingLiquidated",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "resolvePerpPnlDeficit",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "resolvePerpBankruptcy",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "quoteSpotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "resolveSpotBankruptcy",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "liquidator",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "liquidatorStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "settleRevenueToInsuranceFund",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateFundingRate",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updatePrelaunchOracle",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updatePerpBidAskTwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "keeperStats",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateSpotMarketCumulativeInterest",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateAmms",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndexes",
+          "type": {
+            "vec": "u16"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketExpiry",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "expiryTs",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updateUserQuoteAssetInsuranceStake",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateUserGovTokenInsuranceStake",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateDelegateUserGovTokenInsuranceStake",
+      "accounts": [
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "spotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "addInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "requestRemoveInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "cancelRequestRemoveInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "removeInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "beginInsuranceFundSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "outInsuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inInsuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ifRebalanceConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amountIn",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "endInsuranceFundSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "outInsuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inInsuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ifRebalanceConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "transferProtocolIfSharesToRevenuePool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ifRebalanceConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "adminWithdrawFromInsuranceFundVault",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "recipientTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositIntoInsuranceFundStake",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundStake",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updatePythPullOracle",
+      "accounts": [
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pythSolanaReceiver",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "encodedVaa",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "priceFeed",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feedId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "params",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "postPythPullOracleUpdateAtomic",
+      "accounts": [
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pythSolanaReceiver",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "guardianSet",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "priceFeed",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feedId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "params",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "postMultiPythPullOracleUpdatesAtomic",
+      "accounts": [
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pythSolanaReceiver",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "guardianSet",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "pauseSpotMarketDepositWithdraw",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "quoteAssetMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeSpotMarket",
+      "accounts": [
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "optimalUtilization",
+          "type": "u32"
+        },
+        {
+          "name": "optimalBorrowRate",
+          "type": "u32"
+        },
+        {
+          "name": "maxBorrowRate",
+          "type": "u32"
+        },
+        {
+          "name": "oracleSource",
+          "type": {
+            "defined": "OracleSource"
+          }
+        },
+        {
+          "name": "initialAssetWeight",
+          "type": "u32"
+        },
+        {
+          "name": "maintenanceAssetWeight",
+          "type": "u32"
+        },
+        {
+          "name": "initialLiabilityWeight",
+          "type": "u32"
+        },
+        {
+          "name": "maintenanceLiabilityWeight",
+          "type": "u32"
+        },
+        {
+          "name": "imfFactor",
+          "type": "u32"
+        },
+        {
+          "name": "liquidatorFee",
+          "type": "u32"
+        },
+        {
+          "name": "ifLiquidationFee",
+          "type": "u32"
+        },
+        {
+          "name": "activeStatus",
+          "type": "bool"
+        },
+        {
+          "name": "assetTier",
+          "type": {
+            "defined": "AssetTier"
+          }
+        },
+        {
+          "name": "scaleInitialAssetWeightStart",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawGuardThreshold",
+          "type": "u64"
+        },
+        {
+          "name": "orderTickSize",
+          "type": "u64"
+        },
+        {
+          "name": "orderStepSize",
+          "type": "u64"
+        },
+        {
+          "name": "ifTotalFactor",
+          "type": "u32"
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "deleteInitializedSpotMarket",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "insuranceFundVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initializeSerumFulfillmentConfig",
+      "accounts": [
+        {
+          "name": "baseSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "quoteSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "serumProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "serumMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "serumOpenOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "serumFulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateSerumFulfillmentConfigStatus",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "serumFulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": {
+            "defined": "SpotFulfillmentConfigStatus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "deleteSerumFulfillmentConfig",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "serumFulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeOpenbookV2FulfillmentConfig",
+      "accounts": [
+        {
+          "name": "baseSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "quoteSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "openbookV2Program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openbookV2Market",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openbookV2FulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "openbookV2FulfillmentConfigStatus",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openbookV2FulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": {
+            "defined": "SpotFulfillmentConfigStatus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "deleteOpenbookV2FulfillmentConfig",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openbookV2FulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializePhoenixFulfillmentConfig",
+      "accounts": [
+        {
+          "name": "baseSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "quoteSpotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "phoenixProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "phoenixMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "phoenixFulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "phoenixFulfillmentConfigStatus",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "phoenixFulfillmentConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": {
+            "defined": "SpotFulfillmentConfigStatus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializePerpMarket",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "ammBaseAssetReserve",
+          "type": "u128"
+        },
+        {
+          "name": "ammQuoteAssetReserve",
+          "type": "u128"
+        },
+        {
+          "name": "ammPeriodicity",
+          "type": "i64"
+        },
+        {
+          "name": "ammPegMultiplier",
+          "type": "u128"
+        },
+        {
+          "name": "oracleSource",
+          "type": {
+            "defined": "OracleSource"
+          }
+        },
+        {
+          "name": "contractTier",
+          "type": {
+            "defined": "ContractTier"
+          }
+        },
+        {
+          "name": "marginRatioInitial",
+          "type": "u32"
+        },
+        {
+          "name": "marginRatioMaintenance",
+          "type": "u32"
+        },
+        {
+          "name": "liquidatorFee",
+          "type": "u32"
+        },
+        {
+          "name": "ifLiquidationFee",
+          "type": "u32"
+        },
+        {
+          "name": "imfFactor",
+          "type": "u32"
+        },
+        {
+          "name": "activeStatus",
+          "type": "bool"
+        },
+        {
+          "name": "baseSpread",
+          "type": "u32"
+        },
+        {
+          "name": "maxSpread",
+          "type": "u32"
+        },
+        {
+          "name": "maxOpenInterest",
+          "type": "u128"
+        },
+        {
+          "name": "maxRevenueWithdrawPerPeriod",
+          "type": "u64"
+        },
+        {
+          "name": "quoteMaxInsurance",
+          "type": "u64"
+        },
+        {
+          "name": "orderStepSize",
+          "type": "u64"
+        },
+        {
+          "name": "orderTickSize",
+          "type": "u64"
+        },
+        {
+          "name": "minOrderSize",
+          "type": "u64"
+        },
+        {
+          "name": "concentrationCoefScale",
+          "type": "u128"
+        },
+        {
+          "name": "curveUpdateIntensity",
+          "type": "u8"
+        },
+        {
+          "name": "ammJitIntensity",
+          "type": "u8"
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "lpPoolId",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "initializeAmmCache",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "addMarketToAmmCache",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deleteAmmCache",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateInitialAmmCacheInfo",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializePredictionMarket",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deleteInitializedPerpMarket",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "moveAmmPrice",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "baseAssetReserve",
+          "type": "u128"
+        },
+        {
+          "name": "quoteAssetReserve",
+          "type": "u128"
+        },
+        {
+          "name": "sqrtK",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "recenterPerpMarketAmm",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pegMultiplier",
+          "type": "u128"
+        },
+        {
+          "name": "sqrtK",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "recenterPerpMarketAmmCrank",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "depth",
+          "type": {
+            "option": "u128"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketAmmSummaryStats",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "UpdatePerpMarketSummaryStatsParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketExpiry",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "expiryTs",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketLpPoolPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lpPausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketLpPoolStatus",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lpStatus",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketLpPoolFeeTransferScalar",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "optionalLpFeeTransferScalar",
+          "type": {
+            "option": "u8"
+          }
+        },
+        {
+          "name": "optionalLpNetPnlTransferScalar",
+          "type": {
+            "option": "u8"
+          }
+        }
+      ]
+    },
+    {
+      "name": "settleExpiredMarketPoolsToRevenuePool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositIntoPerpMarketFeePool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "sourceVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "quoteSpotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketPnlPool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositIntoSpotMarketVault",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "sourceVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositIntoSpotMarketRevenuePool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repegAmmCurve",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newPegCandidate",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketAmmOracleTwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "resetPerpMarketAmmOracleTwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateK",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sqrtK",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMarginRatio",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marginRatioInitial",
+          "type": "u32"
+        },
+        {
+          "name": "marginRatioMaintenance",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketHighLeverageMarginRatio",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marginRatioInitial",
+          "type": "u16"
+        },
+        {
+          "name": "marginRatioMaintenance",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketFundingPeriod",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "fundingPeriod",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMaxImbalances",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "unrealizedMaxImbalance",
+          "type": "u64"
+        },
+        {
+          "name": "maxRevenueWithdrawPerPeriod",
+          "type": "u64"
+        },
+        {
+          "name": "quoteMaxInsurance",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketLiquidationFee",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidatorFee",
+          "type": "u32"
+        },
+        {
+          "name": "ifLiquidationFee",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketLpPoolId",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lpPoolId",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateInsuranceFundUnstakingPeriod",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "insuranceFundUnstakingPeriod",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketPoolId",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "poolId",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketLiquidationFee",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidatorFee",
+          "type": "u32"
+        },
+        {
+          "name": "ifLiquidationFee",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateWithdrawGuardThreshold",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "withdrawGuardThreshold",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketIfFactor",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "userIfFactor",
+          "type": "u32"
+        },
+        {
+          "name": "totalIfFactor",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketRevenueSettlePeriod",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "revenueSettlePeriod",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketStatus",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": {
+            "defined": "MarketStatus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketAssetTier",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "assetTier",
+          "type": {
+            "defined": "AssetTier"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketMarginWeights",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "initialAssetWeight",
+          "type": "u32"
+        },
+        {
+          "name": "maintenanceAssetWeight",
+          "type": "u32"
+        },
+        {
+          "name": "initialLiabilityWeight",
+          "type": "u32"
+        },
+        {
+          "name": "maintenanceLiabilityWeight",
+          "type": "u32"
+        },
+        {
+          "name": "imfFactor",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketBorrowRate",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "optimalUtilization",
+          "type": "u32"
+        },
+        {
+          "name": "optimalBorrowRate",
+          "type": "u32"
+        },
+        {
+          "name": "maxBorrowRate",
+          "type": "u32"
+        },
+        {
+          "name": "minBorrowRate",
+          "type": {
+            "option": "u8"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketMaxTokenDeposits",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxTokenDeposits",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketMaxTokenBorrows",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxTokenBorrowsFraction",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketScaleInitialAssetWeightStart",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "scaleInitialAssetWeightStart",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oldOracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "oracle",
+          "type": "publicKey"
+        },
+        {
+          "name": "oracleSource",
+          "type": {
+            "defined": "OracleSource"
+          }
+        },
+        {
+          "name": "skipInvariantCheck",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketStepSizeAndTickSize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "stepSize",
+          "type": "u64"
+        },
+        {
+          "name": "tickSize",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketMinOrderSize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderSize",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketOrdersEnabled",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ordersEnabled",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketIfPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketName",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketStatus",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": {
+            "defined": "MarketStatus"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketContractTier",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "contractTier",
+          "type": {
+            "defined": "ContractTier"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketImfFactor",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "imfFactor",
+          "type": "u32"
+        },
+        {
+          "name": "unrealizedPnlImfFactor",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketUnrealizedAssetWeight",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "unrealizedInitialAssetWeight",
+          "type": "u32"
+        },
+        {
+          "name": "unrealizedMaintenanceAssetWeight",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketConcentrationCoef",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "concentrationScale",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketCurveUpdateIntensity",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "curveUpdateIntensity",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketReferencePriceOffsetDeadbandPct",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "referencePriceOffsetDeadbandPct",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpFeeStructure",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feeStructure",
+          "type": {
+            "defined": "FeeStructure"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateSpotFeeStructure",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feeStructure",
+          "type": {
+            "defined": "FeeStructure"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateInitialPctToLiquidate",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "initialPctToLiquidate",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateLiquidationDuration",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidationDuration",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateLiquidationMarginBufferRatio",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidationMarginBufferRatio",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateOracleGuardRails",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "oracleGuardRails",
+          "type": {
+            "defined": "OracleGuardRails"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateStateSettlementDuration",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "settlementDuration",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateStateMaxNumberOfSubAccounts",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxNumberOfSubAccounts",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateStateMaxInitializeUserFee",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxInitializeUserFee",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oldOracle",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "oracle",
+          "type": "publicKey"
+        },
+        {
+          "name": "oracleSource",
+          "type": {
+            "defined": "OracleSource"
+          }
+        },
+        {
+          "name": "skipInvariantCheck",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketBaseSpread",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "baseSpread",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateAmmJitIntensity",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ammJitIntensity",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMaxSpread",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxSpread",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketStepSizeAndTickSize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "stepSize",
+          "type": "u64"
+        },
+        {
+          "name": "tickSize",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketName",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMinOrderSize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderSize",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMaxSlippageRatio",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxSlippageRatio",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMaxFillReserveFraction",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxFillReserveFraction",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketMaxOpenInterest",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxOpenInterest",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketNumberOfUsers",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "numberOfUsers",
+          "type": {
+            "option": "u32"
+          }
+        },
+        {
+          "name": "numberOfUsersWithBase",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketFeeAdjustment",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feeAdjustment",
+          "type": "i16"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotMarketFeeAdjustment",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feeAdjustment",
+          "type": "i16"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketProtectedMakerParams",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "protectedMakerLimitPriceDivisor",
+          "type": {
+            "option": "u8"
+          }
+        },
+        {
+          "name": "protectedMakerDynamicDivisor",
+          "type": {
+            "option": "u8"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketOracleLowRiskSlotDelayOverride",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "oracleLowRiskSlotDelayOverride",
+          "type": "i8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketAmmSpreadAdjustment",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ammSpreadAdjustment",
+          "type": "i8"
+        },
+        {
+          "name": "ammInventorySpreadAdjustment",
+          "type": "i8"
+        },
+        {
+          "name": "referencePriceOffset",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpMarketOracleSlotDelayOverride",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "oracleSlotDelayOverride",
+          "type": "i8"
+        }
+      ]
+    },
+    {
+      "name": "updateAdmin",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "updateDiscountMint",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "discountMint",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "updateExchangeStatus",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "exchangeStatus",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updatePerpAuctionDuration",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "minPerpAuctionDuration",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateSpotAuctionDuration",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "defaultSpotAuctionDuration",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "initializePrelaunchOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "prelaunchOracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "PrelaunchOracleParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updatePrelaunchOracleParams",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "prelaunchOracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "PrelaunchOracleParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "deletePrelaunchOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "prelaunchOracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initializePythPullOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pythSolanaReceiver",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "priceFeed",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feedId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializePythLazerOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lazerOracle",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feedId",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "postPythLazerOracleUpdate",
+      "accounts": [
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "pythLazerStorage",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ixSysvar",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pythMessage",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "initializeHighLeverageModeConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "highLeverageModeConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxUsers",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateHighLeverageModeConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "highLeverageModeConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxUsers",
+          "type": "u32"
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        },
+        {
+          "name": "currentUsers",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializeProtectedMakerModeConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "protectedMakerModeConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxUsers",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "updateProtectedMakerModeConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "protectedMakerModeConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxUsers",
+          "type": "u32"
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        },
+        {
+          "name": "currentUsers",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    },
+    {
+      "name": "adminDeposit",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "adminTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initializeIfRebalanceConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "ifRebalanceConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "IfRebalanceConfigParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateIfRebalanceConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "ifRebalanceConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "IfRebalanceConfigParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateFeatureBitFlagsMmOracle",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "zeroMmOracleFields",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateFeatureBitFlagsMedianTriggerPrice",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateFeatureBitFlagsBuilderCodes",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "initializeRevenueShare",
+      "accounts": [
+        {
+          "name": "revenueShare",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeRevenueShareEscrow",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "numOrders",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "resizeRevenueShareEscrowOrders",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "numOrders",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "changeApprovedBuilder",
+      "accounts": [
+        {
+          "name": "escrow",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "builder",
+          "type": "publicKey"
+        },
+        {
+          "name": "maxFeeBps",
+          "type": "u16"
+        },
+        {
+          "name": "add",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "initializeLpPool",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPoolTokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ammConstituentMapping",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentCorrelations",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lpPoolId",
+          "type": "u8"
+        },
+        {
+          "name": "minMintFee",
+          "type": "i64"
+        },
+        {
+          "name": "maxAum",
+          "type": "u128"
+        },
+        {
+          "name": "maxSettleQuoteAmountPerMarket",
+          "type": "u64"
+        },
+        {
+          "name": "whitelistMint",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "updateFeatureBitFlagsSettleLpPool",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateFeatureBitFlagsSwapLpPool",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "updateFeatureBitFlagsMintRedeemLpPool",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "initializeConstituent",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentCorrelations",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "spotMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "decimals",
+          "type": "u8"
+        },
+        {
+          "name": "maxWeightDeviation",
+          "type": "i64"
+        },
+        {
+          "name": "swapFeeMin",
+          "type": "i64"
+        },
+        {
+          "name": "swapFeeMax",
+          "type": "i64"
+        },
+        {
+          "name": "maxBorrowTokenAmount",
+          "type": "u64"
+        },
+        {
+          "name": "oracleStalenessThreshold",
+          "type": "u64"
+        },
+        {
+          "name": "costToTrade",
+          "type": "i32"
+        },
+        {
+          "name": "constituentDerivativeIndex",
+          "type": {
+            "option": "i16"
+          }
+        },
+        {
+          "name": "constituentDerivativeDepegThreshold",
+          "type": "u64"
+        },
+        {
+          "name": "derivativeWeight",
+          "type": "u64"
+        },
+        {
+          "name": "volatility",
+          "type": "u64"
+        },
+        {
+          "name": "gammaExecution",
+          "type": "u8"
+        },
+        {
+          "name": "gammaInventory",
+          "type": "u8"
+        },
+        {
+          "name": "xi",
+          "type": "u8"
+        },
+        {
+          "name": "newConstituentCorrelations",
+          "type": {
+            "vec": "i64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateConstituentStatus",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "newStatus",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateConstituentPausedOperations",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "pausedOperations",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateConstituentParams",
+      "accounts": [
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "constituentParams",
+          "type": {
+            "defined": "ConstituentParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateLpPoolParams",
+      "accounts": [
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lpPoolParams",
+          "type": {
+            "defined": "LpPoolParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "addAmmConstituentMappingData",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammConstituentMapping",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ammConstituentMappingData",
+          "type": {
+            "vec": {
+              "defined": "AddAmmConstituentMappingDatum"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateAmmConstituentMappingData",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammConstituentMapping",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "ammConstituentMappingData",
+          "type": {
+            "vec": {
+              "defined": "AddAmmConstituentMappingDatum"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "removeAmmConstituentMappingData",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammConstituentMapping",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "perpMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "constituentIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateConstituentCorrelationData",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentCorrelations",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "index1",
+          "type": "u16"
+        },
+        {
+          "name": "index2",
+          "type": "u16"
+        },
+        {
+          "name": "correlation",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "updateLpConstituentTargetBase",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "ammConstituentMapping",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateLpPoolAum",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateAmmCache",
+      "accounts": [
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "quoteMarket",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "overrideAmmCacheInfo",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "overrideParams",
+          "type": {
+            "defined": "OverrideAmmCacheParams"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lpPoolSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentCorrelations",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentOutTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userOutTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "outMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u64"
+        },
+        {
+          "name": "minOutAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "viewLpPoolSwapFees",
+      "accounts": [
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentCorrelations",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentOutTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "inConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u64"
+        },
+        {
+          "name": "inTargetWeight",
+          "type": "i64"
+        },
+        {
+          "name": "outTargetWeight",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "lpPoolAddLiquidity",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "inMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "inConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userLpTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lpMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPoolTokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u128"
+        },
+        {
+          "name": "minMintAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lpPoolRemoveLiquidity",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "outMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userOutTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentOutTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userLpTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lpMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPoolTokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ammCache",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u64"
+        },
+        {
+          "name": "minOutAmount",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "viewLpPoolAddLiquidityFees",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "inMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "inConstituent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "viewLpPoolRemoveLiquidityFees",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "outMarketMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTargetBase",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "inAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "beginLpSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "signerOutTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Signer token accounts"
+          ]
+        },
+        {
+          "name": "signerInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentOutTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Constituent token accounts"
+          ]
+        },
+        {
+          "name": "constituentInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Constituents"
+          ]
+        },
+        {
+          "name": "inConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "amountIn",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "endLpSwap",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "signerOutTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Signer token accounts"
+          ]
+        },
+        {
+          "name": "signerInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentOutTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Constituent token accounts"
+          ]
+        },
+        {
+          "name": "constituentInTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "outConstituent",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Constituents"
+          ]
+        },
+        {
+          "name": "inConstituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructions",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Instructions Sysvar for instruction introspection"
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "inMarketIndex",
+          "type": "u16"
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "updateConstituentOracleInfo",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositToProgramVault",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawFromProgramVault",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "spotMarketVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracle",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "settlePerpToLpPool",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lpPool",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "keeper",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "ammCache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "quoteMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituent",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "constituentQuoteTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "quoteTokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "driftSigner",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updatePerpMarketConfig",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "perpMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "marketConfig",
+          "type": "u8"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "AmmCache",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "cache",
+            "type": {
+              "vec": {
+                "defined": "CacheInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenbookV2FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2ProgramId",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2Market",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2MarketAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2EventHeap",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2Bids",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2Asks",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2BaseVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "openbookV2QuoteVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillmentType",
+            "type": {
+              "defined": "SpotFulfillmentType"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": "SpotFulfillmentConfigStatus"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PhoenixV1FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "phoenixProgramId",
+            "type": "publicKey"
+          },
+          {
+            "name": "phoenixLogAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "phoenixMarket",
+            "type": "publicKey"
+          },
+          {
+            "name": "phoenixBaseVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "phoenixQuoteVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillmentType",
+            "type": {
+              "defined": "SpotFulfillmentType"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": "SpotFulfillmentConfigStatus"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SerumV3FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumProgramId",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumMarket",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumRequestQueue",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumEventQueue",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumBids",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumAsks",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumBaseVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumQuoteVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumOpenOrders",
+            "type": "publicKey"
+          },
+          {
+            "name": "serumSignerNonce",
+            "type": "u64"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillmentType",
+            "type": {
+              "defined": "SpotFulfillmentType"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": "SpotFulfillmentConfigStatus"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "HighLeverageModeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxUsers",
+            "type": "u32"
+          },
+          {
+            "name": "currentUsers",
+            "type": "u32"
+          },
+          {
+            "name": "reduceOnly",
+            "type": "u8"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "currentMaintenanceUsers",
+            "type": "u32"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "IfRebalanceConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalInAmount",
+            "docs": [
+              "total amount to be sold"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "currentInAmount",
+            "docs": [
+              "amount already sold"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "currentOutAmount",
+            "docs": [
+              "amount already bought"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "currentOutAmountTransferred",
+            "docs": [
+              "amount already transferred to revenue pool"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "currentInAmountSinceLastTransfer",
+            "docs": [
+              "amount already bought in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epochStartTs",
+            "docs": [
+              "start time of epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "epochInAmount",
+            "docs": [
+              "amount already bought in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epochMaxInAmount",
+            "docs": [
+              "max amount to swap in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epochDuration",
+            "docs": [
+              "duration of epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "outMarketIndex",
+            "docs": [
+              "market index to sell"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "inMarketIndex",
+            "docs": [
+              "market index to buy"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "maxSlippageBps",
+            "type": "u16"
+          },
+          {
+            "name": "swapMode",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFundStake",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "ifShares",
+            "type": "u128"
+          },
+          {
+            "name": "lastWithdrawRequestShares",
+            "type": "u128"
+          },
+          {
+            "name": "ifBase",
+            "type": "u128"
+          },
+          {
+            "name": "lastValidTs",
+            "type": "i64"
+          },
+          {
+            "name": "lastWithdrawRequestValue",
+            "type": "u64"
+          },
+          {
+            "name": "lastWithdrawRequestTs",
+            "type": "i64"
+          },
+          {
+            "name": "costBasis",
+            "type": "i64"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolIfSharesTransferConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelistedSigners",
+            "type": {
+              "array": [
+                "publicKey",
+                4
+              ]
+            }
+          },
+          {
+            "name": "maxTransferPerEpoch",
+            "type": "u128"
+          },
+          {
+            "name": "currentEpochTransfer",
+            "type": "u128"
+          },
+          {
+            "name": "nextEpochTs",
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u128",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LPPool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "address of the vault."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "constituentTargetBase",
+            "type": "publicKey"
+          },
+          {
+            "name": "constituentCorrelations",
+            "type": "publicKey"
+          },
+          {
+            "name": "maxAum",
+            "docs": [
+              "The current number of VaultConstituents in the vault, each constituent is pda(LPPool.address, constituent_index)",
+              "which constituent is the quote, receives revenue pool distributions. (maybe this should just be implied idx 0)",
+              "pub quote_constituent_index: u16,",
+              "QUOTE_PRECISION: Max AUM, Prohibit minting new DLP beyond this"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "lastAum",
+            "docs": [
+              "QUOTE_PRECISION: AUM of the vault in USD, updated lazily"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeQuoteSentToPerpMarkets",
+            "docs": [
+              "QUOTE PRECISION: Cumulative quotes from settles"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeQuoteReceivedFromPerpMarkets",
+            "type": "u128"
+          },
+          {
+            "name": "totalMintRedeemFeesPaid",
+            "docs": [
+              "QUOTE_PRECISION: Total fees paid for minting and redeeming LP tokens"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "lastAumSlot",
+            "docs": [
+              "timestamp of last AUM slot"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxSettleQuoteAmount",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "timestamp of last vAMM revenue rebalance"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mintRedeemId",
+            "docs": [
+              "Every mint/redeem has a monotonically increasing id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settleId",
+            "type": "u64"
+          },
+          {
+            "name": "minMintFee",
+            "docs": [
+              "PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "tokenSupply",
+            "type": "u64"
+          },
+          {
+            "name": "volatility",
+            "type": "u64"
+          },
+          {
+            "name": "constituents",
+            "type": "u16"
+          },
+          {
+            "name": "quoteConsituentIndex",
+            "type": "u16"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "gammaExecution",
+            "type": "u8"
+          },
+          {
+            "name": "xi",
+            "type": "u8"
+          },
+          {
+            "name": "targetOracleDelayFeeBpsPer10Slots",
+            "type": "u8"
+          },
+          {
+            "name": "targetPositionDelayFeeBpsPer10Slots",
+            "type": "u8"
+          },
+          {
+            "name": "lpPoolId",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Constituent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "address of the constituent"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalSwapFees",
+            "docs": [
+              "total fees received by the constituent. Positive = fees received, Negative = fees paid"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "spotBalance",
+            "docs": [
+              "spot borrow-lend balance for constituent"
+            ],
+            "type": {
+              "defined": "ConstituentSpotBalance"
+            }
+          },
+          {
+            "name": "lastSpotBalanceTokenAmount",
+            "type": "i64"
+          },
+          {
+            "name": "cumulativeSpotInterestAccruedTokenAmount",
+            "type": "i64"
+          },
+          {
+            "name": "maxWeightDeviation",
+            "docs": [
+              "max deviation from target_weight allowed for the constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "swapFeeMin",
+            "docs": [
+              "min fee charged on swaps to/from this constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "swapFeeMax",
+            "docs": [
+              "max fee charged on swaps to/from this constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "maxBorrowTokenAmount",
+            "docs": [
+              "Max Borrow amount:",
+              "precision: token precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "vaultTokenBalance",
+            "docs": [
+              "ata token balance in token precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastOraclePrice",
+            "type": "i64"
+          },
+          {
+            "name": "lastOracleSlot",
+            "type": "u64"
+          },
+          {
+            "name": "oracleStalenessThreshold",
+            "docs": [
+              "Delay allowed for valid AUM calculation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flashLoanInitialTokenAmount",
+            "type": "u64"
+          },
+          {
+            "name": "nextSwapId",
+            "docs": [
+              "Every swap to/from this constituent has a monotonically increasing id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "derivativeWeight",
+            "docs": [
+              "percentable of derivatve weight to go to this specific derivative PERCENTAGE_PRECISION. Zero if no derivative weight"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "volatility",
+            "type": "u64"
+          },
+          {
+            "name": "constituentDerivativeDepegThreshold",
+            "type": "u64"
+          },
+          {
+            "name": "constituentDerivativeIndex",
+            "docs": [
+              "The `constituent_index` of the parent constituent. -1 if it is a parent index",
+              "Example: if in a pool with SOL (parent) and dSOL (derivative),",
+              "SOL.constituent_index = 1, SOL.constituent_derivative_index = -1,",
+              "dSOL.constituent_index = 2, dSOL.constituent_derivative_index = 1"
+            ],
+            "type": "i16"
+          },
+          {
+            "name": "spotMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "constituentIndex",
+            "type": "u16"
+          },
+          {
+            "name": "decimals",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "vaultBump",
+            "type": "u8"
+          },
+          {
+            "name": "gammaInventory",
+            "type": "u8"
+          },
+          {
+            "name": "gammaExecution",
+            "type": "u8"
+          },
+          {
+            "name": "xi",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "pausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                162
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentMapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "weights",
+            "type": {
+              "vec": {
+                "defined": "AmmConstituentDatum"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentTargetBase",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "targets",
+            "type": {
+              "vec": {
+                "defined": "TargetsDatum"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentCorrelations",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "correlations",
+            "type": {
+              "vec": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrelaunchOracle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "maxPrice",
+            "type": "i64"
+          },
+          {
+            "name": "confidence",
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdateSlot",
+            "type": "u64"
+          },
+          {
+            "name": "ammLastUpdateSlot",
+            "type": "u64"
+          },
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                70
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "The perp market's address. It is a pda of the market index"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "amm",
+            "docs": [
+              "The automated market maker"
+            ],
+            "type": {
+              "defined": "AMM"
+            }
+          },
+          {
+            "name": "pnlPool",
+            "docs": [
+              "The market's pnl pool. When users settle negative pnl, the balance increases.",
+              "When users settle positive pnl, the balance decreases. Can not go negative."
+            ],
+            "type": {
+              "defined": "PoolBalance"
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Encoded display name for the perp market e.g. SOL-PERP"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "insuranceClaim",
+            "docs": [
+              "The perp market's claim on the insurance fund"
+            ],
+            "type": {
+              "defined": "InsuranceClaim"
+            }
+          },
+          {
+            "name": "unrealizedPnlMaxImbalance",
+            "docs": [
+              "The max pnl imbalance before positive pnl asset weight is discounted",
+              "pnl imbalance is the difference between long and short pnl. When it's greater than 0,",
+              "the amm has negative pnl and the initial asset weight for positive pnl is discounted",
+              "precision = QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "The ts when the market will be expired. Only set if market is in reduce only mode"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "expiryPrice",
+            "docs": [
+              "The price at which positions will be settled. Only set if market is expired",
+              "precision = PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "nextFillRecordId",
+            "docs": [
+              "Every trade has a fill record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "nextFundingRateRecordId",
+            "docs": [
+              "Every funding rate update has a record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "nextCurveRecordId",
+            "docs": [
+              "Every amm k updated has a record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "imfFactor",
+            "docs": [
+              "The initial margin fraction factor. Used to increase margin ratio for large positions",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealizedPnlImfFactor",
+            "docs": [
+              "The imf factor for unrealized pnl. Used to discount asset weight for large positive pnl",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "liquidatorFee",
+            "docs": [
+              "The fee the liquidator is paid for taking over perp position",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "ifLiquidationFee",
+            "docs": [
+              "The fee the insurance fund receives from liquidation",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "marginRatioInitial",
+            "docs": [
+              "The margin ratio which determines how much collateral is required to open a position",
+              "e.g. margin ratio of .1 means a user must have $100 of total collateral to open a $1000 position",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "marginRatioMaintenance",
+            "docs": [
+              "The margin ratio which determines when a user will be liquidated",
+              "e.g. margin ratio of .05 means a user must have $50 of total collateral to maintain a $1000 position",
+              "else they will be liquidated",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealizedPnlInitialAssetWeight",
+            "docs": [
+              "The initial asset weight for positive pnl. Negative pnl always has an asset weight of 1",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealizedPnlMaintenanceAssetWeight",
+            "docs": [
+              "The maintenance asset weight for positive pnl. Negative pnl always has an asset weight of 1",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "numberOfUsersWithBase",
+            "docs": [
+              "number of users in a position (base)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "numberOfUsers",
+            "docs": [
+              "number of users in a position (pnl) or pnl (quote)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether a market is active, reduce only, expired, etc",
+              "Affects whether users can open/close positions"
+            ],
+            "type": {
+              "defined": "MarketStatus"
+            }
+          },
+          {
+            "name": "contractType",
+            "docs": [
+              "Currently only Perpetual markets are supported"
+            ],
+            "type": {
+              "defined": "ContractType"
+            }
+          },
+          {
+            "name": "contractTier",
+            "docs": [
+              "The contract tier determines how much insurance a market can receive, with more speculative markets receiving less insurance",
+              "It also influences the order perp markets can be liquidated, with less speculative markets being liquidated first"
+            ],
+            "type": {
+              "defined": "ContractTier"
+            }
+          },
+          {
+            "name": "pausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "quoteSpotMarketIndex",
+            "docs": [
+              "The spot market that pnl is settled in"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "feeAdjustment",
+            "docs": [
+              "Between -100 and 100, represents what % to increase/decrease the fee by",
+              "E.g. if this is -50 and the fee is 5bps, the new fee will be 2.5bps",
+              "if this is 50 and the fee is 5bps, the new fee will be 7.5bps"
+            ],
+            "type": "i16"
+          },
+          {
+            "name": "fuelBoostPosition",
+            "docs": [
+              "fuel multiplier for perp funding",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostTaker",
+            "docs": [
+              "fuel multiplier for perp taker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostMaker",
+            "docs": [
+              "fuel multiplier for perp maker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "poolId",
+            "type": "u8"
+          },
+          {
+            "name": "highLeverageMarginRatioInitial",
+            "type": "u16"
+          },
+          {
+            "name": "highLeverageMarginRatioMaintenance",
+            "type": "u16"
+          },
+          {
+            "name": "protectedMakerLimitPriceDivisor",
+            "type": "u8"
+          },
+          {
+            "name": "protectedMakerDynamicDivisor",
+            "type": "u8"
+          },
+          {
+            "name": "lpFeeTransferScalar",
+            "type": "u8"
+          },
+          {
+            "name": "lpStatus",
+            "type": "u8"
+          },
+          {
+            "name": "lpPausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "lpExchangeFeeExcluscionScalar",
+            "type": "u8"
+          },
+          {
+            "name": "lastFillPrice",
+            "type": "u64"
+          },
+          {
+            "name": "lpPoolId",
+            "type": "u8"
+          },
+          {
+            "name": "marketConfig",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                22
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtectedMakerModeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxUsers",
+            "type": "u32"
+          },
+          {
+            "name": "currentUsers",
+            "type": "u32"
+          },
+          {
+            "name": "reduceOnly",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                31
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PythLazerOracle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "publishTime",
+            "type": "u64"
+          },
+          {
+            "name": "postedSlot",
+            "type": "u64"
+          },
+          {
+            "name": "exponent",
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "conf",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShare",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "the owner of this account, a builder or referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "totalReferrerRewards",
+            "type": "u64"
+          },
+          {
+            "name": "totalBuilderRewards",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                18
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "the owner of this account, a user"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "referrer",
+            "type": "publicKey"
+          },
+          {
+            "name": "referrerBoostExpireTs",
+            "type": "u32"
+          },
+          {
+            "name": "referrerRewardOffset",
+            "type": "i8"
+          },
+          {
+            "name": "refereeFeeNumeratorOffset",
+            "type": "i8"
+          },
+          {
+            "name": "referrerBoostNumerator",
+            "type": "i8"
+          },
+          {
+            "name": "reservedFixed",
+            "type": {
+              "array": [
+                "u8",
+                17
+              ]
+            }
+          },
+          {
+            "name": "padding0",
+            "type": "u32"
+          },
+          {
+            "name": "orders",
+            "type": {
+              "vec": {
+                "defined": "RevenueShareOrder"
+              }
+            }
+          },
+          {
+            "name": "padding1",
+            "type": "u32"
+          },
+          {
+            "name": "approvedBuilders",
+            "type": {
+              "vec": {
+                "defined": "BuilderInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgUserOrders",
+      "docs": [
+        "* This struct is a duplicate of SignedMsgUserOrdersZeroCopy\n * It is used to give anchor an struct to generate the idl for clients\n * The struct SignedMsgUserOrdersZeroCopy is used to load the data in efficiently"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authorityPubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          },
+          {
+            "name": "signedMsgOrderData",
+            "type": {
+              "vec": {
+                "defined": "SignedMsgOrderId"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgWsDelegates",
+      "docs": [
+        "* Used to store authenticated delegates for swift-like ws connections"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegates",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "The address of the spot market. It is a pda of the market index"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "oracle",
+            "docs": [
+              "The oracle used to price the markets deposits/borrows"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint of the market"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "The vault used to store the market's deposits",
+              "The amount in the vault should be equal to or greater than deposits - borrows"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "name",
+            "docs": [
+              "The encoded display name for the market e.g. SOL"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "historicalOracleData",
+            "type": {
+              "defined": "HistoricalOracleData"
+            }
+          },
+          {
+            "name": "historicalIndexData",
+            "type": {
+              "defined": "HistoricalIndexData"
+            }
+          },
+          {
+            "name": "revenuePool",
+            "docs": [
+              "Revenue the protocol has collected in this markets token",
+              "e.g. for SOL-PERP, funds can be settled in usdc and will flow into the USDC revenue pool"
+            ],
+            "type": {
+              "defined": "PoolBalance"
+            }
+          },
+          {
+            "name": "spotFeePool",
+            "docs": [
+              "The fees collected from swaps between this market and the quote market",
+              "Is settled to the quote markets revenue pool"
+            ],
+            "type": {
+              "defined": "PoolBalance"
+            }
+          },
+          {
+            "name": "insuranceFund",
+            "docs": [
+              "Details on the insurance fund covering bankruptcies in this markets token",
+              "Covers bankruptcies for borrows with this markets token and perps settling in this markets token"
+            ],
+            "type": {
+              "defined": "InsuranceFund"
+            }
+          },
+          {
+            "name": "totalSpotFee",
+            "docs": [
+              "The total spot fees collected for this market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "depositBalance",
+            "docs": [
+              "The sum of the scaled balances for deposits across users and pool balances",
+              "To convert to the deposit token amount, multiply by the cumulative deposit interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowBalance",
+            "docs": [
+              "The sum of the scaled balances for borrows across users and pool balances",
+              "To convert to the borrow token amount, multiply by the cumulative borrow interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeDepositInterest",
+            "docs": [
+              "The cumulative interest earned by depositors",
+              "Used to calculate the deposit token amount from the deposit balance",
+              "precision: SPOT_CUMULATIVE_INTEREST_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeBorrowInterest",
+            "docs": [
+              "The cumulative interest earned by borrowers",
+              "Used to calculate the borrow token amount from the borrow balance",
+              "precision: SPOT_CUMULATIVE_INTEREST_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalSocialLoss",
+            "docs": [
+              "The total socialized loss from borrows, in the mint's token",
+              "precision: token mint precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalQuoteSocialLoss",
+            "docs": [
+              "The total socialized loss from borrows, in the quote market's token",
+              "preicision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "withdrawGuardThreshold",
+            "docs": [
+              "no withdraw limits/guards when deposits below this threshold",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxTokenDeposits",
+            "docs": [
+              "The max amount of token deposits in this market",
+              "0 if there is no limit",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositTokenTwap",
+            "docs": [
+              "24hr average of deposit token amount",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowTokenTwap",
+            "docs": [
+              "24hr average of borrow token amount",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "utilizationTwap",
+            "docs": [
+              "24hr average of utilization",
+              "which is borrow amount over token amount",
+              "precision: SPOT_UTILIZATION_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastInterestTs",
+            "docs": [
+              "Last time the cumulative deposit and borrow interest was updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastTwapTs",
+            "docs": [
+              "Last time the deposit/borrow/utilization averages were updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiryTs",
+            "docs": [
+              "The time the market is set to expire. Only set if market is in reduce only mode"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "orderStepSize",
+            "docs": [
+              "Spot orders must be a multiple of the step size",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orderTickSize",
+            "docs": [
+              "Spot orders must be a multiple of the tick size",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minOrderSize",
+            "docs": [
+              "The minimum order size",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxPositionSize",
+            "docs": [
+              "The maximum spot position size",
+              "if the limit is 0, there is no limit",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "nextFillRecordId",
+            "docs": [
+              "Every spot trade has a fill record id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "nextDepositRecordId",
+            "docs": [
+              "Every deposit has a deposit record id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "initialAssetWeight",
+            "docs": [
+              "The initial asset weight used to calculate a deposits contribution to a users initial total collateral",
+              "e.g. if the asset weight is .8, $100 of deposits contributes $80 to the users initial total collateral",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maintenanceAssetWeight",
+            "docs": [
+              "The maintenance asset weight used to calculate a deposits contribution to a users maintenance total collateral",
+              "e.g. if the asset weight is .9, $100 of deposits contributes $90 to the users maintenance total collateral",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "initialLiabilityWeight",
+            "docs": [
+              "The initial liability weight used to calculate a borrows contribution to a users initial margin requirement",
+              "e.g. if the liability weight is .9, $100 of borrows contributes $90 to the users initial margin requirement",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maintenanceLiabilityWeight",
+            "docs": [
+              "The maintenance liability weight used to calculate a borrows contribution to a users maintenance margin requirement",
+              "e.g. if the liability weight is .8, $100 of borrows contributes $80 to the users maintenance margin requirement",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "imfFactor",
+            "docs": [
+              "The initial margin fraction factor. Used to increase liability weight/decrease asset weight for large positions",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "liquidatorFee",
+            "docs": [
+              "The fee the liquidator is paid for taking over borrow/deposit",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "ifLiquidationFee",
+            "docs": [
+              "The fee the insurance fund receives from liquidation",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "optimalUtilization",
+            "docs": [
+              "The optimal utilization rate for this market.",
+              "Used to determine the markets borrow rate",
+              "precision: SPOT_UTILIZATION_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "optimalBorrowRate",
+            "docs": [
+              "The borrow rate for this market when the market has optimal utilization",
+              "precision: SPOT_RATE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maxBorrowRate",
+            "docs": [
+              "The borrow rate for this market when the market has 1000 utilization",
+              "precision: SPOT_RATE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "decimals",
+            "docs": [
+              "The market's token mint's decimals. To from decimals to a precision, 10^decimals"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "ordersEnabled",
+            "docs": [
+              "Whether or not spot trading is enabled"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "oracleSource",
+            "type": {
+              "defined": "OracleSource"
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": "MarketStatus"
+            }
+          },
+          {
+            "name": "assetTier",
+            "docs": [
+              "The asset tier affects how a deposit can be used as collateral and the priority for a borrow being liquidated"
+            ],
+            "type": {
+              "defined": "AssetTier"
+            }
+          },
+          {
+            "name": "pausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "ifPausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "feeAdjustment",
+            "type": "i16"
+          },
+          {
+            "name": "maxTokenBorrowsFraction",
+            "docs": [
+              "What fraction of max_token_deposits",
+              "disabled when 0, 1 => 1/10000 => .01% of max_token_deposits",
+              "precision: X/10000"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "flashLoanAmount",
+            "docs": [
+              "For swaps, the amount of token loaned out in the begin_swap ix",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flashLoanInitialTokenAmount",
+            "docs": [
+              "For swaps, the amount in the users token account in the begin_swap ix",
+              "Used to calculate how much of the token left the system in end_swap ix",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalSwapFee",
+            "docs": [
+              "The total fees received from swaps",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "scaleInitialAssetWeightStart",
+            "docs": [
+              "When to begin scaling down the initial asset weight",
+              "disabled when 0",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minBorrowRate",
+            "docs": [
+              "The min borrow rate for this market when the market regardless of utilization",
+              "1 => 1/200 => .5%",
+              "precision: X/200"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostDeposits",
+            "docs": [
+              "fuel multiplier for spot deposits",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostBorrows",
+            "docs": [
+              "fuel multiplier for spot borrows",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostTaker",
+            "docs": [
+              "fuel multiplier for spot taker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostMaker",
+            "docs": [
+              "fuel multiplier for spot maker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelBoostInsurance",
+            "docs": [
+              "fuel multiplier for spot insurance stake",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "tokenProgramFlag",
+            "type": "u8"
+          },
+          {
+            "name": "poolId",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                40
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "State",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "discountMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "signer",
+            "type": "publicKey"
+          },
+          {
+            "name": "srmVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "perpFeeStructure",
+            "type": {
+              "defined": "FeeStructure"
+            }
+          },
+          {
+            "name": "spotFeeStructure",
+            "type": {
+              "defined": "FeeStructure"
+            }
+          },
+          {
+            "name": "oracleGuardRails",
+            "type": {
+              "defined": "OracleGuardRails"
+            }
+          },
+          {
+            "name": "numberOfAuthorities",
+            "type": "u64"
+          },
+          {
+            "name": "numberOfSubAccounts",
+            "type": "u64"
+          },
+          {
+            "name": "lpCooldownTime",
+            "type": "u64"
+          },
+          {
+            "name": "liquidationMarginBufferRatio",
+            "type": "u32"
+          },
+          {
+            "name": "settlementDuration",
+            "type": "u16"
+          },
+          {
+            "name": "numberOfMarkets",
+            "type": "u16"
+          },
+          {
+            "name": "numberOfSpotMarkets",
+            "type": "u16"
+          },
+          {
+            "name": "signerNonce",
+            "type": "u8"
+          },
+          {
+            "name": "minPerpAuctionDuration",
+            "type": "u8"
+          },
+          {
+            "name": "defaultMarketOrderTimeInForce",
+            "type": "u8"
+          },
+          {
+            "name": "defaultSpotAuctionDuration",
+            "type": "u8"
+          },
+          {
+            "name": "exchangeStatus",
+            "type": "u8"
+          },
+          {
+            "name": "liquidationDuration",
+            "type": "u8"
+          },
+          {
+            "name": "initialPctToLiquidate",
+            "type": "u16"
+          },
+          {
+            "name": "maxNumberOfSubAccounts",
+            "type": "u16"
+          },
+          {
+            "name": "maxInitializeUserFee",
+            "type": "u16"
+          },
+          {
+            "name": "featureBitFlags",
+            "type": "u8"
+          },
+          {
+            "name": "lpPoolFeatureBitFlags",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "User",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The owner/authority of the account"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "delegate",
+            "docs": [
+              "An addresses that can control the account on the authority's behalf. Has limited power, cant withdraw"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Encoded display name e.g. \"toly\""
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "spotPositions",
+            "docs": [
+              "The user's spot positions"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "SpotPosition"
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "perpPositions",
+            "docs": [
+              "The user's perp positions"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "PerpPosition"
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "orders",
+            "docs": [
+              "The user's orders"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "Order"
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "lastAddPerpLpSharesTs",
+            "docs": [
+              "The last time the user added perp lp positions"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "totalDeposits",
+            "docs": [
+              "The total values of deposits the user has made",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalWithdraws",
+            "docs": [
+              "The total values of withdrawals the user has made",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalSocialLoss",
+            "docs": [
+              "The total socialized loss the users has incurred upon the protocol",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settledPerpPnl",
+            "docs": [
+              "Fees (taker fees, maker rebate, referrer reward, filler reward) and pnl for perps",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulativeSpotFees",
+            "docs": [
+              "Fees (taker fees, maker rebate, filler reward) for spot",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulativePerpFunding",
+            "docs": [
+              "Cumulative funding paid/received for perps",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "liquidationMarginFreed",
+            "docs": [
+              "The amount of margin freed during liquidation. Used to force the liquidation to occur over a period of time",
+              "Defaults to zero when not being liquidated",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastActiveSlot",
+            "docs": [
+              "The last slot a user was active. Used to determine if a user is idle"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "nextOrderId",
+            "docs": [
+              "Every user order has an order id. This is the next order id to be used"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maxMarginRatio",
+            "docs": [
+              "Custom max initial margin ratio for the user"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "nextLiquidationId",
+            "docs": [
+              "The next liquidation id to be used for user"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "subAccountId",
+            "docs": [
+              "The sub account id for this user"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether the user is active, being liquidated or bankrupt"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "isMarginTradingEnabled",
+            "docs": [
+              "Whether the user has enabled margin trading"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "idle",
+            "docs": [
+              "User is idle if they haven't interacted with the protocol in 1 week and they have no orders, perp positions or borrows",
+              "Off-chain keeper bots can ignore users that are idle"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "openOrders",
+            "docs": [
+              "number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "hasOpenOrder",
+            "docs": [
+              "Whether or not user has open order"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "openAuctions",
+            "docs": [
+              "number of open orders with auction"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "hasOpenAuction",
+            "docs": [
+              "Whether or not user has open order with auction"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "marginMode",
+            "type": {
+              "defined": "MarginMode"
+            }
+          },
+          {
+            "name": "poolId",
+            "type": "u8"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "lastFuelBonusUpdateTs",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStats",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority for all of a users sub accounts"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "referrer",
+            "docs": [
+              "The address that referred this user"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Stats on the fees paid by the user"
+            ],
+            "type": {
+              "defined": "UserFees"
+            }
+          },
+          {
+            "name": "nextEpochTs",
+            "docs": [
+              "The timestamp of the next epoch",
+              "Epoch is used to limit referrer rewards earned in single epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "makerVolume30d",
+            "docs": [
+              "Rolling 30day maker volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "takerVolume30d",
+            "docs": [
+              "Rolling 30day taker volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fillerVolume30d",
+            "docs": [
+              "Rolling 30day filler volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastMakerVolume30dTs",
+            "docs": [
+              "last time the maker volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastTakerVolume30dTs",
+            "docs": [
+              "last time the taker volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastFillerVolume30dTs",
+            "docs": [
+              "last time the filler volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "ifStakedQuoteAssetAmount",
+            "docs": [
+              "The amount of tokens staked in the quote spot markets if"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "numberOfSubAccounts",
+            "docs": [
+              "The current number of sub accounts"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "numberOfSubAccountsCreated",
+            "docs": [
+              "The number of sub accounts created. Can be greater than the number of sub accounts if user",
+              "has deleted sub accounts"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "referrerStatus",
+            "docs": [
+              "Flags for referrer status:",
+              "First bit (LSB): 1 if user is a referrer, 0 otherwise",
+              "Second bit: 1 if user was referred, 0 otherwise"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "disableUpdatePerpBidAskTwap",
+            "type": "u8"
+          },
+          {
+            "name": "pausedOperations",
+            "type": "u8"
+          },
+          {
+            "name": "fuelOverflowStatus",
+            "docs": [
+              "whether the user has a FuelOverflow account"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuelInsurance",
+            "docs": [
+              "accumulated fuel for token amounts of insurance"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuelDeposits",
+            "docs": [
+              "accumulated fuel for notional of deposits"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuelBorrows",
+            "docs": [
+              "accumulate fuel bonus for notional of borrows"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuelPositions",
+            "docs": [
+              "accumulated fuel for perp open interest"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuelTaker",
+            "docs": [
+              "accumulate fuel bonus for taker volume"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuelMaker",
+            "docs": [
+              "accumulate fuel bonus for maker volume"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "ifStakedGovTokenAmount",
+            "docs": [
+              "The amount of tokens staked in the governance spot markets if"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastFuelIfBonusUpdateTs",
+            "docs": [
+              "last unix ts user stats data was used to update if fuel (u32 to save space)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerName",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "user",
+            "type": "publicKey"
+          },
+          {
+            "name": "userStats",
+            "type": "publicKey"
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FuelOverflow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority of this overflow account"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "fuelInsurance",
+            "type": "u128"
+          },
+          {
+            "name": "fuelDeposits",
+            "type": "u128"
+          },
+          {
+            "name": "fuelBorrows",
+            "type": "u128"
+          },
+          {
+            "name": "fuelPositions",
+            "type": "u128"
+          },
+          {
+            "name": "fuelTaker",
+            "type": "u128"
+          },
+          {
+            "name": "fuelMaker",
+            "type": "u128"
+          },
+          {
+            "name": "lastFuelSweepTs",
+            "type": "u32"
+          },
+          {
+            "name": "lastResetTs",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "UpdatePerpMarketSummaryStatsParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quoteAssetAmountWithUnsettledLp",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "netUnsettledFundingPnl",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "updateAmmSummaryStats",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "excludeTotalLiqFee",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxWeightDeviation",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "swapFeeMin",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "swapFeeMax",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "maxBorrowTokenAmount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracleStalenessThreshold",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "costToTradeBps",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "constituentDerivativeIndex",
+            "type": {
+              "option": "i16"
+            }
+          },
+          {
+            "name": "derivativeWeight",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "volatility",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "gammaExecution",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "gammaInventory",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "xi",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpPoolParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxSettleQuoteAmount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "volatility",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "gammaExecution",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "xi",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "maxAum",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "whitelistMint",
+            "type": {
+              "option": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideAmmCacheParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quoteOwedFromLpPool",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "lastSettleSlot",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "lastFeePoolTokenAmount",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "lastNetPnlPoolTokenAmount",
+            "type": {
+              "option": "i128"
+            }
+          },
+          {
+            "name": "ammPositionScalar",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "ammInventoryLimit",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddAmmConstituentMappingDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "constituentIndex",
+            "type": "u16"
+          },
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "weight",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CacheInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "publicKey"
+          },
+          {
+            "name": "lastFeePoolTokenAmount",
+            "type": "u128"
+          },
+          {
+            "name": "lastNetPnlPoolTokenAmount",
+            "type": "i128"
+          },
+          {
+            "name": "lastExchangeFees",
+            "type": "u128"
+          },
+          {
+            "name": "lastSettleAmmExFees",
+            "type": "u128"
+          },
+          {
+            "name": "lastSettleAmmPnl",
+            "type": "i128"
+          },
+          {
+            "name": "position",
+            "docs": [
+              "BASE PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "lastSettleAmount",
+            "type": "u64"
+          },
+          {
+            "name": "lastSettleSlot",
+            "type": "u64"
+          },
+          {
+            "name": "lastSettleTs",
+            "type": "i64"
+          },
+          {
+            "name": "quoteOwedFromLpPool",
+            "type": "i64"
+          },
+          {
+            "name": "ammInventoryLimit",
+            "type": "i64"
+          },
+          {
+            "name": "oraclePrice",
+            "type": "i64"
+          },
+          {
+            "name": "oracleSlot",
+            "type": "u64"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "oracleSource",
+            "type": "u8"
+          },
+          {
+            "name": "oracleValidity",
+            "type": "u8"
+          },
+          {
+            "name": "lpStatusForPerpMarket",
+            "type": "u8"
+          },
+          {
+            "name": "ammPositionScalar",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                34
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmCacheFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidatePerpRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "oraclePrice",
+            "type": "i64"
+          },
+          {
+            "name": "baseAssetAmount",
+            "type": "i64"
+          },
+          {
+            "name": "quoteAssetAmount",
+            "type": "i64"
+          },
+          {
+            "name": "lpShares",
+            "docs": [
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fillRecordId",
+            "type": "u64"
+          },
+          {
+            "name": "userOrderId",
+            "type": "u32"
+          },
+          {
+            "name": "liquidatorOrderId",
+            "type": "u32"
+          },
+          {
+            "name": "liquidatorFee",
+            "docs": [
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ifFee",
+            "docs": [
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidateSpotRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "assetMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "assetPrice",
+            "type": "i64"
+          },
+          {
+            "name": "assetTransfer",
+            "type": "u128"
+          },
+          {
+            "name": "liabilityMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "liabilityPrice",
+            "type": "i64"
+          },
+          {
+            "name": "liabilityTransfer",
+            "docs": [
+              "precision: token mint precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "ifFee",
+            "docs": [
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidateBorrowForPerpPnlRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "marketOraclePrice",
+            "type": "i64"
+          },
+          {
+            "name": "pnlTransfer",
+            "type": "u128"
+          },
+          {
+            "name": "liabilityMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "liabilityPrice",
+            "type": "i64"
+          },
+          {
+            "name": "liabilityTransfer",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidatePerpPnlForDepositRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "marketOraclePrice",
+            "type": "i64"
+          },
+          {
+            "name": "pnlTransfer",
+            "type": "u128"
+          },
+          {
+            "name": "assetMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "assetPrice",
+            "type": "i64"
+          },
+          {
+            "name": "assetTransfer",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpBankruptcyRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "pnl",
+            "type": "i128"
+          },
+          {
+            "name": "ifPayment",
+            "type": "u128"
+          },
+          {
+            "name": "clawbackUser",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "clawbackUserPayment",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "cumulativeFundingRateDelta",
+            "type": "i128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotBankruptcyRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "borrowAmount",
+            "type": "u128"
+          },
+          {
+            "name": "ifPayment",
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeDepositInterestDelta",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IfRebalanceConfigParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "totalInAmount",
+            "type": "u64"
+          },
+          {
+            "name": "epochMaxInAmount",
+            "type": "u64"
+          },
+          {
+            "name": "epochDuration",
+            "type": "i64"
+          },
+          {
+            "name": "outMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "inMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "maxSlippageBps",
+            "type": "u16"
+          },
+          {
+            "name": "swapMode",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentSpotBalance",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaledBalance",
+            "docs": [
+              "The scaled balance of the position. To get the token amount, multiply by the cumulative deposit/borrow",
+              "interest of corresponding market.",
+              "precision: token precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeDeposits",
+            "docs": [
+              "The cumulative deposits/borrows a user has made into a market",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "marketIndex",
+            "docs": [
+              "The market index of the corresponding spot market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "balanceType",
+            "docs": [
+              "Whether the position is deposit or borrow"
+            ],
+            "type": {
+              "defined": "SpotBalanceType"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "constituentIndex",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "lastSlot",
+            "type": "u64"
+          },
+          {
+            "name": "weight",
+            "docs": [
+              "PERCENTAGE_PRECISION. The weight this constituent has on the perp market"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentMappingFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TargetsDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "costToTradeBps",
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "targetBase",
+            "type": "i64"
+          },
+          {
+            "name": "lastOracleSlot",
+            "type": "u64"
+          },
+          {
+            "name": "lastPositionSlot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentTargetBaseFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "docs": [
+              "total elements in the flattened `data` vec"
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentCorrelationsFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lpPool",
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "docs": [
+              "total elements in the flattened `data` vec"
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketIdentifier",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marketType",
+            "type": {
+              "defined": "MarketType"
+            }
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HistoricalOracleData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lastOraclePrice",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastOracleConf",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastOracleDelay",
+            "docs": [
+              "number of slots since last update"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastOraclePriceTwap",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastOraclePriceTwap5min",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastOraclePriceTwapTs",
+            "docs": [
+              "unix_timestamp of last snapshot"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HistoricalIndexData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lastIndexBidPrice",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastIndexAskPrice",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastIndexPriceTwap",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastIndexPriceTwap5min",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastIndexPriceTwapTs",
+            "docs": [
+              "unix_timestamp of last snapshot"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrelaunchOracleParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perpMarketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "price",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "maxPrice",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "orderType",
+            "type": {
+              "defined": "OrderType"
+            }
+          },
+          {
+            "name": "marketType",
+            "type": {
+              "defined": "MarketType"
+            }
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": "PositionDirection"
+            }
+          },
+          {
+            "name": "userOrderId",
+            "type": "u8"
+          },
+          {
+            "name": "baseAssetAmount",
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "type": "u64"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "reduceOnly",
+            "type": "bool"
+          },
+          {
+            "name": "postOnly",
+            "type": {
+              "defined": "PostOnlyParam"
+            }
+          },
+          {
+            "name": "bitFlags",
+            "type": "u8"
+          },
+          {
+            "name": "maxTs",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "triggerPrice",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "triggerCondition",
+            "type": {
+              "defined": "OrderTriggerCondition"
+            }
+          },
+          {
+            "name": "oraclePriceOffset",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "auctionDuration",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "auctionStartPrice",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "auctionEndPrice",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderParamsMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signedMsgOrderParams",
+            "type": {
+              "defined": "OrderParams"
+            }
+          },
+          {
+            "name": "subAccountId",
+            "type": "u16"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "takeProfitOrderParams",
+            "type": {
+              "option": {
+                "defined": "SignedMsgTriggerOrderParams"
+              }
+            }
+          },
+          {
+            "name": "stopLossOrderParams",
+            "type": {
+              "option": {
+                "defined": "SignedMsgTriggerOrderParams"
+              }
+            }
+          },
+          {
+            "name": "maxMarginRatio",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "builderIdx",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "builderFeeTenthBps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "isolatedPositionDeposit",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderParamsDelegateMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signedMsgOrderParams",
+            "type": {
+              "defined": "OrderParams"
+            }
+          },
+          {
+            "name": "takerPubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "takeProfitOrderParams",
+            "type": {
+              "option": {
+                "defined": "SignedMsgTriggerOrderParams"
+              }
+            }
+          },
+          {
+            "name": "stopLossOrderParams",
+            "type": {
+              "option": {
+                "defined": "SignedMsgTriggerOrderParams"
+              }
+            }
+          },
+          {
+            "name": "maxMarginRatio",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "builderIdx",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "builderFeeTenthBps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "isolatedPositionDeposit",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgTriggerOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "triggerPrice",
+            "type": "u64"
+          },
+          {
+            "name": "baseAssetAmount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "direction",
+            "type": {
+              "option": {
+                "defined": "PositionDirection"
+              }
+            }
+          },
+          {
+            "name": "baseAssetAmount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "price",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "reduceOnly",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "postOnly",
+            "type": {
+              "option": {
+                "defined": "PostOnlyParam"
+              }
+            }
+          },
+          {
+            "name": "bitFlags",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "maxTs",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "triggerPrice",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "triggerCondition",
+            "type": {
+              "option": {
+                "defined": "OrderTriggerCondition"
+              }
+            }
+          },
+          {
+            "name": "oraclePriceOffset",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "auctionDuration",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "auctionStartPrice",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "auctionEndPrice",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "policy",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceClaim",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "revenueWithdrawSinceLastSettle",
+            "docs": [
+              "The amount of revenue last settled",
+              "Positive if funds left the perp market,",
+              "negative if funds were pulled into the perp market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "maxRevenueWithdrawPerPeriod",
+            "docs": [
+              "The max amount of revenue that can be withdrawn per period",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quoteMaxInsurance",
+            "docs": [
+              "The max amount of insurance that perp market can use to resolve bankruptcy and pnl deficits",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quoteSettledInsurance",
+            "docs": [
+              "The amount of insurance that has been used to resolve bankruptcy and pnl deficits",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastRevenueWithdrawTs",
+            "docs": [
+              "The last time revenue was settled in/out of market"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolBalance",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaledBalance",
+            "docs": [
+              "To get the pool's token amount, you must multiply the scaled balance by the market's cumulative",
+              "deposit interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketIndex",
+            "docs": [
+              "The spot market the pool is for"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AMM",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "docs": [
+              "oracle price data public key"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "historicalOracleData",
+            "docs": [
+              "stores historically witnessed oracle data"
+            ],
+            "type": {
+              "defined": "HistoricalOracleData"
+            }
+          },
+          {
+            "name": "baseAssetAmountPerLp",
+            "docs": [
+              "accumulated base asset amount since inception per lp share",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quoteAssetAmountPerLp",
+            "docs": [
+              "accumulated quote asset amount since inception per lp share",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "feePool",
+            "docs": [
+              "partition of fees from perp market trading moved from pnl settlements"
+            ],
+            "type": {
+              "defined": "PoolBalance"
+            }
+          },
+          {
+            "name": "baseAssetReserve",
+            "docs": [
+              "`x` reserves for constant product mm formula (x * y = k)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "quoteAssetReserve",
+            "docs": [
+              "`y` reserves for constant product mm formula (x * y = k)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "concentrationCoef",
+            "docs": [
+              "determines how close the min/max base asset reserve sit vs base reserves",
+              "allow for decreasing slippage without increasing liquidity and v.v.",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "minBaseAssetReserve",
+            "docs": [
+              "minimum base_asset_reserve allowed before AMM is unavailable",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "maxBaseAssetReserve",
+            "docs": [
+              "maximum base_asset_reserve allowed before AMM is unavailable",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrtK",
+            "docs": [
+              "`sqrt(k)` in constant product mm formula (x * y = k). stored to avoid drift caused by integer math issues",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pegMultiplier",
+            "docs": [
+              "normalizing numerical factor for y, its use offers lowest slippage in cp-curve when market is balanced",
+              "precision: PEG_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "terminalQuoteAssetReserve",
+            "docs": [
+              "y when market is balanced. stored to save computation",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "baseAssetAmountLong",
+            "docs": [
+              "always non-negative. tracks number of total longs in market (regardless of counterparty)",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "baseAssetAmountShort",
+            "docs": [
+              "always non-positive. tracks number of total shorts in market (regardless of counterparty)",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "baseAssetAmountWithAmm",
+            "docs": [
+              "tracks net position (longs-shorts) in market with AMM as counterparty",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "baseAssetAmountWithUnsettledLp",
+            "docs": [
+              "tracks net position (longs-shorts) in market with LPs as counterparty",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "maxOpenInterest",
+            "docs": [
+              "max allowed open interest, blocks trades that breach this value",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "quoteAssetAmount",
+            "docs": [
+              "sum of all user's perp quote_asset_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quoteEntryAmountLong",
+            "docs": [
+              "sum of all long user's quote_entry_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quoteEntryAmountShort",
+            "docs": [
+              "sum of all short user's quote_entry_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quoteBreakEvenAmountLong",
+            "docs": [
+              "sum of all long user's quote_break_even_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quoteBreakEvenAmountShort",
+            "docs": [
+              "sum of all short user's quote_break_even_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "userLpShares",
+            "docs": [
+              "total user lp shares of sqrt_k (protocol owned liquidity = sqrt_k - last_funding_rate)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "lastFundingRate",
+            "docs": [
+              "last funding rate in this perp market (unit is quote per base)",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastFundingRateLong",
+            "docs": [
+              "last funding rate for longs in this perp market (unit is quote per base)",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastFundingRateShort",
+            "docs": [
+              "last funding rate for shorts in this perp market (unit is quote per base)",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last24hAvgFundingRate",
+            "docs": [
+              "estimate of last 24h of funding rate perp market (unit is quote per base)",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "totalFee",
+            "docs": [
+              "total fees collected by this perp market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "totalMmFee",
+            "docs": [
+              "total fees collected by the vAMM's bid/ask spread",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "totalExchangeFee",
+            "docs": [
+              "total fees collected by exchange fee schedule",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalFeeMinusDistributions",
+            "docs": [
+              "total fees minus any recognized upnl and pool withdraws",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "totalFeeWithdrawn",
+            "docs": [
+              "sum of all fees from fee pool withdrawn to revenue pool",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalLiquidationFee",
+            "docs": [
+              "all fees collected by market for liquidations",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeFundingRateLong",
+            "docs": [
+              "accumulated funding rate for longs since inception in market"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "cumulativeFundingRateShort",
+            "docs": [
+              "accumulated funding rate for shorts since inception in market"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "totalSocialLoss",
+            "docs": [
+              "accumulated social loss paid by users since inception in market"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "askBaseAssetReserve",
+            "docs": [
+              "transformed base_asset_reserve for users going long",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "askQuoteAssetReserve",
+            "docs": [
+              "transformed quote_asset_reserve for users going long",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bidBaseAssetReserve",
+            "docs": [
+              "transformed base_asset_reserve for users going short",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bidQuoteAssetReserve",
+            "docs": [
+              "transformed quote_asset_reserve for users going short",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "lastOracleNormalisedPrice",
+            "docs": [
+              "the last seen oracle price partially shrunk toward the amm reserve price",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastOracleReservePriceSpreadPct",
+            "docs": [
+              "the gap between the oracle price and the reserve price = y * peg_multiplier / x"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastBidPriceTwap",
+            "docs": [
+              "average estimate of bid price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastAskPriceTwap",
+            "docs": [
+              "average estimate of ask price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastMarkPriceTwap",
+            "docs": [
+              "average estimate of (bid+ask)/2 price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastMarkPriceTwap5min",
+            "docs": [
+              "average estimate of (bid+ask)/2 price over FIVE_MINUTES"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdateSlot",
+            "docs": [
+              "the last blockchain slot the amm was updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastOracleConfPct",
+            "docs": [
+              "the pct size of the oracle confidence interval",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "netRevenueSinceLastFunding",
+            "docs": [
+              "the total_fee_minus_distribution change since the last funding update",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lastFundingRateTs",
+            "docs": [
+              "the last funding rate update unix_timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "fundingPeriod",
+            "docs": [
+              "the peridocity of the funding rate updates"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "orderStepSize",
+            "docs": [
+              "the base step size (increment) of orders",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orderTickSize",
+            "docs": [
+              "the price tick size of orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minOrderSize",
+            "docs": [
+              "the minimum base size of an order",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mmOracleSlot",
+            "docs": [
+              "the max base size a single user can have",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "volume24h",
+            "docs": [
+              "estimated total of volume in market",
+              "QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "longIntensityVolume",
+            "docs": [
+              "the volume intensity of long fills against AMM"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "shortIntensityVolume",
+            "docs": [
+              "the volume intensity of short fills against AMM"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastTradeTs",
+            "docs": [
+              "the blockchain unix timestamp at the time of the last trade"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "markStd",
+            "docs": [
+              "estimate of standard deviation of the fill (mark) prices",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "oracleStd",
+            "docs": [
+              "estimate of standard deviation of the oracle price at each update",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastMarkPriceTwapTs",
+            "docs": [
+              "the last unix_timestamp the mark twap was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "baseSpread",
+            "docs": [
+              "the minimum spread the AMM can quote. also used as step size for some spread logic increases."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maxSpread",
+            "docs": [
+              "the maximum spread the AMM can quote"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "longSpread",
+            "docs": [
+              "the spread for asks vs the reserve price"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "shortSpread",
+            "docs": [
+              "the spread for bids vs the reserve price"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "mmOraclePrice",
+            "docs": [
+              "MM oracle price"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "maxFillReserveFraction",
+            "docs": [
+              "the fraction of total available liquidity a single fill on the AMM can consume"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "maxSlippageRatio",
+            "docs": [
+              "the maximum slippage a single fill on the AMM can push"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "curveUpdateIntensity",
+            "docs": [
+              "the update intensity of AMM formulaic updates (adjusting k). 0-100"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "ammJitIntensity",
+            "docs": [
+              "the jit intensity of AMM. larger intensity means larger participation in jit. 0 means no jit participation.",
+              "(0, 100] is intensity for protocol-owned AMM. (100, 200] is intensity for user LP-owned AMM."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "oracleSource",
+            "docs": [
+              "the oracle provider information. used to decode/scale the oracle public key"
+            ],
+            "type": {
+              "defined": "OracleSource"
+            }
+          },
+          {
+            "name": "lastOracleValid",
+            "docs": [
+              "tracks whether the oracle was considered valid at the last AMM update"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "targetBaseAssetAmountPerLp",
+            "docs": [
+              "the target value for `base_asset_amount_per_lp`, used during AMM JIT with LP split",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "perLpBase",
+            "docs": [
+              "expo for unit of per_lp, base 10 (if per_lp_base=X, then per_lp unit is 10^X)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "oracleLowRiskSlotDelayOverride",
+            "docs": [
+              "the override for the state.min_perp_auction_duration",
+              "0 is no override, -1 is disable speed bump, 1-100 is literal speed bump"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "ammSpreadAdjustment",
+            "docs": [
+              "signed scale amm_spread similar to fee_adjustment logic (-100 = 0, 100 = double)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "oracleSlotDelayOverride",
+            "type": "i8"
+          },
+          {
+            "name": "mmOracleSequenceId",
+            "type": "u64"
+          },
+          {
+            "name": "netUnsettledFundingPnl",
+            "type": "i64"
+          },
+          {
+            "name": "quoteAssetAmountWithUnsettledLp",
+            "type": "i64"
+          },
+          {
+            "name": "referencePriceOffset",
+            "type": "i32"
+          },
+          {
+            "name": "ammInventorySpreadAdjustment",
+            "docs": [
+              "signed scale amm_spread similar to fee_adjustment logic (-100 = 0, 100 = double)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "referencePriceOffsetDeadbandPct",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "lastFundingOracleTwap",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareOrder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feesAccrued",
+            "docs": [
+              "fees accrued so far for this order slot. This is not exclusively fees from this order_id",
+              "and may include fees from other orders in the same market. This may be swept to the",
+              "builder's SpotPosition during settle_pnl."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orderId",
+            "docs": [
+              "the order_id of the current active order in this slot. It's only relevant while bit_flag = Open"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "feeTenthBps",
+            "docs": [
+              "the builder fee on this order, in tenths of a bps, e.g. 100 = 0.01%"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "subAccountId",
+            "docs": [
+              "the subaccount_id of the user who created this order. It's only relevant while bit_flag = Open"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "builderIdx",
+            "docs": [
+              "the index of the RevenueShareEscrow.approved_builders list, that this order's fee will settle to. Ignored",
+              "if bit_flag = Referral."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "bitFlags",
+            "docs": [
+              "bitflags that describe the state of the order.",
+              "[`RevenueShareOrderBitFlag::Init`]: this order slot is available for use.",
+              "[`RevenueShareOrderBitFlag::Open`]: this order slot is occupied, `order_id` is the `sub_account_id`'s active order.",
+              "[`RevenueShareOrderBitFlag::Completed`]: this order has been filled or canceled, and is waiting to be settled into.",
+              "the builder's account order_id and sub_account_id are no longer relevant, it may be merged with other orders.",
+              "[`RevenueShareOrderBitFlag::Referral`]: this order stores referral rewards waiting to be settled for this market.",
+              "If it is set, no other bitflag should be set."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "userOrderIndex",
+            "docs": [
+              "the index into the User's orders list when this RevenueShareOrder was created, make sure to verify that order_id matches."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "marketType",
+            "type": {
+              "defined": "MarketType"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                10
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "maxFeeTenthBps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareEscrowFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "referrer",
+            "type": "publicKey"
+          },
+          {
+            "name": "referrerBoostExpireTs",
+            "type": "u32"
+          },
+          {
+            "name": "referrerRewardOffset",
+            "type": "i8"
+          },
+          {
+            "name": "refereeFeeNumeratorOffset",
+            "type": "i8"
+          },
+          {
+            "name": "referrerBoostNumerator",
+            "type": "i8"
+          },
+          {
+            "name": "reservedFixed",
+            "type": {
+              "array": [
+                "u8",
+                17
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ScaleOrderParams",
+      "docs": [
+        "Parameters for placing scale orders - multiple limit orders distributed across a price range"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marketType",
+            "type": {
+              "defined": "MarketType"
+            }
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": "PositionDirection"
+            }
+          },
+          {
+            "name": "marketIndex",
+            "type": "u16"
+          },
+          {
+            "name": "totalBaseAssetAmount",
+            "docs": [
+              "Total base asset amount to distribute across all orders"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "startPrice",
+            "docs": [
+              "Starting price for the scale (in PRICE_PRECISION)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "endPrice",
+            "docs": [
+              "Ending price for the scale (in PRICE_PRECISION)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orderCount",
+            "docs": [
+              "Number of orders to place (min 2, max 32)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "sizeDistribution",
+            "docs": [
+              "How to distribute sizes across orders"
+            ],
+            "type": {
+              "defined": "SizeDistribution"
+            }
+          },
+          {
+            "name": "reduceOnly",
+            "docs": [
+              "Whether orders should be reduce-only"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "postOnly",
+            "docs": [
+              "Post-only setting for all orders"
+            ],
+            "type": {
+              "defined": "PostOnlyParam"
+            }
+          },
+          {
+            "name": "bitFlags",
+            "docs": [
+              "Bit flags (e.g., for high leverage mode)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "maxTs",
+            "docs": [
+              "Maximum timestamp for orders to be valid"
+            ],
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderId",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "maxSlot",
+            "type": "u64"
+          },
+          {
+            "name": "orderId",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgUserOrdersFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "userPubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFund",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalShares",
+            "type": "u128"
+          },
+          {
+            "name": "userShares",
+            "type": "u128"
+          },
+          {
+            "name": "sharesBase",
+            "type": "u128"
+          },
+          {
+            "name": "unstakingPeriod",
+            "type": "i64"
+          },
+          {
+            "name": "lastRevenueSettleTs",
+            "type": "i64"
+          },
+          {
+            "name": "revenueSettlePeriod",
+            "type": "i64"
+          },
+          {
+            "name": "totalFactor",
+            "type": "u32"
+          },
+          {
+            "name": "userFactor",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceDivergence",
+            "type": {
+              "defined": "PriceDivergenceGuardRails"
+            }
+          },
+          {
+            "name": "validity",
+            "type": {
+              "defined": "ValidityGuardRails"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceDivergenceGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "markOraclePercentDivergence",
+            "type": "u64"
+          },
+          {
+            "name": "oracleTwap5minPercentDivergence",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ValidityGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slotsBeforeStaleForAmm",
+            "type": "i64"
+          },
+          {
+            "name": "slotsBeforeStaleForMargin",
+            "type": "i64"
+          },
+          {
+            "name": "confidenceIntervalMaxSize",
+            "type": "u64"
+          },
+          {
+            "name": "tooVolatileRatio",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeStructure",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feeTiers",
+            "type": {
+              "array": [
+                {
+                  "defined": "FeeTier"
+                },
+                10
+              ]
+            }
+          },
+          {
+            "name": "fillerRewardStructure",
+            "type": {
+              "defined": "OrderFillerRewardStructure"
+            }
+          },
+          {
+            "name": "referrerRewardEpochUpperBound",
+            "type": "u64"
+          },
+          {
+            "name": "flatFillerFee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeTier",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "feeNumerator",
+            "type": "u32"
+          },
+          {
+            "name": "feeDenominator",
+            "type": "u32"
+          },
+          {
+            "name": "makerRebateNumerator",
+            "type": "u32"
+          },
+          {
+            "name": "makerRebateDenominator",
+            "type": "u32"
+          },
+          {
+            "name": "referrerRewardNumerator",
+            "type": "u32"
+          },
+          {
+            "name": "referrerRewardDenominator",
+            "type": "u32"
+          },
+          {
+            "name": "refereeFeeNumerator",
+            "type": "u32"
+          },
+          {
+            "name": "refereeFeeDenominator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderFillerRewardStructure",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "rewardNumerator",
+            "type": "u32"
+          },
+          {
+            "name": "rewardDenominator",
+            "type": "u32"
+          },
+          {
+            "name": "timeBasedRewardLowerBound",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "totalFeePaid",
+            "docs": [
+              "Total taker fee paid",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalFeeRebate",
+            "docs": [
+              "Total maker fee rebate",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalTokenDiscount",
+            "docs": [
+              "Total discount from holding token",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalRefereeDiscount",
+            "docs": [
+              "Total discount from being referred",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalReferrerReward",
+            "docs": [
+              "Total reward to referrer",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "currentEpochReferrerReward",
+            "docs": [
+              "Total reward to referrer this epoch",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaledBalance",
+            "docs": [
+              "The scaled balance of the position. To get the token amount, multiply by the cumulative deposit/borrow",
+              "interest of corresponding market.",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "openBids",
+            "docs": [
+              "How many spot non reduce only trigger orders the user has open",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "openAsks",
+            "docs": [
+              "How many spot non reduce only trigger orders the user has open",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulativeDeposits",
+            "docs": [
+              "The cumulative deposits/borrows a user has made into a market",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "marketIndex",
+            "docs": [
+              "The market index of the corresponding spot market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "balanceType",
+            "docs": [
+              "Whether the position is deposit or borrow"
+            ],
+            "type": {
+              "defined": "SpotBalanceType"
+            }
+          },
+          {
+            "name": "openOrders",
+            "docs": [
+              "Number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lastCumulativeFundingRate",
+            "docs": [
+              "The perp market's last cumulative funding rate. Used to calculate the funding payment owed to user",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "baseAssetAmount",
+            "docs": [
+              "the size of the users perp position",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quoteAssetAmount",
+            "docs": [
+              "Used to calculate the users pnl. Upon entry, is equal to base_asset_amount * avg entry price - fees",
+              "Updated when the user open/closes position or settles pnl. Includes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quoteBreakEvenAmount",
+            "docs": [
+              "The amount of quote the user would need to exit their position at to break even",
+              "Updated when the user open/closes position or settles pnl. Includes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quoteEntryAmount",
+            "docs": [
+              "The amount quote the user entered the position with. Equal to base asset amount * avg entry price",
+              "Updated when the user open/closes position. Excludes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "openBids",
+            "docs": [
+              "The amount of non reduce only trigger orders the user has open",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "openAsks",
+            "docs": [
+              "The amount of non reduce only trigger orders the user has open",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "settledPnl",
+            "docs": [
+              "The amount of pnl settled in this market since opening the position",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lpShares",
+            "docs": [
+              "The number of lp (liquidity provider) shares the user has in this perp market",
+              "LP shares allow users to provide liquidity via the AMM",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "isolatedPositionScaledBalance",
+            "docs": [
+              "The scaled balance of the isolated position",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastQuoteAssetAmountPerLp",
+            "docs": [
+              "The last quote asset amount per lp the amm had",
+              "Used to settle the users lp position",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "maxMarginRatio",
+            "type": "u16"
+          },
+          {
+            "name": "marketIndex",
+            "docs": [
+              "The market index for the perp market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "openOrders",
+            "docs": [
+              "The number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "positionFlag",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Order",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slot",
+            "docs": [
+              "The slot the order was placed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "docs": [
+              "The limit price for the order (can be 0 for market orders)",
+              "For orders with an auction, this price isn't used until the auction is complete",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "baseAssetAmount",
+            "docs": [
+              "The size of the order",
+              "precision for perps: BASE_PRECISION",
+              "precision for spot: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "baseAssetAmountFilled",
+            "docs": [
+              "The amount of the order filled",
+              "precision for perps: BASE_PRECISION",
+              "precision for spot: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quoteAssetAmountFilled",
+            "docs": [
+              "The amount of quote filled for the order",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "triggerPrice",
+            "docs": [
+              "At what price the order will be triggered. Only relevant for trigger orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auctionStartPrice",
+            "docs": [
+              "The start price for the auction. Only relevant for market/oracle orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "auctionEndPrice",
+            "docs": [
+              "The end price for the auction. Only relevant for market/oracle orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "maxTs",
+            "docs": [
+              "The time when the order will expire"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "oraclePriceOffset",
+            "docs": [
+              "If set, the order limit price is the oracle price + this offset",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "orderId",
+            "docs": [
+              "The id for the order. Each users has their own order id space"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "marketIndex",
+            "docs": [
+              "The perp/spot market index"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether the order is open or unused"
+            ],
+            "type": {
+              "defined": "OrderStatus"
+            }
+          },
+          {
+            "name": "orderType",
+            "docs": [
+              "The type of order"
+            ],
+            "type": {
+              "defined": "OrderType"
+            }
+          },
+          {
+            "name": "marketType",
+            "docs": [
+              "Whether market is spot or perp"
+            ],
+            "type": {
+              "defined": "MarketType"
+            }
+          },
+          {
+            "name": "userOrderId",
+            "docs": [
+              "User generated order id. Can make it easier to place/cancel orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "existingPositionDirection",
+            "docs": [
+              "What the users position was when the order was placed"
+            ],
+            "type": {
+              "defined": "PositionDirection"
+            }
+          },
+          {
+            "name": "direction",
+            "docs": [
+              "Whether the user is going long or short. LONG = bid, SHORT = ask"
+            ],
+            "type": {
+              "defined": "PositionDirection"
+            }
+          },
+          {
+            "name": "reduceOnly",
+            "docs": [
+              "Whether the order is allowed to only reduce position size"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "postOnly",
+            "docs": [
+              "Whether the order must be a maker"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "immediateOrCancel",
+            "docs": [
+              "Whether the order must be canceled the same slot it is placed"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "triggerCondition",
+            "docs": [
+              "Whether the order is triggered above or below the trigger price. Only relevant for trigger orders"
+            ],
+            "type": {
+              "defined": "OrderTriggerCondition"
+            }
+          },
+          {
+            "name": "auctionDuration",
+            "docs": [
+              "How many slots the auction lasts"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "postedSlotTail",
+            "docs": [
+              "Last 8 bits of the slot the order was posted on-chain (not order slot for signed msg orders)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "bitFlags",
+            "docs": [
+              "Bitflags for further classification",
+              "0: is_signed_message"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Add"
+          },
+          {
+            "name": "Remove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderId",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UserOrderId",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "OrderId",
+            "fields": [
+              "u32"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Long"
+          },
+          {
+            "name": "Short"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SerumV3"
+          },
+          {
+            "name": "Match"
+          },
+          {
+            "name": "PhoenixV1"
+          },
+          {
+            "name": "OpenbookV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapReduceOnly",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "In"
+          },
+          {
+            "name": "Out"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TwapPeriod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FundingPeriod"
+          },
+          {
+            "name": "FiveMin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationMultiplierType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Discount"
+          },
+          {
+            "name": "Premium"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlementDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ToLpPool"
+          },
+          {
+            "name": "FromLpPool"
+          },
+          {
+            "name": "None"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginRequirementType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Initial"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Maintenance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleValidity",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NonPositive"
+          },
+          {
+            "name": "TooVolatile"
+          },
+          {
+            "name": "TooUncertain"
+          },
+          {
+            "name": "StaleForMargin"
+          },
+          {
+            "name": "InsufficientDataPoints"
+          },
+          {
+            "name": "StaleForAMM",
+            "fields": [
+              {
+                "name": "immediate",
+                "type": "bool"
+              },
+              {
+                "name": "lowRisk",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Valid"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DriftAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateFunding"
+          },
+          {
+            "name": "SettlePnl"
+          },
+          {
+            "name": "TriggerOrder"
+          },
+          {
+            "name": "FillOrderMatch"
+          },
+          {
+            "name": "FillOrderAmmLowRisk"
+          },
+          {
+            "name": "FillOrderAmmImmediate"
+          },
+          {
+            "name": "Liquidate"
+          },
+          {
+            "name": "MarginCalc"
+          },
+          {
+            "name": "UpdateTwap"
+          },
+          {
+            "name": "UpdateAMMCurve"
+          },
+          {
+            "name": "OracleOrderPrice"
+          },
+          {
+            "name": "UseMMOraclePrice"
+          },
+          {
+            "name": "UpdateAmmCache"
+          },
+          {
+            "name": "UpdateLpPoolAum"
+          },
+          {
+            "name": "LpPoolSwap"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LogMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "ExchangeOracle"
+          },
+          {
+            "name": "MMOracle"
+          },
+          {
+            "name": "SafeMMOracle"
+          },
+          {
+            "name": "Margin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionUpdateType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Increase"
+          },
+          {
+            "name": "Reduce"
+          },
+          {
+            "name": "Close"
+          },
+          {
+            "name": "Flip"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Transfer"
+          },
+          {
+            "name": "Borrow"
+          },
+          {
+            "name": "RepayBorrow"
+          },
+          {
+            "name": "Reward"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Place"
+          },
+          {
+            "name": "Cancel"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Trigger"
+          },
+          {
+            "name": "Expire"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderActionExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "InsufficientFreeCollateral"
+          },
+          {
+            "name": "OraclePriceBreachedLimitPrice"
+          },
+          {
+            "name": "MarketOrderFilledToLimitPrice"
+          },
+          {
+            "name": "OrderExpired"
+          },
+          {
+            "name": "Liquidation"
+          },
+          {
+            "name": "OrderFilledWithAMM"
+          },
+          {
+            "name": "OrderFilledWithAMMJit"
+          },
+          {
+            "name": "OrderFilledWithMatch"
+          },
+          {
+            "name": "OrderFilledWithMatchJit"
+          },
+          {
+            "name": "MarketExpired"
+          },
+          {
+            "name": "RiskingIncreasingOrder"
+          },
+          {
+            "name": "ReduceOnlyOrderIncreasedPosition"
+          },
+          {
+            "name": "OrderFillWithSerum"
+          },
+          {
+            "name": "NoBorrowLiquidity"
+          },
+          {
+            "name": "OrderFillWithPhoenix"
+          },
+          {
+            "name": "OrderFilledWithAMMJitLPSplit"
+          },
+          {
+            "name": "OrderFilledWithLPJit"
+          },
+          {
+            "name": "DeriskLp"
+          },
+          {
+            "name": "OrderFilledWithOpenbookV2"
+          },
+          {
+            "name": "TransferPerpPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LPAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AddLiquidity"
+          },
+          {
+            "name": "RemoveLiquidity"
+          },
+          {
+            "name": "SettleLiquidity"
+          },
+          {
+            "name": "RemoveLiquidityDerisk"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "LiquidatePerp"
+          },
+          {
+            "name": "LiquidateSpot"
+          },
+          {
+            "name": "LiquidateBorrowForPerpPnl"
+          },
+          {
+            "name": "LiquidatePerpPnlForDeposit"
+          },
+          {
+            "name": "PerpBankruptcy"
+          },
+          {
+            "name": "SpotBankruptcy"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "IsolatedPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlePnlExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "ExpiredPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakeAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Stake"
+          },
+          {
+            "name": "UnstakeRequest"
+          },
+          {
+            "name": "UnstakeCancelRequest"
+          },
+          {
+            "name": "Unstake"
+          },
+          {
+            "name": "UnstakeTransfer"
+          },
+          {
+            "name": "StakeTransfer"
+          },
+          {
+            "name": "AdminDeposit"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FillMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "PlaceAndMake"
+          },
+          {
+            "name": "PlaceAndTake",
+            "fields": [
+              "bool",
+              "u8"
+            ]
+          },
+          {
+            "name": "Liquidation"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpFulfillmentMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AMM",
+            "fields": [
+              {
+                "option": "u64"
+              }
+            ]
+          },
+          {
+            "name": "Match",
+            "fields": [
+              "publicKey",
+              "u16",
+              "u64"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ExternalMarket"
+          },
+          {
+            "name": "Match",
+            "fields": [
+              "publicKey",
+              "u16"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "Decommissioned"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginCalculationMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Standard"
+          },
+          {
+            "name": "Liquidation",
+            "fields": [
+              {
+                "name": "marketToTrackMarginRequirement",
+                "type": {
+                  "option": {
+                    "defined": "MarketIdentifier"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginTypeConfig",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Default",
+            "fields": [
+              {
+                "defined": "MarginRequirementType"
+              }
+            ]
+          },
+          {
+            "name": "IsolatedPositionOverride",
+            "fields": [
+              {
+                "name": "marketIndex",
+                "type": "u16"
+              },
+              {
+                "name": "marginRequirementType",
+                "type": {
+                  "defined": "MarginRequirementType"
+                }
+              },
+              {
+                "name": "defaultIsolatedMarginRequirementType",
+                "type": {
+                  "defined": "MarginRequirementType"
+                }
+              },
+              {
+                "name": "crossMarginRequirementType",
+                "type": {
+                  "defined": "MarginRequirementType"
+                }
+              }
+            ]
+          },
+          {
+            "name": "CrossMarginOverride",
+            "fields": [
+              {
+                "name": "marginRequirementType",
+                "type": {
+                  "defined": "MarginRequirementType"
+                }
+              },
+              {
+                "name": "defaultMarginRequirementType",
+                "type": {
+                  "defined": "MarginRequirementType"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleSource",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pyth"
+          },
+          {
+            "name": "Switchboard"
+          },
+          {
+            "name": "QuoteAsset"
+          },
+          {
+            "name": "Pyth1K"
+          },
+          {
+            "name": "Pyth1M"
+          },
+          {
+            "name": "PythStableCoin"
+          },
+          {
+            "name": "Prelaunch"
+          },
+          {
+            "name": "PythPull"
+          },
+          {
+            "name": "Pyth1KPull"
+          },
+          {
+            "name": "Pyth1MPull"
+          },
+          {
+            "name": "PythStableCoinPull"
+          },
+          {
+            "name": "SwitchboardOnDemand"
+          },
+          {
+            "name": "PythLazer"
+          },
+          {
+            "name": "PythLazer1K"
+          },
+          {
+            "name": "PythLazer1M"
+          },
+          {
+            "name": "PythLazerStableCoin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderParamsBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ImmediateOrCancel"
+          },
+          {
+            "name": "UpdateHighLeverageMode"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PostOnlyParam",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "MustPostOnly"
+          },
+          {
+            "name": "TryPostOnly"
+          },
+          {
+            "name": "Slide"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderPolicy",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MustModify"
+          },
+          {
+            "name": "ExcludePreviousFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceAndTakeOrderSuccessCondition",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PartialFill"
+          },
+          {
+            "name": "FullFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateFunding"
+          },
+          {
+            "name": "AmmFill"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "SettlePnl"
+          },
+          {
+            "name": "SettlePnlWithPosition"
+          },
+          {
+            "name": "Liquidation"
+          },
+          {
+            "name": "AmmImmediateFill"
+          },
+          {
+            "name": "SettleRevPool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateCumulativeInterest"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          },
+          {
+            "name": "Liquidation"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFundOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Add"
+          },
+          {
+            "name": "RequestRemove"
+          },
+          {
+            "name": "Remove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpLpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TrackAmmRevenue"
+          },
+          {
+            "name": "SettleQuoteOwed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentLpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Swap"
+          },
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Initialized"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "FundingPaused"
+          },
+          {
+            "name": "AmmPaused"
+          },
+          {
+            "name": "FillPaused"
+          },
+          {
+            "name": "WithdrawPaused"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "Settlement"
+          },
+          {
+            "name": "Delisted"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uncollateralized"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Decommissioning"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ContractType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Perpetual"
+          },
+          {
+            "name": "Future"
+          },
+          {
+            "name": "Prediction"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ContractTier",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "A"
+          },
+          {
+            "name": "B"
+          },
+          {
+            "name": "C"
+          },
+          {
+            "name": "Speculative"
+          },
+          {
+            "name": "HighlySpeculative"
+          },
+          {
+            "name": "Isolated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketConfigFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "DisableFormulaicKUpdate"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareOrderBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Completed"
+          },
+          {
+            "name": "Referral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SizeDistribution",
+      "docs": [
+        "How to distribute order sizes across scale orders"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Flat"
+          },
+          {
+            "name": "Ascending"
+          },
+          {
+            "name": "Descending"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlePnlMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MustSettle"
+          },
+          {
+            "name": "TrySettle"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotBalanceType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Borrow"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentConfigStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enabled"
+          },
+          {
+            "name": "Disabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetTier",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Protected"
+          },
+          {
+            "name": "Cross"
+          },
+          {
+            "name": "Isolated"
+          },
+          {
+            "name": "Unlisted"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProgramFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Token2022"
+          },
+          {
+            "name": "TransferHook"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExchangeStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "DepositPaused"
+          },
+          {
+            "name": "WithdrawPaused"
+          },
+          {
+            "name": "AmmPaused"
+          },
+          {
+            "name": "FillPaused"
+          },
+          {
+            "name": "LiqPaused"
+          },
+          {
+            "name": "FundingPaused"
+          },
+          {
+            "name": "SettlePnlPaused"
+          },
+          {
+            "name": "AmmImmediateFillPaused"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeatureBitFlags",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MmOracleUpdate"
+          },
+          {
+            "name": "MedianTriggerPrice"
+          },
+          {
+            "name": "BuilderCodes"
+          },
+          {
+            "name": "BuilderReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpPoolFeatureBitFlags",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SettleLpPool"
+          },
+          {
+            "name": "SwapLpPool"
+          },
+          {
+            "name": "MintRedeemLpPool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "BeingLiquidated"
+          },
+          {
+            "name": "Bankrupt"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "AdvancedLp"
+          },
+          {
+            "name": "ProtectedMakerOrders"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Base"
+          },
+          {
+            "name": "Quote"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Filled"
+          },
+          {
+            "name": "Canceled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Market"
+          },
+          {
+            "name": "Limit"
+          },
+          {
+            "name": "TriggerMarket"
+          },
+          {
+            "name": "TriggerLimit"
+          },
+          {
+            "name": "Oracle"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderTriggerCondition",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Above"
+          },
+          {
+            "name": "Below"
+          },
+          {
+            "name": "TriggeredAbove"
+          },
+          {
+            "name": "TriggeredBelow"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Spot"
+          },
+          {
+            "name": "Perp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SignedMessage"
+          },
+          {
+            "name": "OracleTriggerMarket"
+          },
+          {
+            "name": "SafeTriggerOrder"
+          },
+          {
+            "name": "NewTriggerReduceOnly"
+          },
+          {
+            "name": "HasBuilder"
+          },
+          {
+            "name": "IsIsolatedPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "IsolatedPosition"
+          },
+          {
+            "name": "BeingLiquidated"
+          },
+          {
+            "name": "Bankrupt"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "IsReferrer"
+          },
+          {
+            "name": "IsReferred"
+          },
+          {
+            "name": "BuilderReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Default"
+          },
+          {
+            "name": "HighLeverage"
+          },
+          {
+            "name": "HighLeverageMaintenance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FuelOverflowStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Exists"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStatsPausedOperations",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateBidAskTwap"
+          },
+          {
+            "name": "AmmAtomicFill"
+          },
+          {
+            "name": "AmmAtomicRiskIncreasingFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignatureVerificationError",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "InvalidEd25519InstructionProgramId"
+          },
+          {
+            "name": "InvalidEd25519InstructionDataLength"
+          },
+          {
+            "name": "InvalidSignatureIndex"
+          },
+          {
+            "name": "InvalidSignatureOffset"
+          },
+          {
+            "name": "InvalidPublicKeyOffset"
+          },
+          {
+            "name": "InvalidMessageOffset"
+          },
+          {
+            "name": "InvalidMessageDataSize"
+          },
+          {
+            "name": "InvalidInstructionIndex"
+          },
+          {
+            "name": "MessageOffsetOverflow"
+          },
+          {
+            "name": "InvalidMessageHex"
+          },
+          {
+            "name": "InvalidMessageData"
+          },
+          {
+            "name": "LoadInstructionAtFailed"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "NewUserRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userAuthority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "subAccountId",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          },
+          "index": false
+        },
+        {
+          "name": "referrer",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "DepositRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userAuthority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": "DepositDirection"
+          },
+          "index": false
+        },
+        {
+          "name": "depositRecordId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "oraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "marketDepositBalance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "marketWithdrawBalance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "marketCumulativeDepositInterest",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "marketCumulativeBorrowInterest",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "totalDepositsAfter",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "totalWithdrawsAfter",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "explanation",
+          "type": {
+            "defined": "DepositExplanation"
+          },
+          "index": false
+        },
+        {
+          "name": "transferUser",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "signer",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "userTokenAmountAfter",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SpotInterestRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "depositBalance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "cumulativeDepositInterest",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "borrowBalance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "cumulativeBorrowInterest",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "optimalUtilization",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "optimalBorrowRate",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "maxBorrowRate",
+          "type": "u32",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FundingPaymentRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userAuthority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "fundingPayment",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userLastCumulativeFunding",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "ammCumulativeFundingLong",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "ammCumulativeFundingShort",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FundingRateRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "recordId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "fundingRate",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "fundingRateLong",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "fundingRateShort",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "cumulativeFundingRateLong",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "cumulativeFundingRateShort",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oraclePriceTwap",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "markPriceTwap",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "periodRevenue",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountWithAmm",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountWithUnsettledLp",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "CurveRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "recordId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "pegMultiplierBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "baseAssetReserveBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "quoteAssetReserveBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "sqrtKBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "pegMultiplierAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "baseAssetReserveAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "quoteAssetReserveAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "sqrtKAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountLong",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountShort",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountWithAmm",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "totalFee",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "totalFeeMinusDistributions",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "adjustmentCost",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "fillRecord",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "numberOfUsers",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SignedMsgOrderRecord",
+      "fields": [
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "hash",
+          "type": "string",
+          "index": false
+        },
+        {
+          "name": "matchingOrderParams",
+          "type": {
+            "defined": "OrderParams"
+          },
+          "index": false
+        },
+        {
+          "name": "userOrderId",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "signedMsgOrderMaxSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "signedMsgOrderUuid",
+          "type": {
+            "array": [
+              "u8",
+              8
+            ]
+          },
+          "index": false
+        },
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "OrderRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "order",
+          "type": {
+            "defined": "Order"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "OrderActionRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "action",
+          "type": {
+            "defined": "OrderAction"
+          },
+          "index": false
+        },
+        {
+          "name": "actionExplanation",
+          "type": {
+            "defined": "OrderActionExplanation"
+          },
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "marketType",
+          "type": {
+            "defined": "MarketType"
+          },
+          "index": false
+        },
+        {
+          "name": "filler",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "fillerReward",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "fillRecordId",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "baseAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "quoteAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "takerFee",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "makerFee",
+          "type": {
+            "option": "i64"
+          },
+          "index": false
+        },
+        {
+          "name": "referrerReward",
+          "type": {
+            "option": "u32"
+          },
+          "index": false
+        },
+        {
+          "name": "quoteAssetAmountSurplus",
+          "type": {
+            "option": "i64"
+          },
+          "index": false
+        },
+        {
+          "name": "spotFulfillmentMethodFee",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "taker",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "takerOrderId",
+          "type": {
+            "option": "u32"
+          },
+          "index": false
+        },
+        {
+          "name": "takerOrderDirection",
+          "type": {
+            "option": {
+              "defined": "PositionDirection"
+            }
+          },
+          "index": false
+        },
+        {
+          "name": "takerOrderBaseAssetAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "takerOrderCumulativeBaseAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "takerOrderCumulativeQuoteAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "maker",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "makerOrderId",
+          "type": {
+            "option": "u32"
+          },
+          "index": false
+        },
+        {
+          "name": "makerOrderDirection",
+          "type": {
+            "option": {
+              "defined": "PositionDirection"
+            }
+          },
+          "index": false
+        },
+        {
+          "name": "makerOrderBaseAssetAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "makerOrderCumulativeBaseAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "makerOrderCumulativeQuoteAssetAmountFilled",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "oraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "bitFlags",
+          "type": "u8",
+          "index": false
+        },
+        {
+          "name": "takerExistingQuoteEntryAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "takerExistingBaseAssetAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "makerExistingQuoteEntryAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "makerExistingBaseAssetAmount",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "triggerPrice",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        },
+        {
+          "name": "builderIdx",
+          "type": {
+            "option": "u8"
+          },
+          "index": false
+        },
+        {
+          "name": "builderFee",
+          "type": {
+            "option": "u64"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LPRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "action",
+          "type": {
+            "defined": "LPAction"
+          },
+          "index": false
+        },
+        {
+          "name": "nShares",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "deltaBaseAssetAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "deltaQuoteAssetAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "pnl",
+          "type": "i64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LiquidationRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "liquidationType",
+          "type": {
+            "defined": "LiquidationType"
+          },
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "liquidator",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marginRequirement",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "totalCollateral",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "marginFreed",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "liquidationId",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "bankrupt",
+          "type": "bool",
+          "index": false
+        },
+        {
+          "name": "canceledOrderIds",
+          "type": {
+            "vec": "u32"
+          },
+          "index": false
+        },
+        {
+          "name": "liquidatePerp",
+          "type": {
+            "defined": "LiquidatePerpRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "liquidateSpot",
+          "type": {
+            "defined": "LiquidateSpotRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "liquidateBorrowForPerpPnl",
+          "type": {
+            "defined": "LiquidateBorrowForPerpPnlRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "liquidatePerpPnlForDeposit",
+          "type": {
+            "defined": "LiquidatePerpPnlForDepositRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "perpBankruptcy",
+          "type": {
+            "defined": "PerpBankruptcyRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "spotBankruptcy",
+          "type": {
+            "defined": "SpotBankruptcyRecord"
+          },
+          "index": false
+        },
+        {
+          "name": "bitFlags",
+          "type": "u8",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SettlePnlRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "pnl",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "baseAssetAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "quoteAssetAmountAfter",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "quoteEntryAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "settlePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "explanation",
+          "type": {
+            "defined": "SettlePnlExplanation"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "InsuranceFundRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "spotMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "userIfFactor",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "totalIfFactor",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "vaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "insuranceVaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "totalIfSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "totalIfSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "i64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "InsuranceFundStakeRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userAuthority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "action",
+          "type": {
+            "defined": "StakeAction"
+          },
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "insuranceVaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "ifSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "userIfSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "totalIfSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "ifSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "userIfSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "totalIfSharesAfter",
+          "type": "u128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "InsuranceFundSwapRecord",
+      "fields": [
+        {
+          "name": "rebalanceConfig",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "inIfTotalSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "outIfTotalSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "inIfUserSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "outIfUserSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "inIfTotalSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "outIfTotalSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "inIfUserSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "outIfUserSharesAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outOraclePrice",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outOraclePriceTwap",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inVaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outVaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "inFundVaultAmountAfter",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outFundVaultAmountAfter",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "inMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "TransferProtocolIfSharesToRevenuePoolRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "shares",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "ifVaultAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "protocolSharesBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "transferAmount",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SwapRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "amountOut",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "amountIn",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "inMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "outOraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inOraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "fee",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SpotMarketVaultDepositRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "depositBalance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "cumulativeDepositInterestBefore",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "cumulativeDepositInterestAfter",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "depositTokenAmountBefore",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "DeleteUserRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "userAuthority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "user",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "subAccountId",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "keeper",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FuelSweepRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelInsurance",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelDeposits",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelBorrows",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelPositions",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelTaker",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "userStatsFuelMaker",
+          "type": "u32",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelInsurance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelDeposits",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelBorrows",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelPositions",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelTaker",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelOverflowFuelMaker",
+          "type": "u128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FuelSeasonRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "fuelInsurance",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelDeposits",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelBorrows",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelPositions",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelTaker",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelMaker",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fuelTotal",
+          "type": "u128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "RevenueShareSettleRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "builder",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "referrer",
+          "type": {
+            "option": "publicKey"
+          },
+          "index": false
+        },
+        {
+          "name": "feeSettled",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "marketType",
+          "type": {
+            "defined": "MarketType"
+          },
+          "index": false
+        },
+        {
+          "name": "builderSubAccountId",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "builderTotalReferrerRewards",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "builderTotalBuilderRewards",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LPSettleRecord",
+      "fields": [
+        {
+          "name": "recordId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "lastTs",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lastSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "slot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "perpMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "settleToLpAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "perpAmmPnlDelta",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "perpAmmExFeeDelta",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lpAum",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "lpPrice",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "lpPool",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LPSwapRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "slot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "outAmount",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "inAmount",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "outFee",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "inFee",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "outSpotMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "inSpotMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "outConstituentIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "inConstituentIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "outOraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inOraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lastAum",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "lastAumSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "inMarketCurrentWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "outMarketCurrentWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inMarketTargetWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "outMarketTargetWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inSwapId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "outSwapId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "lpPool",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LPMintRedeemRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "slot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "authority",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "description",
+          "type": "u8",
+          "index": false
+        },
+        {
+          "name": "amount",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "fee",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "spotMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "constituentIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "oraclePrice",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "mint",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "lpAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "lpFee",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lpPrice",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "mintRedeemId",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "lastAum",
+          "type": "u128",
+          "index": false
+        },
+        {
+          "name": "lastAumSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "inMarketCurrentWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "inMarketTargetWeight",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lpPool",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LPBorrowLendDepositRecord",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "slot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "spotMarketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "constituentIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "direction",
+          "type": {
+            "defined": "DepositDirection"
+          },
+          "index": false
+        },
+        {
+          "name": "tokenBalance",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "lastTokenBalance",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "interestAccruedTokenAmount",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "amountDepositWithdraw",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "lpPool",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidSpotMarketAuthority",
+      "msg": "Invalid Spot Market Authority"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidInsuranceFundAuthority",
+      "msg": "Clearing house not insurance fund authority"
+    },
+    {
+      "code": 6002,
+      "name": "InsufficientDeposit",
+      "msg": "Insufficient deposit"
+    },
+    {
+      "code": 6003,
+      "name": "InsufficientCollateral",
+      "msg": "Insufficient collateral"
+    },
+    {
+      "code": 6004,
+      "name": "SufficientCollateral",
+      "msg": "Sufficient collateral"
+    },
+    {
+      "code": 6005,
+      "name": "MaxNumberOfPositions",
+      "msg": "Max number of positions taken"
+    },
+    {
+      "code": 6006,
+      "name": "AdminControlsPricesDisabled",
+      "msg": "Admin Controls Prices Disabled"
+    },
+    {
+      "code": 6007,
+      "name": "MarketDelisted",
+      "msg": "Market Delisted"
+    },
+    {
+      "code": 6008,
+      "name": "MarketIndexAlreadyInitialized",
+      "msg": "Market Index Already Initialized"
+    },
+    {
+      "code": 6009,
+      "name": "UserAccountAndUserPositionsAccountMismatch",
+      "msg": "User Account And User Positions Account Mismatch"
+    },
+    {
+      "code": 6010,
+      "name": "UserHasNoPositionInMarket",
+      "msg": "User Has No Position In Market"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidInitialPeg",
+      "msg": "Invalid Initial Peg"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidRepegRedundant",
+      "msg": "AMM repeg already configured with amt given"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidRepegDirection",
+      "msg": "AMM repeg incorrect repeg direction"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidRepegProfitability",
+      "msg": "AMM repeg out of bounds pnl"
+    },
+    {
+      "code": 6015,
+      "name": "SlippageOutsideLimit",
+      "msg": "Slippage Outside Limit Price"
+    },
+    {
+      "code": 6016,
+      "name": "OrderSizeTooSmall",
+      "msg": "Order Size Too Small"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidUpdateK",
+      "msg": "Price change too large when updating K"
+    },
+    {
+      "code": 6018,
+      "name": "AdminWithdrawTooLarge",
+      "msg": "Admin tried to withdraw amount larger than fees collected"
+    },
+    {
+      "code": 6019,
+      "name": "MathError",
+      "msg": "Math Error"
+    },
+    {
+      "code": 6020,
+      "name": "BnConversionError",
+      "msg": "Conversion to u128/u64 failed with an overflow or underflow"
+    },
+    {
+      "code": 6021,
+      "name": "ClockUnavailable",
+      "msg": "Clock unavailable"
+    },
+    {
+      "code": 6022,
+      "name": "UnableToLoadOracle",
+      "msg": "Unable To Load Oracles"
+    },
+    {
+      "code": 6023,
+      "name": "PriceBandsBreached",
+      "msg": "Price Bands Breached"
+    },
+    {
+      "code": 6024,
+      "name": "ExchangePaused",
+      "msg": "Exchange is paused"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidWhitelistToken",
+      "msg": "Invalid whitelist token"
+    },
+    {
+      "code": 6026,
+      "name": "WhitelistTokenNotFound",
+      "msg": "Whitelist token not found"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidDiscountToken",
+      "msg": "Invalid discount token"
+    },
+    {
+      "code": 6028,
+      "name": "DiscountTokenNotFound",
+      "msg": "Discount token not found"
+    },
+    {
+      "code": 6029,
+      "name": "ReferrerNotFound",
+      "msg": "Referrer not found"
+    },
+    {
+      "code": 6030,
+      "name": "ReferrerStatsNotFound",
+      "msg": "ReferrerNotFound"
+    },
+    {
+      "code": 6031,
+      "name": "ReferrerMustBeWritable",
+      "msg": "ReferrerMustBeWritable"
+    },
+    {
+      "code": 6032,
+      "name": "ReferrerStatsMustBeWritable",
+      "msg": "ReferrerMustBeWritable"
+    },
+    {
+      "code": 6033,
+      "name": "ReferrerAndReferrerStatsAuthorityUnequal",
+      "msg": "ReferrerAndReferrerStatsAuthorityUnequal"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidReferrer",
+      "msg": "InvalidReferrer"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidOracle",
+      "msg": "InvalidOracle"
+    },
+    {
+      "code": 6036,
+      "name": "OracleNotFound",
+      "msg": "OracleNotFound"
+    },
+    {
+      "code": 6037,
+      "name": "LiquidationsBlockedByOracle",
+      "msg": "Liquidations Blocked By Oracle"
+    },
+    {
+      "code": 6038,
+      "name": "MaxDeposit",
+      "msg": "Can not deposit more than max deposit"
+    },
+    {
+      "code": 6039,
+      "name": "CantDeleteUserWithCollateral",
+      "msg": "Can not delete user that still has collateral"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidFundingProfitability",
+      "msg": "AMM funding out of bounds pnl"
+    },
+    {
+      "code": 6041,
+      "name": "CastingFailure",
+      "msg": "Casting Failure"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidOrder",
+      "msg": "InvalidOrder"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidOrderMaxTs",
+      "msg": "InvalidOrderMaxTs"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidOrderMarketType",
+      "msg": "InvalidOrderMarketType"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidOrderForInitialMarginReq",
+      "msg": "InvalidOrderForInitialMarginReq"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidOrderNotRiskReducing",
+      "msg": "InvalidOrderNotRiskReducing"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidOrderSizeTooSmall",
+      "msg": "InvalidOrderSizeTooSmall"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidOrderNotStepSizeMultiple",
+      "msg": "InvalidOrderNotStepSizeMultiple"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidOrderBaseQuoteAsset",
+      "msg": "InvalidOrderBaseQuoteAsset"
+    },
+    {
+      "code": 6050,
+      "name": "InvalidOrderIOC",
+      "msg": "InvalidOrderIOC"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidOrderPostOnly",
+      "msg": "InvalidOrderPostOnly"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidOrderIOCPostOnly",
+      "msg": "InvalidOrderIOCPostOnly"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidOrderTrigger",
+      "msg": "InvalidOrderTrigger"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidOrderAuction",
+      "msg": "InvalidOrderAuction"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidOrderOracleOffset",
+      "msg": "InvalidOrderOracleOffset"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidOrderMinOrderSize",
+      "msg": "InvalidOrderMinOrderSize"
+    },
+    {
+      "code": 6057,
+      "name": "PlacePostOnlyLimitFailure",
+      "msg": "Failed to Place Post-Only Limit Order"
+    },
+    {
+      "code": 6058,
+      "name": "UserHasNoOrder",
+      "msg": "User has no order"
+    },
+    {
+      "code": 6059,
+      "name": "OrderAmountTooSmall",
+      "msg": "Order Amount Too Small"
+    },
+    {
+      "code": 6060,
+      "name": "MaxNumberOfOrders",
+      "msg": "Max number of orders taken"
+    },
+    {
+      "code": 6061,
+      "name": "OrderDoesNotExist",
+      "msg": "Order does not exist"
+    },
+    {
+      "code": 6062,
+      "name": "OrderNotOpen",
+      "msg": "Order not open"
+    },
+    {
+      "code": 6063,
+      "name": "FillOrderDidNotUpdateState",
+      "msg": "FillOrderDidNotUpdateState"
+    },
+    {
+      "code": 6064,
+      "name": "ReduceOnlyOrderIncreasedRisk",
+      "msg": "Reduce only order increased risk"
+    },
+    {
+      "code": 6065,
+      "name": "UnableToLoadAccountLoader",
+      "msg": "Unable to load AccountLoader"
+    },
+    {
+      "code": 6066,
+      "name": "TradeSizeTooLarge",
+      "msg": "Trade Size Too Large"
+    },
+    {
+      "code": 6067,
+      "name": "UserCantReferThemselves",
+      "msg": "User cant refer themselves"
+    },
+    {
+      "code": 6068,
+      "name": "DidNotReceiveExpectedReferrer",
+      "msg": "Did not receive expected referrer"
+    },
+    {
+      "code": 6069,
+      "name": "CouldNotDeserializeReferrer",
+      "msg": "Could not deserialize referrer"
+    },
+    {
+      "code": 6070,
+      "name": "CouldNotDeserializeReferrerStats",
+      "msg": "Could not deserialize referrer stats"
+    },
+    {
+      "code": 6071,
+      "name": "UserOrderIdAlreadyInUse",
+      "msg": "User Order Id Already In Use"
+    },
+    {
+      "code": 6072,
+      "name": "NoPositionsLiquidatable",
+      "msg": "No positions liquidatable"
+    },
+    {
+      "code": 6073,
+      "name": "InvalidMarginRatio",
+      "msg": "Invalid Margin Ratio"
+    },
+    {
+      "code": 6074,
+      "name": "CantCancelPostOnlyOrder",
+      "msg": "Cant Cancel Post Only Order"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidOracleOffset",
+      "msg": "InvalidOracleOffset"
+    },
+    {
+      "code": 6076,
+      "name": "CantExpireOrders",
+      "msg": "CantExpireOrders"
+    },
+    {
+      "code": 6077,
+      "name": "CouldNotLoadMarketData",
+      "msg": "CouldNotLoadMarketData"
+    },
+    {
+      "code": 6078,
+      "name": "PerpMarketNotFound",
+      "msg": "PerpMarketNotFound"
+    },
+    {
+      "code": 6079,
+      "name": "InvalidMarketAccount",
+      "msg": "InvalidMarketAccount"
+    },
+    {
+      "code": 6080,
+      "name": "UnableToLoadPerpMarketAccount",
+      "msg": "UnableToLoadMarketAccount"
+    },
+    {
+      "code": 6081,
+      "name": "MarketWrongMutability",
+      "msg": "MarketWrongMutability"
+    },
+    {
+      "code": 6082,
+      "name": "UnableToCastUnixTime",
+      "msg": "UnableToCastUnixTime"
+    },
+    {
+      "code": 6083,
+      "name": "CouldNotFindSpotPosition",
+      "msg": "CouldNotFindSpotPosition"
+    },
+    {
+      "code": 6084,
+      "name": "NoSpotPositionAvailable",
+      "msg": "NoSpotPositionAvailable"
+    },
+    {
+      "code": 6085,
+      "name": "InvalidSpotMarketInitialization",
+      "msg": "InvalidSpotMarketInitialization"
+    },
+    {
+      "code": 6086,
+      "name": "CouldNotLoadSpotMarketData",
+      "msg": "CouldNotLoadSpotMarketData"
+    },
+    {
+      "code": 6087,
+      "name": "SpotMarketNotFound",
+      "msg": "SpotMarketNotFound"
+    },
+    {
+      "code": 6088,
+      "name": "InvalidSpotMarketAccount",
+      "msg": "InvalidSpotMarketAccount"
+    },
+    {
+      "code": 6089,
+      "name": "UnableToLoadSpotMarketAccount",
+      "msg": "UnableToLoadSpotMarketAccount"
+    },
+    {
+      "code": 6090,
+      "name": "SpotMarketWrongMutability",
+      "msg": "SpotMarketWrongMutability"
+    },
+    {
+      "code": 6091,
+      "name": "SpotMarketInterestNotUpToDate",
+      "msg": "SpotInterestNotUpToDate"
+    },
+    {
+      "code": 6092,
+      "name": "SpotMarketInsufficientDeposits",
+      "msg": "SpotMarketInsufficientDeposits"
+    },
+    {
+      "code": 6093,
+      "name": "UserMustSettleTheirOwnPositiveUnsettledPNL",
+      "msg": "UserMustSettleTheirOwnPositiveUnsettledPNL"
+    },
+    {
+      "code": 6094,
+      "name": "CantUpdateSpotBalanceType",
+      "msg": "CantUpdateSpotBalanceType"
+    },
+    {
+      "code": 6095,
+      "name": "InsufficientCollateralForSettlingPNL",
+      "msg": "InsufficientCollateralForSettlingPNL"
+    },
+    {
+      "code": 6096,
+      "name": "AMMNotUpdatedInSameSlot",
+      "msg": "AMMNotUpdatedInSameSlot"
+    },
+    {
+      "code": 6097,
+      "name": "AuctionNotComplete",
+      "msg": "AuctionNotComplete"
+    },
+    {
+      "code": 6098,
+      "name": "MakerNotFound",
+      "msg": "MakerNotFound"
+    },
+    {
+      "code": 6099,
+      "name": "MakerStatsNotFound",
+      "msg": "MakerNotFound"
+    },
+    {
+      "code": 6100,
+      "name": "MakerMustBeWritable",
+      "msg": "MakerMustBeWritable"
+    },
+    {
+      "code": 6101,
+      "name": "MakerStatsMustBeWritable",
+      "msg": "MakerMustBeWritable"
+    },
+    {
+      "code": 6102,
+      "name": "MakerOrderNotFound",
+      "msg": "MakerOrderNotFound"
+    },
+    {
+      "code": 6103,
+      "name": "CouldNotDeserializeMaker",
+      "msg": "CouldNotDeserializeMaker"
+    },
+    {
+      "code": 6104,
+      "name": "CouldNotDeserializeMakerStats",
+      "msg": "CouldNotDeserializeMaker"
+    },
+    {
+      "code": 6105,
+      "name": "AuctionPriceDoesNotSatisfyMaker",
+      "msg": "AuctionPriceDoesNotSatisfyMaker"
+    },
+    {
+      "code": 6106,
+      "name": "MakerCantFulfillOwnOrder",
+      "msg": "MakerCantFulfillOwnOrder"
+    },
+    {
+      "code": 6107,
+      "name": "MakerOrderMustBePostOnly",
+      "msg": "MakerOrderMustBePostOnly"
+    },
+    {
+      "code": 6108,
+      "name": "CantMatchTwoPostOnlys",
+      "msg": "CantMatchTwoPostOnlys"
+    },
+    {
+      "code": 6109,
+      "name": "OrderBreachesOraclePriceLimits",
+      "msg": "OrderBreachesOraclePriceLimits"
+    },
+    {
+      "code": 6110,
+      "name": "OrderMustBeTriggeredFirst",
+      "msg": "OrderMustBeTriggeredFirst"
+    },
+    {
+      "code": 6111,
+      "name": "OrderNotTriggerable",
+      "msg": "OrderNotTriggerable"
+    },
+    {
+      "code": 6112,
+      "name": "OrderDidNotSatisfyTriggerCondition",
+      "msg": "OrderDidNotSatisfyTriggerCondition"
+    },
+    {
+      "code": 6113,
+      "name": "PositionAlreadyBeingLiquidated",
+      "msg": "PositionAlreadyBeingLiquidated"
+    },
+    {
+      "code": 6114,
+      "name": "PositionDoesntHaveOpenPositionOrOrders",
+      "msg": "PositionDoesntHaveOpenPositionOrOrders"
+    },
+    {
+      "code": 6115,
+      "name": "AllOrdersAreAlreadyLiquidations",
+      "msg": "AllOrdersAreAlreadyLiquidations"
+    },
+    {
+      "code": 6116,
+      "name": "CantCancelLiquidationOrder",
+      "msg": "CantCancelLiquidationOrder"
+    },
+    {
+      "code": 6117,
+      "name": "UserIsBeingLiquidated",
+      "msg": "UserIsBeingLiquidated"
+    },
+    {
+      "code": 6118,
+      "name": "LiquidationsOngoing",
+      "msg": "LiquidationsOngoing"
+    },
+    {
+      "code": 6119,
+      "name": "WrongSpotBalanceType",
+      "msg": "WrongSpotBalanceType"
+    },
+    {
+      "code": 6120,
+      "name": "UserCantLiquidateThemself",
+      "msg": "UserCantLiquidateThemself"
+    },
+    {
+      "code": 6121,
+      "name": "InvalidPerpPositionToLiquidate",
+      "msg": "InvalidPerpPositionToLiquidate"
+    },
+    {
+      "code": 6122,
+      "name": "InvalidBaseAssetAmountForLiquidatePerp",
+      "msg": "InvalidBaseAssetAmountForLiquidatePerp"
+    },
+    {
+      "code": 6123,
+      "name": "InvalidPositionLastFundingRate",
+      "msg": "InvalidPositionLastFundingRate"
+    },
+    {
+      "code": 6124,
+      "name": "InvalidPositionDelta",
+      "msg": "InvalidPositionDelta"
+    },
+    {
+      "code": 6125,
+      "name": "UserBankrupt",
+      "msg": "UserBankrupt"
+    },
+    {
+      "code": 6126,
+      "name": "UserNotBankrupt",
+      "msg": "UserNotBankrupt"
+    },
+    {
+      "code": 6127,
+      "name": "UserHasInvalidBorrow",
+      "msg": "UserHasInvalidBorrow"
+    },
+    {
+      "code": 6128,
+      "name": "DailyWithdrawLimit",
+      "msg": "DailyWithdrawLimit"
+    },
+    {
+      "code": 6129,
+      "name": "DefaultError",
+      "msg": "DefaultError"
+    },
+    {
+      "code": 6130,
+      "name": "InsufficientLPTokens",
+      "msg": "Insufficient LP tokens"
+    },
+    {
+      "code": 6131,
+      "name": "CantLPWithPerpPosition",
+      "msg": "Cant LP with a market position"
+    },
+    {
+      "code": 6132,
+      "name": "UnableToBurnLPTokens",
+      "msg": "Unable to burn LP tokens"
+    },
+    {
+      "code": 6133,
+      "name": "TryingToRemoveLiquidityTooFast",
+      "msg": "Trying to remove liqudity too fast after adding it"
+    },
+    {
+      "code": 6134,
+      "name": "InvalidSpotMarketVault",
+      "msg": "Invalid Spot Market Vault"
+    },
+    {
+      "code": 6135,
+      "name": "InvalidSpotMarketState",
+      "msg": "Invalid Spot Market State"
+    },
+    {
+      "code": 6136,
+      "name": "InvalidSerumProgram",
+      "msg": "InvalidSerumProgram"
+    },
+    {
+      "code": 6137,
+      "name": "InvalidSerumMarket",
+      "msg": "InvalidSerumMarket"
+    },
+    {
+      "code": 6138,
+      "name": "InvalidSerumBids",
+      "msg": "InvalidSerumBids"
+    },
+    {
+      "code": 6139,
+      "name": "InvalidSerumAsks",
+      "msg": "InvalidSerumAsks"
+    },
+    {
+      "code": 6140,
+      "name": "InvalidSerumOpenOrders",
+      "msg": "InvalidSerumOpenOrders"
+    },
+    {
+      "code": 6141,
+      "name": "FailedSerumCPI",
+      "msg": "FailedSerumCPI"
+    },
+    {
+      "code": 6142,
+      "name": "FailedToFillOnExternalMarket",
+      "msg": "FailedToFillOnExternalMarket"
+    },
+    {
+      "code": 6143,
+      "name": "InvalidFulfillmentConfig",
+      "msg": "InvalidFulfillmentConfig"
+    },
+    {
+      "code": 6144,
+      "name": "InvalidFeeStructure",
+      "msg": "InvalidFeeStructure"
+    },
+    {
+      "code": 6145,
+      "name": "InsufficientIFShares",
+      "msg": "Insufficient IF shares"
+    },
+    {
+      "code": 6146,
+      "name": "MarketActionPaused",
+      "msg": "the Market has paused this action"
+    },
+    {
+      "code": 6147,
+      "name": "MarketPlaceOrderPaused",
+      "msg": "the Market status doesnt allow placing orders"
+    },
+    {
+      "code": 6148,
+      "name": "MarketFillOrderPaused",
+      "msg": "the Market status doesnt allow filling orders"
+    },
+    {
+      "code": 6149,
+      "name": "MarketWithdrawPaused",
+      "msg": "the Market status doesnt allow withdraws"
+    },
+    {
+      "code": 6150,
+      "name": "ProtectedAssetTierViolation",
+      "msg": "Action violates the Protected Asset Tier rules"
+    },
+    {
+      "code": 6151,
+      "name": "IsolatedAssetTierViolation",
+      "msg": "Action violates the Isolated Asset Tier rules"
+    },
+    {
+      "code": 6152,
+      "name": "UserCantBeDeleted",
+      "msg": "User Cant Be Deleted"
+    },
+    {
+      "code": 6153,
+      "name": "ReduceOnlyWithdrawIncreasedRisk",
+      "msg": "Reduce Only Withdraw Increased Risk"
+    },
+    {
+      "code": 6154,
+      "name": "MaxOpenInterest",
+      "msg": "Max Open Interest"
+    },
+    {
+      "code": 6155,
+      "name": "CantResolvePerpBankruptcy",
+      "msg": "Cant Resolve Perp Bankruptcy"
+    },
+    {
+      "code": 6156,
+      "name": "LiquidationDoesntSatisfyLimitPrice",
+      "msg": "Liquidation Doesnt Satisfy Limit Price"
+    },
+    {
+      "code": 6157,
+      "name": "MarginTradingDisabled",
+      "msg": "Margin Trading Disabled"
+    },
+    {
+      "code": 6158,
+      "name": "InvalidMarketStatusToSettlePnl",
+      "msg": "Invalid Market Status to Settle Perp Pnl"
+    },
+    {
+      "code": 6159,
+      "name": "PerpMarketNotInSettlement",
+      "msg": "PerpMarketNotInSettlement"
+    },
+    {
+      "code": 6160,
+      "name": "PerpMarketNotInReduceOnly",
+      "msg": "PerpMarketNotInReduceOnly"
+    },
+    {
+      "code": 6161,
+      "name": "PerpMarketSettlementBufferNotReached",
+      "msg": "PerpMarketSettlementBufferNotReached"
+    },
+    {
+      "code": 6162,
+      "name": "PerpMarketSettlementUserHasOpenOrders",
+      "msg": "PerpMarketSettlementUserHasOpenOrders"
+    },
+    {
+      "code": 6163,
+      "name": "PerpMarketSettlementUserHasActiveLP",
+      "msg": "PerpMarketSettlementUserHasActiveLP"
+    },
+    {
+      "code": 6164,
+      "name": "UnableToSettleExpiredUserPosition",
+      "msg": "UnableToSettleExpiredUserPosition"
+    },
+    {
+      "code": 6165,
+      "name": "UnequalMarketIndexForSpotTransfer",
+      "msg": "UnequalMarketIndexForSpotTransfer"
+    },
+    {
+      "code": 6166,
+      "name": "InvalidPerpPositionDetected",
+      "msg": "InvalidPerpPositionDetected"
+    },
+    {
+      "code": 6167,
+      "name": "InvalidSpotPositionDetected",
+      "msg": "InvalidSpotPositionDetected"
+    },
+    {
+      "code": 6168,
+      "name": "InvalidAmmDetected",
+      "msg": "InvalidAmmDetected"
+    },
+    {
+      "code": 6169,
+      "name": "InvalidAmmForFillDetected",
+      "msg": "InvalidAmmForFillDetected"
+    },
+    {
+      "code": 6170,
+      "name": "InvalidAmmLimitPriceOverride",
+      "msg": "InvalidAmmLimitPriceOverride"
+    },
+    {
+      "code": 6171,
+      "name": "InvalidOrderFillPrice",
+      "msg": "InvalidOrderFillPrice"
+    },
+    {
+      "code": 6172,
+      "name": "SpotMarketBalanceInvariantViolated",
+      "msg": "SpotMarketBalanceInvariantViolated"
+    },
+    {
+      "code": 6173,
+      "name": "SpotMarketVaultInvariantViolated",
+      "msg": "SpotMarketVaultInvariantViolated"
+    },
+    {
+      "code": 6174,
+      "name": "InvalidPDA",
+      "msg": "InvalidPDA"
+    },
+    {
+      "code": 6175,
+      "name": "InvalidPDASigner",
+      "msg": "InvalidPDASigner"
+    },
+    {
+      "code": 6176,
+      "name": "RevenueSettingsCannotSettleToIF",
+      "msg": "RevenueSettingsCannotSettleToIF"
+    },
+    {
+      "code": 6177,
+      "name": "NoRevenueToSettleToIF",
+      "msg": "NoRevenueToSettleToIF"
+    },
+    {
+      "code": 6178,
+      "name": "NoAmmPerpPnlDeficit",
+      "msg": "NoAmmPerpPnlDeficit"
+    },
+    {
+      "code": 6179,
+      "name": "SufficientPerpPnlPool",
+      "msg": "SufficientPerpPnlPool"
+    },
+    {
+      "code": 6180,
+      "name": "InsufficientPerpPnlPool",
+      "msg": "InsufficientPerpPnlPool"
+    },
+    {
+      "code": 6181,
+      "name": "PerpPnlDeficitBelowThreshold",
+      "msg": "PerpPnlDeficitBelowThreshold"
+    },
+    {
+      "code": 6182,
+      "name": "MaxRevenueWithdrawPerPeriodReached",
+      "msg": "MaxRevenueWithdrawPerPeriodReached"
+    },
+    {
+      "code": 6183,
+      "name": "MaxIFWithdrawReached",
+      "msg": "InvalidSpotPositionDetected"
+    },
+    {
+      "code": 6184,
+      "name": "NoIFWithdrawAvailable",
+      "msg": "NoIFWithdrawAvailable"
+    },
+    {
+      "code": 6185,
+      "name": "InvalidIFUnstake",
+      "msg": "InvalidIFUnstake"
+    },
+    {
+      "code": 6186,
+      "name": "InvalidIFUnstakeSize",
+      "msg": "InvalidIFUnstakeSize"
+    },
+    {
+      "code": 6187,
+      "name": "InvalidIFUnstakeCancel",
+      "msg": "InvalidIFUnstakeCancel"
+    },
+    {
+      "code": 6188,
+      "name": "InvalidIFForNewStakes",
+      "msg": "InvalidIFForNewStakes"
+    },
+    {
+      "code": 6189,
+      "name": "InvalidIFRebase",
+      "msg": "InvalidIFRebase"
+    },
+    {
+      "code": 6190,
+      "name": "InvalidInsuranceUnstakeSize",
+      "msg": "InvalidInsuranceUnstakeSize"
+    },
+    {
+      "code": 6191,
+      "name": "InvalidOrderLimitPrice",
+      "msg": "InvalidOrderLimitPrice"
+    },
+    {
+      "code": 6192,
+      "name": "InvalidIFDetected",
+      "msg": "InvalidIFDetected"
+    },
+    {
+      "code": 6193,
+      "name": "InvalidAmmMaxSpreadDetected",
+      "msg": "InvalidAmmMaxSpreadDetected"
+    },
+    {
+      "code": 6194,
+      "name": "InvalidConcentrationCoef",
+      "msg": "InvalidConcentrationCoef"
+    },
+    {
+      "code": 6195,
+      "name": "InvalidSrmVault",
+      "msg": "InvalidSrmVault"
+    },
+    {
+      "code": 6196,
+      "name": "InvalidVaultOwner",
+      "msg": "InvalidVaultOwner"
+    },
+    {
+      "code": 6197,
+      "name": "InvalidMarketStatusForFills",
+      "msg": "InvalidMarketStatusForFills"
+    },
+    {
+      "code": 6198,
+      "name": "IFWithdrawRequestInProgress",
+      "msg": "IFWithdrawRequestInProgress"
+    },
+    {
+      "code": 6199,
+      "name": "NoIFWithdrawRequestInProgress",
+      "msg": "NoIFWithdrawRequestInProgress"
+    },
+    {
+      "code": 6200,
+      "name": "IFWithdrawRequestTooSmall",
+      "msg": "IFWithdrawRequestTooSmall"
+    },
+    {
+      "code": 6201,
+      "name": "IncorrectSpotMarketAccountPassed",
+      "msg": "IncorrectSpotMarketAccountPassed"
+    },
+    {
+      "code": 6202,
+      "name": "BlockchainClockInconsistency",
+      "msg": "BlockchainClockInconsistency"
+    },
+    {
+      "code": 6203,
+      "name": "InvalidIFSharesDetected",
+      "msg": "InvalidIFSharesDetected"
+    },
+    {
+      "code": 6204,
+      "name": "NewLPSizeTooSmall",
+      "msg": "NewLPSizeTooSmall"
+    },
+    {
+      "code": 6205,
+      "name": "MarketStatusInvalidForNewLP",
+      "msg": "MarketStatusInvalidForNewLP"
+    },
+    {
+      "code": 6206,
+      "name": "InvalidMarkTwapUpdateDetected",
+      "msg": "InvalidMarkTwapUpdateDetected"
+    },
+    {
+      "code": 6207,
+      "name": "MarketSettlementAttemptOnActiveMarket",
+      "msg": "MarketSettlementAttemptOnActiveMarket"
+    },
+    {
+      "code": 6208,
+      "name": "MarketSettlementRequiresSettledLP",
+      "msg": "MarketSettlementRequiresSettledLP"
+    },
+    {
+      "code": 6209,
+      "name": "MarketSettlementAttemptTooEarly",
+      "msg": "MarketSettlementAttemptTooEarly"
+    },
+    {
+      "code": 6210,
+      "name": "MarketSettlementTargetPriceInvalid",
+      "msg": "MarketSettlementTargetPriceInvalid"
+    },
+    {
+      "code": 6211,
+      "name": "UnsupportedSpotMarket",
+      "msg": "UnsupportedSpotMarket"
+    },
+    {
+      "code": 6212,
+      "name": "SpotOrdersDisabled",
+      "msg": "SpotOrdersDisabled"
+    },
+    {
+      "code": 6213,
+      "name": "MarketBeingInitialized",
+      "msg": "Market Being Initialized"
+    },
+    {
+      "code": 6214,
+      "name": "InvalidUserSubAccountId",
+      "msg": "Invalid Sub Account Id"
+    },
+    {
+      "code": 6215,
+      "name": "InvalidTriggerOrderCondition",
+      "msg": "Invalid Trigger Order Condition"
+    },
+    {
+      "code": 6216,
+      "name": "InvalidSpotPosition",
+      "msg": "Invalid Spot Position"
+    },
+    {
+      "code": 6217,
+      "name": "CantTransferBetweenSameUserAccount",
+      "msg": "Cant transfer between same user account"
+    },
+    {
+      "code": 6218,
+      "name": "InvalidPerpPosition",
+      "msg": "Invalid Perp Position"
+    },
+    {
+      "code": 6219,
+      "name": "UnableToGetLimitPrice",
+      "msg": "Unable To Get Limit Price"
+    },
+    {
+      "code": 6220,
+      "name": "InvalidLiquidation",
+      "msg": "Invalid Liquidation"
+    },
+    {
+      "code": 6221,
+      "name": "SpotFulfillmentConfigDisabled",
+      "msg": "Spot Fulfillment Config Disabled"
+    },
+    {
+      "code": 6222,
+      "name": "InvalidMaker",
+      "msg": "Invalid Maker"
+    },
+    {
+      "code": 6223,
+      "name": "FailedUnwrap",
+      "msg": "Failed Unwrap"
+    },
+    {
+      "code": 6224,
+      "name": "MaxNumberOfUsers",
+      "msg": "Max Number Of Users"
+    },
+    {
+      "code": 6225,
+      "name": "InvalidOracleForSettlePnl",
+      "msg": "InvalidOracleForSettlePnl"
+    },
+    {
+      "code": 6226,
+      "name": "MarginOrdersOpen",
+      "msg": "MarginOrdersOpen"
+    },
+    {
+      "code": 6227,
+      "name": "TierViolationLiquidatingPerpPnl",
+      "msg": "TierViolationLiquidatingPerpPnl"
+    },
+    {
+      "code": 6228,
+      "name": "CouldNotLoadUserData",
+      "msg": "CouldNotLoadUserData"
+    },
+    {
+      "code": 6229,
+      "name": "UserWrongMutability",
+      "msg": "UserWrongMutability"
+    },
+    {
+      "code": 6230,
+      "name": "InvalidUserAccount",
+      "msg": "InvalidUserAccount"
+    },
+    {
+      "code": 6231,
+      "name": "CouldNotLoadUserStatsData",
+      "msg": "CouldNotLoadUserData"
+    },
+    {
+      "code": 6232,
+      "name": "UserStatsWrongMutability",
+      "msg": "UserWrongMutability"
+    },
+    {
+      "code": 6233,
+      "name": "InvalidUserStatsAccount",
+      "msg": "InvalidUserAccount"
+    },
+    {
+      "code": 6234,
+      "name": "UserNotFound",
+      "msg": "UserNotFound"
+    },
+    {
+      "code": 6235,
+      "name": "UnableToLoadUserAccount",
+      "msg": "UnableToLoadUserAccount"
+    },
+    {
+      "code": 6236,
+      "name": "UserStatsNotFound",
+      "msg": "UserStatsNotFound"
+    },
+    {
+      "code": 6237,
+      "name": "UnableToLoadUserStatsAccount",
+      "msg": "UnableToLoadUserStatsAccount"
+    },
+    {
+      "code": 6238,
+      "name": "UserNotInactive",
+      "msg": "User Not Inactive"
+    },
+    {
+      "code": 6239,
+      "name": "RevertFill",
+      "msg": "RevertFill"
+    },
+    {
+      "code": 6240,
+      "name": "InvalidMarketAccountforDeletion",
+      "msg": "Invalid MarketAccount for Deletion"
+    },
+    {
+      "code": 6241,
+      "name": "InvalidSpotFulfillmentParams",
+      "msg": "Invalid Spot Fulfillment Params"
+    },
+    {
+      "code": 6242,
+      "name": "FailedToGetMint",
+      "msg": "Failed to Get Mint"
+    },
+    {
+      "code": 6243,
+      "name": "FailedPhoenixCPI",
+      "msg": "FailedPhoenixCPI"
+    },
+    {
+      "code": 6244,
+      "name": "FailedToDeserializePhoenixMarket",
+      "msg": "FailedToDeserializePhoenixMarket"
+    },
+    {
+      "code": 6245,
+      "name": "InvalidPricePrecision",
+      "msg": "InvalidPricePrecision"
+    },
+    {
+      "code": 6246,
+      "name": "InvalidPhoenixProgram",
+      "msg": "InvalidPhoenixProgram"
+    },
+    {
+      "code": 6247,
+      "name": "InvalidPhoenixMarket",
+      "msg": "InvalidPhoenixMarket"
+    },
+    {
+      "code": 6248,
+      "name": "InvalidSwap",
+      "msg": "InvalidSwap"
+    },
+    {
+      "code": 6249,
+      "name": "SwapLimitPriceBreached",
+      "msg": "SwapLimitPriceBreached"
+    },
+    {
+      "code": 6250,
+      "name": "SpotMarketReduceOnly",
+      "msg": "SpotMarketReduceOnly"
+    },
+    {
+      "code": 6251,
+      "name": "FundingWasNotUpdated",
+      "msg": "FundingWasNotUpdated"
+    },
+    {
+      "code": 6252,
+      "name": "ImpossibleFill",
+      "msg": "ImpossibleFill"
+    },
+    {
+      "code": 6253,
+      "name": "CantUpdatePerpBidAskTwap",
+      "msg": "CantUpdatePerpBidAskTwap"
+    },
+    {
+      "code": 6254,
+      "name": "UserReduceOnly",
+      "msg": "UserReduceOnly"
+    },
+    {
+      "code": 6255,
+      "name": "InvalidMarginCalculation",
+      "msg": "InvalidMarginCalculation"
+    },
+    {
+      "code": 6256,
+      "name": "CantPayUserInitFee",
+      "msg": "CantPayUserInitFee"
+    },
+    {
+      "code": 6257,
+      "name": "CantReclaimRent",
+      "msg": "CantReclaimRent"
+    },
+    {
+      "code": 6258,
+      "name": "InsuranceFundOperationPaused",
+      "msg": "InsuranceFundOperationPaused"
+    },
+    {
+      "code": 6259,
+      "name": "NoUnsettledPnl",
+      "msg": "NoUnsettledPnl"
+    },
+    {
+      "code": 6260,
+      "name": "PnlPoolCantSettleUser",
+      "msg": "PnlPoolCantSettleUser"
+    },
+    {
+      "code": 6261,
+      "name": "OracleNonPositive",
+      "msg": "OracleInvalid"
+    },
+    {
+      "code": 6262,
+      "name": "OracleTooVolatile",
+      "msg": "OracleTooVolatile"
+    },
+    {
+      "code": 6263,
+      "name": "OracleTooUncertain",
+      "msg": "OracleTooUncertain"
+    },
+    {
+      "code": 6264,
+      "name": "OracleStaleForMargin",
+      "msg": "OracleStaleForMargin"
+    },
+    {
+      "code": 6265,
+      "name": "OracleInsufficientDataPoints",
+      "msg": "OracleInsufficientDataPoints"
+    },
+    {
+      "code": 6266,
+      "name": "OracleStaleForAMM",
+      "msg": "OracleStaleForAMM"
+    },
+    {
+      "code": 6267,
+      "name": "UnableToParsePullOracleMessage",
+      "msg": "Unable to parse pull oracle message"
+    },
+    {
+      "code": 6268,
+      "name": "MaxBorrows",
+      "msg": "Can not borow more than max borrows"
+    },
+    {
+      "code": 6269,
+      "name": "OracleUpdatesNotMonotonic",
+      "msg": "Updates must be monotonically increasing"
+    },
+    {
+      "code": 6270,
+      "name": "OraclePriceFeedMessageMismatch",
+      "msg": "Trying to update price feed with the wrong feed id"
+    },
+    {
+      "code": 6271,
+      "name": "OracleUnsupportedMessageType",
+      "msg": "The message in the update must be a PriceFeedMessage"
+    },
+    {
+      "code": 6272,
+      "name": "OracleDeserializeMessageFailed",
+      "msg": "Could not deserialize the message in the update"
+    },
+    {
+      "code": 6273,
+      "name": "OracleWrongGuardianSetOwner",
+      "msg": "Wrong guardian set owner in update price atomic"
+    },
+    {
+      "code": 6274,
+      "name": "OracleWrongWriteAuthority",
+      "msg": "Oracle post update atomic price feed account must be drift program"
+    },
+    {
+      "code": 6275,
+      "name": "OracleWrongVaaOwner",
+      "msg": "Oracle vaa owner must be wormhole program"
+    },
+    {
+      "code": 6276,
+      "name": "OracleTooManyPriceAccountUpdates",
+      "msg": "Multi updates must have 2 or fewer accounts passed in remaining accounts"
+    },
+    {
+      "code": 6277,
+      "name": "OracleMismatchedVaaAndPriceUpdates",
+      "msg": "Don't have the same remaining accounts number and pyth updates left"
+    },
+    {
+      "code": 6278,
+      "name": "OracleBadRemainingAccountPublicKey",
+      "msg": "Remaining account passed does not match oracle update derived pda"
+    },
+    {
+      "code": 6279,
+      "name": "FailedOpenbookV2CPI",
+      "msg": "FailedOpenbookV2CPI"
+    },
+    {
+      "code": 6280,
+      "name": "InvalidOpenbookV2Program",
+      "msg": "InvalidOpenbookV2Program"
+    },
+    {
+      "code": 6281,
+      "name": "InvalidOpenbookV2Market",
+      "msg": "InvalidOpenbookV2Market"
+    },
+    {
+      "code": 6282,
+      "name": "NonZeroTransferFee",
+      "msg": "Non zero transfer fee"
+    },
+    {
+      "code": 6283,
+      "name": "LiquidationOrderFailedToFill",
+      "msg": "Liquidation order failed to fill"
+    },
+    {
+      "code": 6284,
+      "name": "InvalidPredictionMarketOrder",
+      "msg": "Invalid prediction market order"
+    },
+    {
+      "code": 6285,
+      "name": "InvalidVerificationIxIndex",
+      "msg": "Ed25519 Ix must be before place and make SignedMsg order ix"
+    },
+    {
+      "code": 6286,
+      "name": "SigVerificationFailed",
+      "msg": "SignedMsg message verificaiton failed"
+    },
+    {
+      "code": 6287,
+      "name": "MismatchedSignedMsgOrderParamsMarketIndex",
+      "msg": "Market index mismatched b/w taker and maker SignedMsg order params"
+    },
+    {
+      "code": 6288,
+      "name": "InvalidSignedMsgOrderParam",
+      "msg": "Invalid SignedMsg order param"
+    },
+    {
+      "code": 6289,
+      "name": "PlaceAndTakeOrderSuccessConditionFailed",
+      "msg": "Place and take order success condition failed"
+    },
+    {
+      "code": 6290,
+      "name": "InvalidHighLeverageModeConfig",
+      "msg": "Invalid High Leverage Mode Config"
+    },
+    {
+      "code": 6291,
+      "name": "InvalidRFQUserAccount",
+      "msg": "Invalid RFQ User Account"
+    },
+    {
+      "code": 6292,
+      "name": "RFQUserAccountWrongMutability",
+      "msg": "RFQUserAccount should be mutable"
+    },
+    {
+      "code": 6293,
+      "name": "RFQUserAccountFull",
+      "msg": "RFQUserAccount has too many active RFQs"
+    },
+    {
+      "code": 6294,
+      "name": "RFQOrderNotFilled",
+      "msg": "RFQ order not filled as expected"
+    },
+    {
+      "code": 6295,
+      "name": "InvalidRFQOrder",
+      "msg": "RFQ orders must be jit makers"
+    },
+    {
+      "code": 6296,
+      "name": "InvalidRFQMatch",
+      "msg": "RFQ matches must be valid"
+    },
+    {
+      "code": 6297,
+      "name": "InvalidSignedMsgUserAccount",
+      "msg": "Invalid SignedMsg user account"
+    },
+    {
+      "code": 6298,
+      "name": "SignedMsgUserAccountWrongMutability",
+      "msg": "SignedMsg account wrong mutability"
+    },
+    {
+      "code": 6299,
+      "name": "SignedMsgUserOrdersAccountFull",
+      "msg": "SignedMsgUserAccount has too many active orders"
+    },
+    {
+      "code": 6300,
+      "name": "SignedMsgOrderDoesNotExist",
+      "msg": "Order with SignedMsg uuid does not exist"
+    },
+    {
+      "code": 6301,
+      "name": "InvalidSignedMsgOrderId",
+      "msg": "SignedMsg order id cannot be 0s"
+    },
+    {
+      "code": 6302,
+      "name": "InvalidPoolId",
+      "msg": "Invalid pool id"
+    },
+    {
+      "code": 6303,
+      "name": "InvalidProtectedMakerModeConfig",
+      "msg": "Invalid Protected Maker Mode Config"
+    },
+    {
+      "code": 6304,
+      "name": "InvalidPythLazerStorageOwner",
+      "msg": "Invalid pyth lazer storage owner"
+    },
+    {
+      "code": 6305,
+      "name": "UnverifiedPythLazerMessage",
+      "msg": "Verification of pyth lazer message failed"
+    },
+    {
+      "code": 6306,
+      "name": "InvalidPythLazerMessage",
+      "msg": "Invalid pyth lazer message"
+    },
+    {
+      "code": 6307,
+      "name": "PythLazerMessagePriceFeedMismatch",
+      "msg": "Pyth lazer message does not correspond to correct fed id"
+    },
+    {
+      "code": 6308,
+      "name": "InvalidLiquidateSpotWithSwap",
+      "msg": "InvalidLiquidateSpotWithSwap"
+    },
+    {
+      "code": 6309,
+      "name": "SignedMsgUserContextUserMismatch",
+      "msg": "User in SignedMsg message does not match user in ix context"
+    },
+    {
+      "code": 6310,
+      "name": "UserFuelOverflowThresholdNotMet",
+      "msg": "User fuel overflow threshold not met"
+    },
+    {
+      "code": 6311,
+      "name": "FuelOverflowAccountNotFound",
+      "msg": "FuelOverflow account not found"
+    },
+    {
+      "code": 6312,
+      "name": "InvalidTransferPerpPosition",
+      "msg": "Invalid Transfer Perp Position"
+    },
+    {
+      "code": 6313,
+      "name": "InvalidSignedMsgUserOrdersResize",
+      "msg": "Invalid SignedMsgUserOrders resize"
+    },
+    {
+      "code": 6314,
+      "name": "CouldNotDeserializeHighLeverageModeConfig",
+      "msg": "Could not deserialize high leverage mode config"
+    },
+    {
+      "code": 6315,
+      "name": "InvalidIfRebalanceConfig",
+      "msg": "Invalid If Rebalance Config"
+    },
+    {
+      "code": 6316,
+      "name": "InvalidIfRebalanceSwap",
+      "msg": "Invalid If Rebalance Swap"
+    },
+    {
+      "code": 6317,
+      "name": "InvalidRevenueShareResize",
+      "msg": "Invalid RevenueShare resize"
+    },
+    {
+      "code": 6318,
+      "name": "BuilderRevoked",
+      "msg": "Builder has been revoked"
+    },
+    {
+      "code": 6319,
+      "name": "InvalidBuilderFee",
+      "msg": "Builder fee is greater than max fee bps"
+    },
+    {
+      "code": 6320,
+      "name": "RevenueShareEscrowAuthorityMismatch",
+      "msg": "RevenueShareEscrow authority mismatch"
+    },
+    {
+      "code": 6321,
+      "name": "RevenueShareEscrowOrdersAccountFull",
+      "msg": "RevenueShareEscrow has too many active orders"
+    },
+    {
+      "code": 6322,
+      "name": "InvalidRevenueShareAccount",
+      "msg": "Invalid RevenueShareAccount"
+    },
+    {
+      "code": 6323,
+      "name": "CannotRevokeBuilderWithOpenOrders",
+      "msg": "Cannot revoke builder with open orders"
+    },
+    {
+      "code": 6324,
+      "name": "UnableToLoadRevenueShareAccount",
+      "msg": "Unable to load builder account"
+    },
+    {
+      "code": 6325,
+      "name": "InvalidConstituent",
+      "msg": "Invalid Constituent"
+    },
+    {
+      "code": 6326,
+      "name": "InvalidAmmConstituentMappingArgument",
+      "msg": "Invalid Amm Constituent Mapping argument"
+    },
+    {
+      "code": 6327,
+      "name": "ConstituentNotFound",
+      "msg": "Constituent not found"
+    },
+    {
+      "code": 6328,
+      "name": "ConstituentCouldNotLoad",
+      "msg": "Constituent could not load"
+    },
+    {
+      "code": 6329,
+      "name": "ConstituentWrongMutability",
+      "msg": "Constituent wrong mutability"
+    },
+    {
+      "code": 6330,
+      "name": "WrongNumberOfConstituents",
+      "msg": "Wrong number of constituents passed to instruction"
+    },
+    {
+      "code": 6331,
+      "name": "InsufficientConstituentTokenBalance",
+      "msg": "Insufficient constituent token balance"
+    },
+    {
+      "code": 6332,
+      "name": "AMMCacheStale",
+      "msg": "Amm Cache data too stale"
+    },
+    {
+      "code": 6333,
+      "name": "LpPoolAumDelayed",
+      "msg": "LP Pool AUM not updated recently"
+    },
+    {
+      "code": 6334,
+      "name": "ConstituentOracleStale",
+      "msg": "Constituent oracle is stale"
+    },
+    {
+      "code": 6335,
+      "name": "LpInvariantFailed",
+      "msg": "LP Invariant failed"
+    },
+    {
+      "code": 6336,
+      "name": "InvalidConstituentDerivativeWeights",
+      "msg": "Invalid constituent derivative weights"
+    },
+    {
+      "code": 6337,
+      "name": "MaxDlpAumBreached",
+      "msg": "Max DLP AUM Breached"
+    },
+    {
+      "code": 6338,
+      "name": "SettleLpPoolDisabled",
+      "msg": "Settle Lp Pool Disabled"
+    },
+    {
+      "code": 6339,
+      "name": "MintRedeemLpPoolDisabled",
+      "msg": "Mint/Redeem Lp Pool Disabled"
+    },
+    {
+      "code": 6340,
+      "name": "LpPoolSettleInvariantBreached",
+      "msg": "Settlement amount exceeded"
+    },
+    {
+      "code": 6341,
+      "name": "InvalidConstituentOperation",
+      "msg": "Invalid constituent operation"
+    },
+    {
+      "code": 6342,
+      "name": "Unauthorized",
+      "msg": "Unauthorized for operation"
+    },
+    {
+      "code": 6343,
+      "name": "InvalidLpPoolId",
+      "msg": "Invalid Lp Pool Id for Operation"
+    },
+    {
+      "code": 6344,
+      "name": "MarketIndexNotFoundAmmCache",
+      "msg": "MarketIndexNotFoundAmmCache"
+    },
+    {
+      "code": 6345,
+      "name": "InvalidIsolatedPerpMarket",
+      "msg": "Invalid Isolated Perp Market"
+    },
+    {
+      "code": 6346,
+      "name": "InvalidOrderScaleOrderCount",
+      "msg": "Invalid scale order count - must be between 2 and 10"
+    },
+    {
+      "code": 6347,
+      "name": "InvalidOrderScalePriceRange",
+      "msg": "Invalid scale order price range"
+    },
+    {
+      "code": 6348,
+      "name": "InvalidPerpMarketConfig",
+      "msg": "Invalid perp market config"
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
@@ -178,13 +178,23 @@ fn build_parsed_fields(
     }
 
     for (account_name, account_address) in &instruction.named_accounts {
-        if let Ok(f) = create_text_field(account_name, account_address) {
+        let label = if parsed.program_call_args.contains_key(account_name) {
+            format!("Current {account_name}")
+        } else {
+            account_name.clone()
+        };
+        if let Ok(f) = create_text_field(&label, account_address) {
             expanded_fields.push(f);
         }
     }
 
     for (key, value) in &parsed.program_call_args {
-        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+        let label = if instruction.named_accounts.contains_key(key) {
+            format!("New {key}")
+        } else {
+            key.clone()
+        };
+        if let Ok(f) = create_text_field(&label, &format_arg_value(value)) {
             expanded_fields.push(f);
         }
     }

--- a/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
@@ -1,0 +1,291 @@
+//! Drift Protocol preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::DriftConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const DRIFT_PROGRAM_ID: &str = "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH";
+
+const DRIFT_IDL_JSON: &str = include_str!("drift.json");
+
+static DRIFT_CONFIG: DriftConfig = DriftConfig;
+
+pub struct DriftVisualizer;
+
+impl InstructionVisualizer for DriftVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let instruction_data_hex = hex::encode(&instruction.data);
+        let fallback_text = format!(
+            "Program ID: {}\nData: {instruction_data_hex}",
+            instruction.program_id,
+        );
+
+        let parsed = parse_drift_instruction(&instruction.data, &instruction.accounts);
+
+        let (title, condensed_fields, expanded_fields) = match parsed {
+            Ok(parsed) => build_parsed_fields(&parsed, &instruction.program_id.to_string()),
+            Err(_) => build_fallback_fields(&instruction.program_id.to_string()),
+        };
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        let expanded_with_raw =
+            append_raw_data(expanded_fields, &instruction.data, &instruction_data_hex);
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_with_raw,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&DRIFT_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex("Drift")
+    }
+}
+
+fn get_drift_idl() -> Option<&'static Idl> {
+    static IDL: std::sync::LazyLock<Option<Idl>> =
+        std::sync::LazyLock::new(|| decode_idl_data(DRIFT_IDL_JSON).ok());
+    IDL.as_ref()
+}
+
+fn parse_drift_instruction(
+    data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> Result<DriftParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_drift_idl().ok_or("Drift IDL not available")?;
+    let parsed = parse_instruction_with_idl(data, DRIFT_PROGRAM_ID, idl)?;
+
+    let named_accounts = build_named_accounts(data, idl, accounts);
+
+    Ok(DriftParsedInstruction {
+        parsed,
+        named_accounts,
+    })
+}
+
+fn build_named_accounts(
+    data: &[u8],
+    idl: &Idl,
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named_accounts = HashMap::new();
+
+    let idl_instruction = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.len() >= disc.len() && data[..disc.len()] == *disc)
+    });
+
+    if let Some(idl_instruction) = idl_instruction {
+        for (index, account_meta) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+            }
+        }
+    }
+
+    named_accounts
+}
+
+struct DriftParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: HashMap<String, String>,
+}
+
+fn build_parsed_fields(
+    instruction: &DriftParsedInstruction,
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let parsed = &instruction.parsed;
+    let title = format!("Drift: {}", parsed.instruction_name);
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    if let Ok(f) = create_text_field("Program", "Drift") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        condensed_fields.push(f);
+    }
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            condensed_fields.push(f);
+        }
+    }
+
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Discriminator", &parsed.discriminator) {
+        expanded_fields.push(f);
+    }
+
+    for (account_name, account_address) in &instruction.named_accounts {
+        if let Ok(f) = create_text_field(account_name, account_address) {
+            expanded_fields.push(f);
+        }
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            expanded_fields.push(f);
+        }
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn build_fallback_fields(
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let title = "Drift: Unknown Instruction".to_string();
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    if let Ok(f) = create_text_field("Program", "Drift") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        condensed_fields.push(f);
+    }
+
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        expanded_fields.push(f);
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn append_raw_data(
+    mut fields: Vec<AnnotatedPayloadField>,
+    data: &[u8],
+    hex_str: &str,
+) -> Vec<AnnotatedPayloadField> {
+    if let Ok(f) = create_raw_data_field(data, Some(hex_str.to_string())) {
+        fields.push(f);
+    }
+    fields
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_drift_idl_loads() {
+        let idl = get_drift_idl();
+        assert!(idl.is_some(), "Drift IDL should load successfully");
+        let idl = idl.unwrap();
+        assert!(!idl.instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_drift_idl_has_discriminators() {
+        let idl = get_drift_idl().unwrap();
+        for instruction in &idl.instructions {
+            assert!(
+                instruction.discriminator.is_some(),
+                "Instruction '{}' should have a computed discriminator",
+                instruction.name
+            );
+            let disc = instruction.discriminator.as_ref().unwrap();
+            assert_eq!(
+                disc.len(),
+                8,
+                "Discriminator for '{}' should be 8 bytes",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        let accounts = vec![];
+        let result = parse_drift_instruction(&garbage_data, &accounts);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short_data = [0x01, 0x02, 0x03];
+        let accounts = vec![];
+        let result = parse_drift_instruction(&short_data, &accounts);
+        assert!(result.is_err(), "Short data should return error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -1,5 +1,6 @@
 pub mod associated_token_account;
 pub mod compute_budget;
+pub mod drift;
 pub mod jupiter_swap;
 pub mod squads_multisig;
 pub mod stakepool;

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -1,6 +1,7 @@
 pub mod associated_token_account;
 pub mod compute_budget;
 pub mod jupiter_swap;
+pub mod squads_multisig;
 pub mod stakepool;
 pub mod swig_wallet;
 pub mod system;

--- a/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/config.rs
@@ -1,0 +1,22 @@
+use super::SQUADS_MULTISIG_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct SquadsMultisigConfig;
+
+impl SolanaIntegrationConfig for SquadsMultisigConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(SQUADS_MULTISIG_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
@@ -4,11 +4,16 @@ mod config;
 
 use crate::core::{
     InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+    available_visualizers, visualize_with_any,
 };
+use crate::idl::IdlRegistry;
 use config::SquadsMultisigConfig;
+use solana_parser::solana::structs::SolanaAccount;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
+use solana_sdk::instruction::{AccountMeta, Instruction};
+use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
@@ -22,6 +27,85 @@ pub(crate) const SQUADS_MULTISIG_PROGRAM_ID: &str = "SQDS4ep65T869zMMBKyuUq6aD6E
 const SQUADS_IDL_JSON: &str = include_str!("squads_multisig_program.json");
 
 static SQUADS_MULTISIG_CONFIG: SquadsMultisigConfig = SquadsMultisigConfig;
+
+// -- VaultTransactionMessage uses Solana's compact wire format (u8 lengths), not borsh --
+
+struct VaultTransactionMessage {
+    account_keys: Vec<Pubkey>,
+    instructions: Vec<MultisigCompiledInstruction>,
+}
+
+struct MultisigCompiledInstruction {
+    program_id_index: u8,
+    account_indexes: Vec<u8>,
+    data: Vec<u8>,
+}
+
+impl VaultTransactionMessage {
+    /// Parse from Squads' compact wire format (mimics Solana Message serialization).
+    /// Format: 3×u8 header, u8 account_keys count + pubkeys,
+    ///         u8 instructions count + compiled instructions,
+    ///         u8 address_table_lookups count + lookups
+    fn deserialize(data: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut pos = 0;
+
+        let read_u8 = |pos: &mut usize| -> Result<u8, Box<dyn std::error::Error>> {
+            if *pos >= data.len() {
+                return Err("unexpected end of data".into());
+            }
+            let val = data[*pos];
+            *pos += 1;
+            Ok(val)
+        };
+
+        let read_bytes =
+            |pos: &mut usize, len: usize| -> Result<&[u8], Box<dyn std::error::Error>> {
+                if *pos + len > data.len() {
+                    return Err("unexpected end of data".into());
+                }
+                let slice = &data[*pos..*pos + len];
+                *pos += len;
+                Ok(slice)
+            };
+
+        // Header: 3 u8s (numSigners, numWritableSigners, numWritableNonSigners)
+        let _num_signers = read_u8(&mut pos)?;
+        let _num_writable_signers = read_u8(&mut pos)?;
+        let _num_writable_non_signers = read_u8(&mut pos)?;
+
+        // Account keys: u8 count + N × 32-byte pubkeys
+        let num_keys = read_u8(&mut pos)? as usize;
+        let mut account_keys = Vec::with_capacity(num_keys);
+        for _ in 0..num_keys {
+            let key_bytes = read_bytes(&mut pos, 32)?;
+            account_keys.push(Pubkey::new_from_array(key_bytes.try_into()?));
+        }
+
+        // Instructions: u8 count + N × compiled instructions
+        let num_instructions = read_u8(&mut pos)? as usize;
+        let mut instructions = Vec::with_capacity(num_instructions);
+        for _ in 0..num_instructions {
+            let program_id_index = read_u8(&mut pos)?;
+            let num_account_indexes = read_u8(&mut pos)? as usize;
+            let account_indexes = read_bytes(&mut pos, num_account_indexes)?.to_vec();
+            let data_len = read_u8(&mut pos)? as usize;
+            let instruction_data = read_bytes(&mut pos, data_len)?.to_vec();
+            instructions.push(MultisigCompiledInstruction {
+                program_id_index,
+                account_indexes,
+                data: instruction_data,
+            });
+        }
+
+        // Address table lookups: u8 count (we skip parsing the contents)
+        // They're not needed for instruction reconstruction without ALT resolution
+
+        Ok(Self {
+            account_keys,
+            instructions,
+        })
+    }
+}
 
 pub struct SquadsMultisigVisualizer;
 
@@ -43,7 +127,9 @@ impl InstructionVisualizer for SquadsMultisigVisualizer {
         let parsed = parse_squads_instruction(&instruction.data, &instruction.accounts);
 
         let (title, condensed_fields, expanded_fields) = match parsed {
-            Ok(parsed) => build_parsed_fields(&parsed, &instruction.program_id.to_string()),
+            Ok(parsed) => {
+                build_parsed_fields(&parsed, &instruction.program_id.to_string(), context)
+            }
             Err(_) => build_fallback_fields(&instruction.program_id.to_string()),
         };
 
@@ -93,7 +179,7 @@ fn get_squads_idl() -> Option<Idl> {
 
 fn parse_squads_instruction(
     data: &[u8],
-    accounts: &[solana_sdk::instruction::AccountMeta],
+    accounts: &[AccountMeta],
 ) -> Result<SquadsParsedInstruction, Box<dyn std::error::Error>> {
     if data.len() < 8 {
         return Err("Invalid instruction data length".into());
@@ -102,7 +188,6 @@ fn parse_squads_instruction(
     let idl = get_squads_idl().ok_or("Squads Multisig IDL not available")?;
     let parsed = parse_instruction_with_idl(data, SQUADS_MULTISIG_PROGRAM_ID, &idl)?;
 
-    // Build named accounts by matching instruction accounts with IDL definitions
     let named_accounts = build_named_accounts(data, &idl, accounts);
 
     Ok(SquadsParsedInstruction {
@@ -114,7 +199,7 @@ fn parse_squads_instruction(
 fn build_named_accounts(
     data: &[u8],
     idl: &Idl,
-    accounts: &[solana_sdk::instruction::AccountMeta],
+    accounts: &[AccountMeta],
 ) -> HashMap<String, String> {
     let mut named_accounts = HashMap::new();
 
@@ -143,12 +228,191 @@ struct SquadsParsedInstruction {
 fn build_parsed_fields(
     instruction: &SquadsParsedInstruction,
     program_id: &str,
+    context: &VisualizerContext,
 ) -> (
     String,
     Vec<AnnotatedPayloadField>,
     Vec<AnnotatedPayloadField>,
 ) {
     let parsed = &instruction.parsed;
+
+    // Special case: decode nested transaction message for vaultTransactionCreate
+    if parsed.instruction_name == "vaultTransactionCreate" {
+        if let Some(fields) = try_build_vault_transaction_fields(
+            parsed,
+            &instruction.named_accounts,
+            program_id,
+            context,
+        ) {
+            return fields;
+        }
+    }
+
+    build_generic_fields(parsed, &instruction.named_accounts, program_id)
+}
+
+/// Try to decode the nested transaction message inside vaultTransactionCreate.
+/// Returns None if decoding fails, falling through to generic display.
+fn try_build_vault_transaction_fields(
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+    program_id: &str,
+    context: &VisualizerContext,
+) -> Option<(
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+)> {
+    // Extract transactionMessage hex from the nested args struct
+    let args_value = parsed.program_call_args.get("args")?;
+    let tx_msg_hex = args_value.get("transactionMessage")?.as_str()?;
+    let tx_msg_bytes = hex::decode(tx_msg_hex).ok()?;
+    let vault_msg = VaultTransactionMessage::deserialize(&tx_msg_bytes).ok()?;
+
+    // Reconstruct full Instructions from the compiled instructions
+    let inner_instructions = reconstruct_instructions(&vault_msg);
+
+    // Visualize inner instructions using the full visualizer framework
+    let inner_fields = visualize_inner_instructions(&inner_instructions, context);
+
+    let vault_index = args_value
+        .get("vaultIndex")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let memo = args_value
+        .get("memo")
+        .and_then(|v| v.as_str())
+        .unwrap_or("None");
+
+    let inner_count = inner_instructions.len();
+    let title = format!("Squads Multisig: Vault Transaction ({inner_count} inner instruction(s))");
+
+    // Condensed: program, instruction, vault index, inner instruction count
+    let mut condensed_fields = vec![];
+    if let Ok(f) = create_text_field("Program", "Squads Multisig") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", "vaultTransactionCreate") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Vault Index", &vault_index.to_string()) {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field(
+        "Inner Instructions",
+        &format!("{inner_count} instruction(s)"),
+    ) {
+        condensed_fields.push(f);
+    }
+
+    // Expanded: full details + decoded inner instructions
+    let mut expanded_fields = vec![];
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", "vaultTransactionCreate") {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Discriminator", &parsed.discriminator) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Vault Index", &vault_index.to_string()) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Memo", memo) {
+        expanded_fields.push(f);
+    }
+
+    // Named accounts from the outer instruction
+    for (account_name, account_address) in named_accounts {
+        if let Ok(f) = create_text_field(account_name, account_address) {
+            expanded_fields.push(f);
+        }
+    }
+
+    // Decoded inner instructions
+    expanded_fields.extend(inner_fields);
+
+    Some((title, condensed_fields, expanded_fields))
+}
+
+/// Reconstruct Instruction objects from VaultTransactionMessage compiled instructions.
+/// Same pattern as core/instructions.rs:39-66.
+fn reconstruct_instructions(vault_msg: &VaultTransactionMessage) -> Vec<Instruction> {
+    let account_keys = &vault_msg.account_keys;
+
+    vault_msg
+        .instructions
+        .iter()
+        .filter_map(|ci| {
+            let program_id_idx = ci.program_id_index as usize;
+            if program_id_idx >= account_keys.len() {
+                return None;
+            }
+
+            let accounts: Vec<AccountMeta> = ci
+                .account_indexes
+                .iter()
+                .filter_map(|&i| {
+                    let idx = i as usize;
+                    if idx < account_keys.len() {
+                        Some(AccountMeta::new_readonly(account_keys[idx], false))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            Some(Instruction {
+                program_id: account_keys[program_id_idx],
+                accounts,
+                data: ci.data.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Visualize reconstructed inner instructions using the full visualizer framework.
+fn visualize_inner_instructions(
+    inner_instructions: &[Instruction],
+    context: &VisualizerContext,
+) -> Vec<AnnotatedPayloadField> {
+    let visualizers: Vec<Box<dyn InstructionVisualizer>> = available_visualizers();
+    let visualizers_refs: Vec<&dyn InstructionVisualizer> =
+        visualizers.iter().map(|v| v.as_ref()).collect();
+
+    let idl_registry = IdlRegistry::new();
+    let sender = SolanaAccount {
+        account_key: context.sender().account_key.clone(),
+        signer: false,
+        writable: false,
+    };
+
+    let instructions_vec: Vec<Instruction> = inner_instructions.to_vec();
+
+    instructions_vec
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, _)| {
+            let inner_context =
+                VisualizerContext::new(&sender, idx, &instructions_vec, &idl_registry);
+
+            visualize_with_any(&visualizers_refs, &inner_context)
+                .and_then(|result| result.ok())
+                .map(|viz_result| viz_result.field)
+        })
+        .collect()
+}
+
+fn build_generic_fields(
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
     let title = format!("Squads Multisig: {}", parsed.instruction_name);
 
     let mut condensed_fields = vec![];
@@ -178,14 +442,12 @@ fn build_parsed_fields(
         expanded_fields.push(f);
     }
 
-    // Named accounts
-    for (account_name, account_address) in &instruction.named_accounts {
+    for (account_name, account_address) in named_accounts {
         if let Ok(f) = create_text_field(account_name, account_address) {
             expanded_fields.push(f);
         }
     }
 
-    // Args
     for (key, value) in &parsed.program_call_args {
         if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
             expanded_fields.push(f);
@@ -290,5 +552,38 @@ mod tests {
         let accounts = vec![];
         let result = parse_squads_instruction(&short_data, &accounts);
         assert!(result.is_err(), "Short data should return error");
+    }
+
+    #[test]
+    fn test_vault_transaction_message_deserialization() {
+        // The transactionMessage hex from the sample transaction
+        let tx_msg_hex = "01010103904fc8953dcfc9f3b5179893ee12fc9c445cad889a957d61cfb8dbcc172f6a4f4a3eef4b03c82a71599ea07a16ee4bcf6dce31357d8460b2ac1bd4c3a9860c9d0954dbbe9ec960c98a7a293fe21336966fe180d151ae4b8179561f89854a53f601020200012800a1b028d53cb8b3e4ef5e27e0961546aad46749acc092e03c1a8c7c1187e887cc245db9cf2bca9a9900";
+        let tx_msg_bytes = hex::decode(tx_msg_hex).unwrap();
+        let vault_msg = VaultTransactionMessage::deserialize(&tx_msg_bytes).unwrap();
+
+        assert_eq!(
+            vault_msg.account_keys.len(),
+            3,
+            "Should have 3 account keys"
+        );
+        assert_eq!(
+            vault_msg.instructions.len(),
+            1,
+            "Should have 1 inner instruction"
+        );
+
+        let inner = &vault_msg.instructions[0];
+        assert!(
+            (inner.program_id_index as usize) < vault_msg.account_keys.len(),
+            "program_id_index should be valid"
+        );
+
+        let instructions = reconstruct_instructions(&vault_msg);
+        assert_eq!(instructions.len(), 1, "Should reconstruct 1 instruction");
+        // The inner instruction's program_id should be one of the account keys
+        assert!(
+            vault_msg.account_keys.contains(&instructions[0].program_id),
+            "Inner instruction program_id should be in account_keys"
+        );
     }
 }

--- a/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
@@ -1,0 +1,294 @@
+//! Squads v4 Multisig preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::SquadsMultisigConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const SQUADS_MULTISIG_PROGRAM_ID: &str = "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf";
+
+const SQUADS_IDL_JSON: &str = include_str!("squads_multisig_program.json");
+
+static SQUADS_MULTISIG_CONFIG: SquadsMultisigConfig = SquadsMultisigConfig;
+
+pub struct SquadsMultisigVisualizer;
+
+impl InstructionVisualizer for SquadsMultisigVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let instruction_data_hex = hex::encode(&instruction.data);
+        let fallback_text = format!(
+            "Program ID: {}\nData: {instruction_data_hex}",
+            instruction.program_id,
+        );
+
+        let parsed = parse_squads_instruction(&instruction.data, &instruction.accounts);
+
+        let (title, condensed_fields, expanded_fields) = match parsed {
+            Ok(parsed) => build_parsed_fields(&parsed, &instruction.program_id.to_string()),
+            Err(_) => build_fallback_fields(&instruction.program_id.to_string()),
+        };
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        let expanded_with_raw =
+            append_raw_data(expanded_fields, &instruction.data, &instruction_data_hex);
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_with_raw,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&SQUADS_MULTISIG_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Payments("SquadsMultisig")
+    }
+}
+
+fn get_squads_idl() -> Option<Idl> {
+    decode_idl_data(SQUADS_IDL_JSON).ok()
+}
+
+fn parse_squads_instruction(
+    data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> Result<SquadsParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_squads_idl().ok_or("Squads Multisig IDL not available")?;
+    let parsed = parse_instruction_with_idl(data, SQUADS_MULTISIG_PROGRAM_ID, &idl)?;
+
+    // Build named accounts by matching instruction accounts with IDL definitions
+    let named_accounts = build_named_accounts(data, &idl, accounts);
+
+    Ok(SquadsParsedInstruction {
+        parsed,
+        named_accounts,
+    })
+}
+
+fn build_named_accounts(
+    data: &[u8],
+    idl: &Idl,
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named_accounts = HashMap::new();
+
+    let idl_instruction = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.len() >= disc.len() && data[..disc.len()] == *disc)
+    });
+
+    if let Some(idl_instruction) = idl_instruction {
+        for (index, account_meta) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+            }
+        }
+    }
+
+    named_accounts
+}
+
+struct SquadsParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: HashMap<String, String>,
+}
+
+fn build_parsed_fields(
+    instruction: &SquadsParsedInstruction,
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let parsed = &instruction.parsed;
+    let title = format!("Squads Multisig: {}", parsed.instruction_name);
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    // Condensed: program name + instruction name + key args
+    if let Ok(f) = create_text_field("Program", "Squads Multisig") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        condensed_fields.push(f);
+    }
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            condensed_fields.push(f);
+        }
+    }
+
+    // Expanded: full details
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Discriminator", &parsed.discriminator) {
+        expanded_fields.push(f);
+    }
+
+    // Named accounts
+    for (account_name, account_address) in &instruction.named_accounts {
+        if let Ok(f) = create_text_field(account_name, account_address) {
+            expanded_fields.push(f);
+        }
+    }
+
+    // Args
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            expanded_fields.push(f);
+        }
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn build_fallback_fields(
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let title = "Squads Multisig: Unknown Instruction".to_string();
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    if let Ok(f) = create_text_field("Program", "Squads Multisig") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        condensed_fields.push(f);
+    }
+
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        expanded_fields.push(f);
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn append_raw_data(
+    mut fields: Vec<AnnotatedPayloadField>,
+    data: &[u8],
+    hex_str: &str,
+) -> Vec<AnnotatedPayloadField> {
+    if let Ok(f) = create_raw_data_field(data, Some(hex_str.to_string())) {
+        fields.push(f);
+    }
+    fields
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_squads_idl_loads() {
+        let idl = get_squads_idl();
+        assert!(idl.is_some(), "Squads IDL should load successfully");
+        let idl = idl.unwrap();
+        assert!(!idl.instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_squads_idl_has_discriminators() {
+        let idl = get_squads_idl().unwrap();
+        for instruction in &idl.instructions {
+            assert!(
+                instruction.discriminator.is_some(),
+                "Instruction '{}' should have a computed discriminator",
+                instruction.name
+            );
+            let disc = instruction.discriminator.as_ref().unwrap();
+            assert_eq!(
+                disc.len(),
+                8,
+                "Discriminator for '{}' should be 8 bytes",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        let accounts = vec![];
+        let result = parse_squads_instruction(&garbage_data, &accounts);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short_data = [0x01, 0x02, 0x03];
+        let accounts = vec![];
+        let result = parse_squads_instruction(&short_data, &accounts);
+        assert!(result.is_err(), "Short data should return error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/mod.rs
@@ -45,7 +45,9 @@ impl VaultTransactionMessage {
     /// Parse from Squads' compact wire format (mimics Solana Message serialization).
     /// Format: 3×u8 header, u8 account_keys count + pubkeys,
     ///         u8 instructions count + compiled instructions,
-    ///         u8 address_table_lookups count + lookups
+    ///         u8 address_table_lookups count + lookups.
+    /// Within compiled instructions, data length is encoded as u16 LE
+    /// (matching the Squads v4 on-chain format).
     fn deserialize(data: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
         let mut pos = 0;
 
@@ -55,6 +57,15 @@ impl VaultTransactionMessage {
             }
             let val = data[*pos];
             *pos += 1;
+            Ok(val)
+        };
+
+        let read_u16_le = |pos: &mut usize| -> Result<u16, Box<dyn std::error::Error>> {
+            if *pos + 2 > data.len() {
+                return Err("unexpected end of data".into());
+            }
+            let val = u16::from_le_bytes([data[*pos], data[*pos + 1]]);
+            *pos += 2;
             Ok(val)
         };
 
@@ -88,7 +99,7 @@ impl VaultTransactionMessage {
             let program_id_index = read_u8(&mut pos)?;
             let num_account_indexes = read_u8(&mut pos)? as usize;
             let account_indexes = read_bytes(&mut pos, num_account_indexes)?.to_vec();
-            let data_len = read_u8(&mut pos)? as usize;
+            let data_len = read_u16_le(&mut pos)? as usize;
             let instruction_data = read_bytes(&mut pos, data_len)?.to_vec();
             instructions.push(MultisigCompiledInstruction {
                 program_id_index,
@@ -173,8 +184,10 @@ impl InstructionVisualizer for SquadsMultisigVisualizer {
     }
 }
 
-fn get_squads_idl() -> Option<Idl> {
-    decode_idl_data(SQUADS_IDL_JSON).ok()
+fn get_squads_idl() -> Option<&'static Idl> {
+    static IDL: std::sync::LazyLock<Option<Idl>> =
+        std::sync::LazyLock::new(|| decode_idl_data(SQUADS_IDL_JSON).ok());
+    IDL.as_ref()
 }
 
 fn parse_squads_instruction(
@@ -186,9 +199,9 @@ fn parse_squads_instruction(
     }
 
     let idl = get_squads_idl().ok_or("Squads Multisig IDL not available")?;
-    let parsed = parse_instruction_with_idl(data, SQUADS_MULTISIG_PROGRAM_ID, &idl)?;
+    let parsed = parse_instruction_with_idl(data, SQUADS_MULTISIG_PROGRAM_ID, idl)?;
 
-    let named_accounts = build_named_accounts(data, &idl, accounts);
+    let named_accounts = build_named_accounts(data, idl, accounts);
 
     Ok(SquadsParsedInstruction {
         parsed,

--- a/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/squads_multisig_program.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/squads_multisig/squads_multisig_program.json
@@ -1,0 +1,3421 @@
+{
+  "version": "2.1.0",
+  "name": "squads_multisig_program",
+  "instructions": [
+    {
+      "name": "programConfigInit",
+      "docs": [
+        "Initialize the program config."
+      ],
+      "accounts": [
+        {
+          "name": "programConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "initializer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The hard-coded account that is used to initialize the program config once."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProgramConfigInitArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "programConfigSetAuthority",
+      "docs": [
+        "Set the `authority` parameter of the program config."
+      ],
+      "accounts": [
+        {
+          "name": "programConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProgramConfigSetAuthorityArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "programConfigSetMultisigCreationFee",
+      "docs": [
+        "Set the `multisig_creation_fee` parameter of the program config."
+      ],
+      "accounts": [
+        {
+          "name": "programConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProgramConfigSetMultisigCreationFeeArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "programConfigSetTreasury",
+      "docs": [
+        "Set the `treasury` parameter of the program config."
+      ],
+      "accounts": [
+        {
+          "name": "programConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProgramConfigSetTreasuryArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigCreate",
+      "docs": [
+        "Create a multisig."
+      ],
+      "accounts": [
+        {
+          "name": "null",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "multisigCreateV2",
+      "docs": [
+        "Create a multisig."
+      ],
+      "accounts": [
+        {
+          "name": "programConfig",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Global program config account."
+          ]
+        },
+        {
+          "name": "treasury",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The treasury where the creation fee is transferred to."
+          ]
+        },
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "createKey",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "An ephemeral signer that is used as a seed for the Multisig PDA.",
+            "Must be a signer to prevent front-running attack by someone else but the original creator."
+          ]
+        },
+        {
+          "name": "creator",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The creator of the multisig."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigCreateArgsV2"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigAddMember",
+      "docs": [
+        "Add a new member to the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigAddMemberArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigRemoveMember",
+      "docs": [
+        "Remove a member/key from the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigRemoveMemberArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigSetTimeLock",
+      "docs": [
+        "Set the `time_lock` config parameter for the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigSetTimeLockArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigChangeThreshold",
+      "docs": [
+        "Set the `threshold` config parameter for the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigChangeThresholdArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigSetConfigAuthority",
+      "docs": [
+        "Set the multisig `config_authority`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigSetConfigAuthorityArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigSetRentCollector",
+      "docs": [
+        "Set the multisig `rent_collector`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged or credited in case the multisig account needs to reallocate space,",
+            "for example when adding a new member or a spending limit.",
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigSetRentCollectorArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigAddSpendingLimit",
+      "docs": [
+        "Create a new spending limit for the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "spendingLimit",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigAddSpendingLimitArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "multisigRemoveSpendingLimit",
+      "docs": [
+        "Remove the spending limit from the controlled multisig."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "configAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Multisig `config_authority` that must authorize the configuration change."
+          ]
+        },
+        {
+          "name": "spendingLimit",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rentCollector",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "This is usually the same as `config_authority`, but can be a different account if needed."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "MultisigRemoveSpendingLimitArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "configTransactionCreate",
+      "docs": [
+        "Create a new config transaction."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the transaction."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the transaction account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ConfigTransactionCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "configTransactionExecute",
+      "docs": [
+        "Execute a config transaction.",
+        "The transaction must be `Approved`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The multisig account that owns the transaction."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "One of the multisig members with `Execute` permission."
+          ]
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The proposal account associated with the transaction."
+          ]
+        },
+        {
+          "name": "transaction",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The transaction to execute."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "isOptional": true,
+          "docs": [
+            "The account that will be charged/credited in case the config transaction causes space reallocation,",
+            "for example when adding a new member, adding or removing a spending limit.",
+            "This is usually the same as `member`, but can be a different account if needed."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "We might need it in case reallocation is needed."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vaultTransactionCreate",
+      "docs": [
+        "Create a new vault transaction."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the transaction."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the transaction account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "VaultTransactionCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "transactionBufferCreate",
+      "docs": [
+        "Create a transaction buffer account."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "transactionBuffer",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the transaction."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the transaction account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "TransactionBufferCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "transactionBufferClose",
+      "docs": [
+        "Close a transaction buffer account."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "transactionBuffer",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that created the TransactionBuffer."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transactionBufferExtend",
+      "docs": [
+        "Extend a transaction buffer account."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "transactionBuffer",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that created the TransactionBuffer."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "TransactionBufferExtendArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "vaultTransactionCreateFromBuffer",
+      "docs": [
+        "Create a new vault transaction from a completed transaction buffer.",
+        "Finalized buffer hash must match `final_buffer_hash`"
+      ],
+      "accounts": [
+        {
+          "name": "vaultTransactionCreate",
+          "accounts": [
+            {
+              "name": "multisig",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "transaction",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "creator",
+              "isMut": false,
+              "isSigner": true,
+              "docs": [
+                "The member of the multisig that is creating the transaction."
+              ]
+            },
+            {
+              "name": "rentPayer",
+              "isMut": true,
+              "isSigner": true,
+              "docs": [
+                "The payer for the transaction account rent."
+              ]
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "transactionBuffer",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": true,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "VaultTransactionCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "vaultTransactionExecute",
+      "docs": [
+        "Execute a vault transaction.",
+        "The transaction must be `Approved`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The proposal account associated with the transaction."
+          ]
+        },
+        {
+          "name": "transaction",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The transaction to execute."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "batchCreate",
+      "docs": [
+        "Create a new batch."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "batch",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the batch."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the batch account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "BatchCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "batchAddTransaction",
+      "docs": [
+        "Add a transaction to the batch."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Multisig account this batch belongs to."
+          ]
+        },
+        {
+          "name": "proposal",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The proposal account associated with the batch."
+          ]
+        },
+        {
+          "name": "batch",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "`VaultBatchTransaction` account to initialize and add to the `batch`."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Member of the multisig."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the batch transaction account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "BatchAddTransactionArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "batchExecuteTransaction",
+      "docs": [
+        "Execute a transaction from the batch."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Multisig account this batch belongs to."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "Member of the multisig."
+          ]
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The proposal account associated with the batch.",
+            "If `transaction` is the last in the batch, the `proposal` status will be set to `Executed`."
+          ]
+        },
+        {
+          "name": "batch",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "transaction",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "Batch transaction to execute."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "proposalCreate",
+      "docs": [
+        "Create a new multisig proposal."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The member of the multisig that is creating the proposal."
+          ]
+        },
+        {
+          "name": "rentPayer",
+          "isMut": true,
+          "isSigner": true,
+          "docs": [
+            "The payer for the proposal account rent."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProposalCreateArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "proposalActivate",
+      "docs": [
+        "Update status of a multisig proposal from `Draft` to `Active`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "member",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "proposalApprove",
+      "docs": [
+        "Approve a multisig proposal on behalf of the `member`.",
+        "The proposal must be `Active`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "member",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProposalVoteArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "proposalReject",
+      "docs": [
+        "Reject a multisig proposal on behalf of the `member`.",
+        "The proposal must be `Active`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "member",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProposalVoteArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "proposalCancel",
+      "docs": [
+        "Cancel a multisig proposal on behalf of the `member`.",
+        "The proposal must be `Approved`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "member",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProposalVoteArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "proposalCancelV2",
+      "docs": [
+        "Cancel a multisig proposal on behalf of the `member`.",
+        "The proposal must be `Approved`.",
+        "This was introduced to incorporate proper state update, as old multisig members",
+        "may have lingering votes, and the proposal size may need to be reallocated to",
+        "accommodate the new amount of cancel votes.",
+        "The previous implemenation still works if the proposal size is in line with the",
+        "threshold size."
+      ],
+      "accounts": [
+        {
+          "name": "proposalVote",
+          "accounts": [
+            {
+              "name": "multisig",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "member",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "proposal",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ProposalVoteArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "spendingLimitUse",
+      "docs": [
+        "Use a spending limit to transfer tokens from a multisig vault to a destination account."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "The multisig account the `spending_limit` is for."
+          ]
+        },
+        {
+          "name": "member",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spendingLimit",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The SpendingLimit account to use."
+          ]
+        },
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Multisig vault account to transfer tokens from."
+          ]
+        },
+        {
+          "name": "destination",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "Destination account to transfer tokens to."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "In case `spending_limit.mint` is SOL."
+          ]
+        },
+        {
+          "name": "mint",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "The mint of the tokens to transfer in case `spending_limit.mint` is an SPL token."
+          ]
+        },
+        {
+          "name": "vaultTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Multisig vault token account to transfer tokens from in case `spending_limit.mint` is an SPL token."
+          ]
+        },
+        {
+          "name": "destinationTokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "Destination token account in case `spending_limit.mint` is an SPL token."
+          ]
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true,
+          "docs": [
+            "In case `spending_limit.mint` is an SPL token."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "SpendingLimitUseArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "configTransactionAccountsClose",
+      "docs": [
+        "Closes a `ConfigTransaction` and the corresponding `Proposal`.",
+        "`transaction` can be closed if either:",
+        "- the `proposal` is in a terminal state: `Executed`, `Rejected`, or `Cancelled`.",
+        "- the `proposal` is stale."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the logic within `config_transaction_accounts_close` does the rest of the checks."
+          ]
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "ConfigTransaction corresponding to the `proposal`."
+          ]
+        },
+        {
+          "name": "rentCollector",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The rent collector."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vaultTransactionAccountsClose",
+      "docs": [
+        "Closes a `VaultTransaction` and the corresponding `Proposal`.",
+        "`transaction` can be closed if either:",
+        "- the `proposal` is in a terminal state: `Executed`, `Rejected`, or `Cancelled`.",
+        "- the `proposal` is stale and not `Approved`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the logic within `vault_transaction_accounts_close` does the rest of the checks."
+          ]
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "VaultTransaction corresponding to the `proposal`."
+          ]
+        },
+        {
+          "name": "rentCollector",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The rent collector."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vaultBatchTransactionAccountClose",
+      "docs": [
+        "Closes a `VaultBatchTransaction` belonging to the `batch` and `proposal`.",
+        "`transaction` can be closed if either:",
+        "- it's marked as executed within the `batch`;",
+        "- the `proposal` is in a terminal state: `Executed`, `Rejected`, or `Cancelled`.",
+        "- the `proposal` is stale and not `Approved`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "batch",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "`Batch` corresponding to the `proposal`."
+          ]
+        },
+        {
+          "name": "transaction",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "`VaultBatchTransaction` account to close.",
+            "The transaction must be the current last one in the batch."
+          ]
+        },
+        {
+          "name": "rentCollector",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The rent collector."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "batchAccountsClose",
+      "docs": [
+        "Closes Batch and the corresponding Proposal accounts for proposals in terminal states:",
+        "`Executed`, `Rejected`, or `Cancelled` or stale proposals that aren't `Approved`.",
+        "",
+        "This instruction is only allowed to be executed when all `VaultBatchTransaction` accounts",
+        "in the `batch` are already closed: `batch.size == 0`."
+      ],
+      "accounts": [
+        {
+          "name": "multisig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "proposal",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "the logic within `batch_accounts_close` does the rest of the checks."
+          ]
+        },
+        {
+          "name": "batch",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "`Batch` corresponding to the `proposal`."
+          ]
+        },
+        {
+          "name": "rentCollector",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The rent collector."
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Batch",
+      "docs": [
+        "Stores data required for serial execution of a batch of multisig vault transactions.",
+        "Vault transaction is a transaction that's executed on behalf of the multisig vault PDA",
+        "and wraps arbitrary Solana instructions, typically calling into other Solana programs.",
+        "The transactions themselves are stored in separate PDAs associated with the this account."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Member of the Multisig who submitted the batch."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "docs": [
+              "Index of this batch within the multisig transactions."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Index of the vault this batch belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultBump",
+            "docs": [
+              "Derivation bump of the vault PDA this batch belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "size",
+            "docs": [
+              "Number of transactions in the batch."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "executedTransactionIndex",
+            "docs": [
+              "Index of the last executed transaction within the batch.",
+              "0 means that no transactions have been executed yet."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultBatchTransaction",
+      "docs": [
+        "Stores data required for execution of one transaction from a batch."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "ephemeralSignerBumps",
+            "docs": [
+              "Derivation bumps for additional signers.",
+              "Some transactions require multiple signers. Often these additional signers are \"ephemeral\" keypairs",
+              "that are generated on the client with a sole purpose of signing the transaction and be discarded immediately after.",
+              "When wrapping such transactions into multisig ones, we replace these \"ephemeral\" signing keypairs",
+              "with PDAs derived from the transaction's `transaction_index` and controlled by the Multisig Program;",
+              "during execution the program includes the seeds of these PDAs into the `invoke_signed` calls,",
+              "thus \"signing\" on behalf of these PDAs."
+            ],
+            "type": "bytes"
+          },
+          {
+            "name": "message",
+            "docs": [
+              "data required for executing the transaction."
+            ],
+            "type": {
+              "defined": "VaultTransactionMessage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigTransaction",
+      "docs": [
+        "Stores data required for execution of a multisig configuration transaction.",
+        "Config transaction can perform a predefined set of actions on the Multisig PDA, such as adding/removing members,",
+        "changing the threshold, etc."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Member of the Multisig who submitted the transaction."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "docs": [
+              "Index of this transaction within the multisig."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump for the transaction seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "actions",
+            "docs": [
+              "Action to be performed on the multisig."
+            ],
+            "type": {
+              "vec": {
+                "defined": "ConfigAction"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Multisig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "createKey",
+            "docs": [
+              "Key that is used to seed the multisig PDA."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "configAuthority",
+            "docs": [
+              "The authority that can change the multisig config.",
+              "This is a very important parameter as this authority can change the members and threshold.",
+              "",
+              "The convention is to set this to `Pubkey::default()`.",
+              "In this case, the multisig becomes autonomous, so every config change goes through",
+              "the normal process of voting by the members.",
+              "",
+              "However, if this parameter is set to any other key, all the config changes for this multisig",
+              "will need to be signed by the `config_authority`. We call such a multisig a \"controlled multisig\"."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "threshold",
+            "docs": [
+              "Threshold for signatures."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "timeLock",
+            "docs": [
+              "How many seconds must pass between transaction voting settlement and execution."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "transactionIndex",
+            "docs": [
+              "Last transaction index. 0 means no transactions have been created."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "staleTransactionIndex",
+            "docs": [
+              "Last stale transaction index. All transactions up until this index are stale.",
+              "This index is updated when multisig config (members/threshold/time_lock) changes."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "rentCollector",
+            "docs": [
+              "The address where the rent for the accounts related to executed, rejected, or cancelled",
+              "transactions can be reclaimed. If set to `None`, the rent reclamation feature is turned off."
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump for the multisig PDA seed."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "members",
+            "docs": [
+              "Members of the multisig."
+            ],
+            "type": {
+              "vec": {
+                "defined": "Member"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfig",
+      "docs": [
+        "Global program configuration account."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority which can update the config."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "multisigCreationFee",
+            "docs": [
+              "The lamports amount charged for creating a new multisig account.",
+              "This fee is sent to the `treasury` account."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "treasury",
+            "docs": [
+              "The treasury account to send charged fees to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Reserved for future use."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Proposal",
+      "docs": [
+        "Stores the data required for tracking the status of a multisig proposal.",
+        "Each `Proposal` has a 1:1 association with a transaction account, e.g. a `VaultTransaction` or a `ConfigTransaction`;",
+        "the latter can be executed only after the `Proposal` has been approved and its time lock is released."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "transactionIndex",
+            "docs": [
+              "Index of the multisig transaction this proposal is associated with."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "The status of the transaction."
+            ],
+            "type": {
+              "defined": "ProposalStatus"
+            }
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "approved",
+            "docs": [
+              "Keys that have approved/signed."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "rejected",
+            "docs": [
+              "Keys that have rejected."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "cancelled",
+            "docs": [
+              "Keys that have cancelled (Approved only)."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpendingLimit",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "createKey",
+            "docs": [
+              "Key that is used to seed the SpendingLimit PDA."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "The index of the vault that the spending limit is for."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint the spending limit is for.",
+              "Pubkey::default() means SOL.",
+              "use NATIVE_MINT for Wrapped SOL."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The amount of tokens that can be spent in a period.",
+              "This amount is in decimals of the mint,",
+              "so 1 SOL would be `1_000_000_000` and 1 USDC would be `1_000_000`."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "period",
+            "docs": [
+              "The reset period of the spending limit.",
+              "When it passes, the remaining amount is reset, unless it's `Period::OneTime`."
+            ],
+            "type": {
+              "defined": "Period"
+            }
+          },
+          {
+            "name": "remainingAmount",
+            "docs": [
+              "The remaining amount of tokens that can be spent in the current period.",
+              "When reaches 0, the spending limit cannot be used anymore until the period reset."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastReset",
+            "docs": [
+              "Unix timestamp marking the last time the spending limit was reset (or created)."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "members",
+            "docs": [
+              "Members of the multisig that can use the spending limit.",
+              "In case a member is removed from the multisig, the spending limit will remain existent",
+              "(until explicitly deleted), but the removed member will not be able to use it anymore."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "destinations",
+            "docs": [
+              "The destination addresses the spending limit is allowed to sent funds to.",
+              "If empty, funds can be sent to any address."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransactionBuffer",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Member of the Multisig who created the TransactionBuffer."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "bufferIndex",
+            "docs": [
+              "Index to seed address derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Vault index of the transaction this buffer belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "finalBufferHash",
+            "docs": [
+              "Hash of the final assembled transaction message."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "finalBufferSize",
+            "docs": [
+              "The size of the final assembled transaction message."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "The buffer of the transaction message."
+            ],
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultTransaction",
+      "docs": [
+        "Stores data required for tracking the voting and execution status of a vault transaction.",
+        "Vault transaction is a transaction that's executed on behalf of the multisig vault PDA",
+        "and wraps arbitrary Solana instructions, typically calling into other Solana programs."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "multisig",
+            "docs": [
+              "The multisig this belongs to."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "Member of the Multisig who submitted the transaction."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "index",
+            "docs": [
+              "Index of this transaction within the multisig."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump for the transaction seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Index of the vault this transaction belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultBump",
+            "docs": [
+              "Derivation bump of the vault PDA this transaction belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "ephemeralSignerBumps",
+            "docs": [
+              "Derivation bumps for additional signers.",
+              "Some transactions require multiple signers. Often these additional signers are \"ephemeral\" keypairs",
+              "that are generated on the client with a sole purpose of signing the transaction and be discarded immediately after.",
+              "When wrapping such transactions into multisig ones, we replace these \"ephemeral\" signing keypairs",
+              "with PDAs derived from the MultisigTransaction's `transaction_index` and controlled by the Multisig Program;",
+              "during execution the program includes the seeds of these PDAs into the `invoke_signed` calls,",
+              "thus \"signing\" on behalf of these PDAs."
+            ],
+            "type": "bytes"
+          },
+          {
+            "name": "message",
+            "docs": [
+              "data required for executing the transaction."
+            ],
+            "type": {
+              "defined": "VaultTransactionMessage"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "BatchAddTransactionArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ephemeralSigners",
+            "docs": [
+              "Number of ephemeral signing PDAs required by the transaction."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "transactionMessage",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BatchCreateArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Index of the vault this transaction belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "memo",
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigTransactionCreateArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "actions",
+            "type": {
+              "vec": {
+                "defined": "ConfigAction"
+              }
+            }
+          },
+          {
+            "name": "memo",
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigAddSpendingLimitArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "createKey",
+            "docs": [
+              "Key that is used to seed the SpendingLimit PDA."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "The index of the vault that the spending limit is for."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint the spending limit is for."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The amount of tokens that can be spent in a period.",
+              "This amount is in decimals of the mint,",
+              "so 1 SOL would be `1_000_000_000` and 1 USDC would be `1_000_000`."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "period",
+            "docs": [
+              "The reset period of the spending limit.",
+              "When it passes, the remaining amount is reset, unless it's `Period::OneTime`."
+            ],
+            "type": {
+              "defined": "Period"
+            }
+          },
+          {
+            "name": "members",
+            "docs": [
+              "Members of the Spending Limit that can use it.",
+              "Don't have to be members of the multisig."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "destinations",
+            "docs": [
+              "The destination addresses the spending limit is allowed to sent funds to.",
+              "If empty, funds can be sent to any address."
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigAddMemberArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "newMember",
+            "type": {
+              "defined": "Member"
+            }
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigRemoveMemberArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oldMember",
+            "type": "publicKey"
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigChangeThresholdArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "newThreshold",
+            "type": "u16"
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigSetTimeLockArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timeLock",
+            "type": "u32"
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigSetConfigAuthorityArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigSetRentCollectorArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "rentCollector",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigCreateArgsV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configAuthority",
+            "docs": [
+              "The authority that can configure the multisig: add/remove members, change the threshold, etc.",
+              "Should be set to `None` for autonomous multisigs."
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "threshold",
+            "docs": [
+              "The number of signatures required to execute a transaction."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "members",
+            "docs": [
+              "The members of the multisig."
+            ],
+            "type": {
+              "vec": {
+                "defined": "Member"
+              }
+            }
+          },
+          {
+            "name": "timeLock",
+            "docs": [
+              "How many seconds must pass between transaction voting, settlement, and execution."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "rentCollector",
+            "docs": [
+              "The address where the rent for the accounts related to executed, rejected, or cancelled",
+              "transactions can be reclaimed. If set to `None`, the rent reclamation feature is turned off."
+            ],
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigRemoveSpendingLimitArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "memo",
+            "docs": [
+              "Memo is used for indexing only."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfigInitArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority that can configure the program config: change the treasury, etc."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "multisigCreationFee",
+            "docs": [
+              "The fee that is charged for creating a new multisig."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "treasury",
+            "docs": [
+              "The treasury where the creation fee is transferred to."
+            ],
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfigSetAuthorityArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "newAuthority",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfigSetMultisigCreationFeeArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "newMultisigCreationFee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfigSetTreasuryArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "newTreasury",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCreateArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "transactionIndex",
+            "docs": [
+              "Index of the multisig transaction this proposal is associated with."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "draft",
+            "docs": [
+              "Whether the proposal should be initialized with status `Draft`."
+            ],
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalVoteArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "memo",
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpendingLimitUseArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of tokens to transfer."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "decimals",
+            "docs": [
+              "Decimals of the token mint. Used for double-checking against incorrect order of magnitude of `amount`."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "memo",
+            "docs": [
+              "Memo used for indexing."
+            ],
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransactionBufferCreateArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bufferIndex",
+            "docs": [
+              "Index of the buffer account to seed the account derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Index of the vault this transaction belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "finalBufferHash",
+            "docs": [
+              "Hash of the final assembled transaction message."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "finalBufferSize",
+            "docs": [
+              "Final size of the buffer."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "buffer",
+            "docs": [
+              "Initial slice of the buffer."
+            ],
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransactionBufferExtendArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "buffer",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultTransactionCreateArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaultIndex",
+            "docs": [
+              "Index of the vault this transaction belongs to."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "ephemeralSigners",
+            "docs": [
+              "Number of ephemeral signing PDAs required by the transaction."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "transactionMessage",
+            "type": "bytes"
+          },
+          {
+            "name": "memo",
+            "type": {
+              "option": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Member",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": "publicKey"
+          },
+          {
+            "name": "permissions",
+            "type": {
+              "defined": "Permissions"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permissions",
+      "docs": [
+        "Bitmask for permissions."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mask",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultTransactionMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "numSigners",
+            "docs": [
+              "The number of signer pubkeys in the account_keys vec."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "numWritableSigners",
+            "docs": [
+              "The number of writable signer pubkeys in the account_keys vec."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "numWritableNonSigners",
+            "docs": [
+              "The number of writable non-signer pubkeys in the account_keys vec."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "accountKeys",
+            "docs": [
+              "Unique account pubkeys (including program IDs) required for execution of the tx.",
+              "The signer pubkeys appear at the beginning of the vec, with writable pubkeys first, and read-only pubkeys following.",
+              "The non-signer pubkeys follow with writable pubkeys first and read-only ones following.",
+              "Program IDs are also stored at the end of the vec along with other non-signer non-writable pubkeys:",
+              "",
+              "```plaintext",
+              "[pubkey1, pubkey2, pubkey3, pubkey4, pubkey5, pubkey6, pubkey7, pubkey8]",
+              "|---writable---|  |---readonly---|  |---writable---|  |---readonly---|",
+              "|------------signers-------------|  |----------non-singers-----------|",
+              "```"
+            ],
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "instructions",
+            "docs": [
+              "List of instructions making up the tx."
+            ],
+            "type": {
+              "vec": {
+                "defined": "MultisigCompiledInstruction"
+              }
+            }
+          },
+          {
+            "name": "addressTableLookups",
+            "docs": [
+              "List of address table lookups used to load additional accounts",
+              "for this transaction."
+            ],
+            "type": {
+              "vec": {
+                "defined": "MultisigMessageAddressTableLookup"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigCompiledInstruction",
+      "docs": [
+        "Concise serialization schema for instructions that make up a transaction.",
+        "Closely mimics the Solana transaction wire format."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "programIdIndex",
+            "type": "u8"
+          },
+          {
+            "name": "accountIndexes",
+            "docs": [
+              "Indices into the tx's `account_keys` list indicating which accounts to pass to the instruction."
+            ],
+            "type": "bytes"
+          },
+          {
+            "name": "data",
+            "docs": [
+              "Instruction data."
+            ],
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigMessageAddressTableLookup",
+      "docs": [
+        "Address table lookups describe an on-chain address lookup table to use",
+        "for loading more readonly and writable accounts into a transaction."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accountKey",
+            "docs": [
+              "Address lookup table account key."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "writableIndexes",
+            "docs": [
+              "List of indexes used to load writable accounts."
+            ],
+            "type": "bytes"
+          },
+          {
+            "name": "readonlyIndexes",
+            "docs": [
+              "List of indexes used to load readonly accounts."
+            ],
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Vote",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Approve"
+          },
+          {
+            "name": "Reject"
+          },
+          {
+            "name": "Cancel"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AddMember",
+            "fields": [
+              {
+                "name": "newMember",
+                "type": {
+                  "defined": "Member"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RemoveMember",
+            "fields": [
+              {
+                "name": "oldMember",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "ChangeThreshold",
+            "fields": [
+              {
+                "name": "newThreshold",
+                "type": "u16"
+              }
+            ]
+          },
+          {
+            "name": "SetTimeLock",
+            "fields": [
+              {
+                "name": "newTimeLock",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "AddSpendingLimit",
+            "fields": [
+              {
+                "name": "createKey",
+                "docs": [
+                  "Key that is used to seed the SpendingLimit PDA."
+                ],
+                "type": "publicKey"
+              },
+              {
+                "name": "vaultIndex",
+                "docs": [
+                  "The index of the vault that the spending limit is for."
+                ],
+                "type": "u8"
+              },
+              {
+                "name": "mint",
+                "docs": [
+                  "The token mint the spending limit is for."
+                ],
+                "type": "publicKey"
+              },
+              {
+                "name": "amount",
+                "docs": [
+                  "The amount of tokens that can be spent in a period.",
+                  "This amount is in decimals of the mint,",
+                  "so 1 SOL would be `1_000_000_000` and 1 USDC would be `1_000_000`."
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "period",
+                "docs": [
+                  "The reset period of the spending limit.",
+                  "When it passes, the remaining amount is reset, unless it's `Period::OneTime`."
+                ],
+                "type": {
+                  "defined": "Period"
+                }
+              },
+              {
+                "name": "members",
+                "docs": [
+                  "Members of the multisig that can use the spending limit.",
+                  "In case a member is removed from the multisig, the spending limit will remain existent",
+                  "(until explicitly deleted), but the removed member will not be able to use it anymore."
+                ],
+                "type": {
+                  "vec": "publicKey"
+                }
+              },
+              {
+                "name": "destinations",
+                "docs": [
+                  "The destination addresses the spending limit is allowed to sent funds to.",
+                  "If empty, funds can be sent to any address."
+                ],
+                "type": {
+                  "vec": "publicKey"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RemoveSpendingLimit",
+            "fields": [
+              {
+                "name": "spendingLimit",
+                "type": "publicKey"
+              }
+            ]
+          },
+          {
+            "name": "SetRentCollector",
+            "fields": [
+              {
+                "name": "newRentCollector",
+                "type": {
+                  "option": "publicKey"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalStatus",
+      "docs": [
+        "The status of a proposal.",
+        "Each variant wraps a timestamp of when the status was set."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Draft",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          },
+          {
+            "name": "Active",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          },
+          {
+            "name": "Rejected",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          },
+          {
+            "name": "Approved",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          },
+          {
+            "name": "Executing"
+          },
+          {
+            "name": "Executed",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          },
+          {
+            "name": "Cancelled",
+            "fields": [
+              {
+                "name": "timestamp",
+                "type": "i64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "Period",
+      "docs": [
+        "The reset period of the spending limit."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "OneTime"
+          },
+          {
+            "name": "Day"
+          },
+          {
+            "name": "Week"
+          },
+          {
+            "name": "Month"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "DuplicateMember",
+      "msg": "Found multiple members with the same pubkey"
+    },
+    {
+      "code": 6001,
+      "name": "EmptyMembers",
+      "msg": "Members array is empty"
+    },
+    {
+      "code": 6002,
+      "name": "TooManyMembers",
+      "msg": "Too many members, can be up to 65535"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidThreshold",
+      "msg": "Invalid threshold, must be between 1 and number of members with Vote permission"
+    },
+    {
+      "code": 6004,
+      "name": "Unauthorized",
+      "msg": "Attempted to perform an unauthorized action"
+    },
+    {
+      "code": 6005,
+      "name": "NotAMember",
+      "msg": "Provided pubkey is not a member of multisig"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidTransactionMessage",
+      "msg": "TransactionMessage is malformed."
+    },
+    {
+      "code": 6007,
+      "name": "StaleProposal",
+      "msg": "Proposal is stale"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidProposalStatus",
+      "msg": "Invalid proposal status"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidTransactionIndex",
+      "msg": "Invalid transaction index"
+    },
+    {
+      "code": 6010,
+      "name": "AlreadyApproved",
+      "msg": "Member already approved the transaction"
+    },
+    {
+      "code": 6011,
+      "name": "AlreadyRejected",
+      "msg": "Member already rejected the transaction"
+    },
+    {
+      "code": 6012,
+      "name": "AlreadyCancelled",
+      "msg": "Member already cancelled the transaction"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidNumberOfAccounts",
+      "msg": "Wrong number of accounts provided"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidAccount",
+      "msg": "Invalid account provided"
+    },
+    {
+      "code": 6015,
+      "name": "RemoveLastMember",
+      "msg": "Cannot remove last member"
+    },
+    {
+      "code": 6016,
+      "name": "NoVoters",
+      "msg": "Members don't include any voters"
+    },
+    {
+      "code": 6017,
+      "name": "NoProposers",
+      "msg": "Members don't include any proposers"
+    },
+    {
+      "code": 6018,
+      "name": "NoExecutors",
+      "msg": "Members don't include any executors"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidStaleTransactionIndex",
+      "msg": "`stale_transaction_index` must be <= `transaction_index`"
+    },
+    {
+      "code": 6020,
+      "name": "NotSupportedForControlled",
+      "msg": "Instruction not supported for controlled multisig"
+    },
+    {
+      "code": 6021,
+      "name": "TimeLockNotReleased",
+      "msg": "Proposal time lock has not been released"
+    },
+    {
+      "code": 6022,
+      "name": "NoActions",
+      "msg": "Config transaction must have at least one action"
+    },
+    {
+      "code": 6023,
+      "name": "MissingAccount",
+      "msg": "Missing account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidMint",
+      "msg": "Invalid mint"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidDestination",
+      "msg": "Invalid destination"
+    },
+    {
+      "code": 6026,
+      "name": "SpendingLimitExceeded",
+      "msg": "Spending limit exceeded"
+    },
+    {
+      "code": 6027,
+      "name": "DecimalsMismatch",
+      "msg": "Decimals don't match the mint"
+    },
+    {
+      "code": 6028,
+      "name": "UnknownPermission",
+      "msg": "Member has unknown permission"
+    },
+    {
+      "code": 6029,
+      "name": "ProtectedAccount",
+      "msg": "Account is protected, it cannot be passed into a CPI as writable"
+    },
+    {
+      "code": 6030,
+      "name": "TimeLockExceedsMaxAllowed",
+      "msg": "Time lock exceeds the maximum allowed (90 days)"
+    },
+    {
+      "code": 6031,
+      "name": "IllegalAccountOwner",
+      "msg": "Account is not owned by Multisig program"
+    },
+    {
+      "code": 6032,
+      "name": "RentReclamationDisabled",
+      "msg": "Rent reclamation is disabled for this multisig"
+    },
+    {
+      "code": 6033,
+      "name": "InvalidRentCollector",
+      "msg": "Invalid rent collector address"
+    },
+    {
+      "code": 6034,
+      "name": "ProposalForAnotherMultisig",
+      "msg": "Proposal is for another multisig"
+    },
+    {
+      "code": 6035,
+      "name": "TransactionForAnotherMultisig",
+      "msg": "Transaction is for another multisig"
+    },
+    {
+      "code": 6036,
+      "name": "TransactionNotMatchingProposal",
+      "msg": "Transaction doesn't match proposal"
+    },
+    {
+      "code": 6037,
+      "name": "TransactionNotLastInBatch",
+      "msg": "Transaction is not last in batch"
+    },
+    {
+      "code": 6038,
+      "name": "BatchNotEmpty",
+      "msg": "Batch is not empty"
+    },
+    {
+      "code": 6039,
+      "name": "SpendingLimitInvalidAmount",
+      "msg": "Invalid SpendingLimit amount"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidInstructionArgs",
+      "msg": "Invalid Instruction Arguments"
+    },
+    {
+      "code": 6041,
+      "name": "FinalBufferHashMismatch",
+      "msg": "Final message buffer hash doesnt match the expected hash"
+    },
+    {
+      "code": 6042,
+      "name": "FinalBufferSizeExceeded",
+      "msg": "Final buffer size cannot exceed 4000 bytes"
+    },
+    {
+      "code": 6043,
+      "name": "FinalBufferSizeMismatch",
+      "msg": "Final buffer size mismatch"
+    },
+    {
+      "code": 6044,
+      "name": "MultisigCreateDeprecated",
+      "msg": "multisig_create has been deprecated. Use multisig_create_v2 instead."
+    }
+  ],
+  "metadata": {
+    "address": "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf",
+    "origin": "anchor",
+    "binaryVersion": "0.29.0",
+    "libVersion": "=0.29.0"
+  }
+}


### PR DESCRIPTION
## Summary
Stacks Squads Multisig (#240) + Drift (#239) presets to fully decode the April 1 2026 Drift Protocol exploit transaction.

Depends on:
- #240 — Squads v4 Multisig visualizer (with `data_len` u16 LE fix)
- #239 — Drift Protocol visualizer preset

### What the parser reveals

The $285M Drift exploit used two pre-signed durable nonce transactions. The parser fully decodes both:

**Transaction 1 — Create + Approve (signer 1)**
https://solscan.io/tx/2HvMSgDEfKhNryYZKhjowrBY55rUx5MWtcWkG9hqxZCFBaTiahPwfynP1dxBSRk9s5UTVc8LFeS4Btvkm9pc2C4H
```
1. AdvanceNonceAccount          — activates durable nonce
2. vaultTransactionCreate       — Squads multisig wrapping inner Drift: updateAdmin
   └─ Inner: Drift updateAdmin  — Current admin: AiLGd...  →  New admin: H7PiG...
3. proposalCreate               — creates governance proposal (transactionIndex: 7)
4. proposalApprove              — first signer approves
```

**Transaction 2 — Approve + Execute (signer 2)**
https://solscan.io/tx/4BKBmAJn6TdsENij7CsVbyMVLJU1tX27nfrMM1zgKv1bs2KJy6Am2NqdA3nJm4g9C6eC64UAf5sNs974ygB9RsN1
```
1. AdvanceNonceAccount          — activates durable nonce
2. proposalApprove              — second signer approves (reaches 2-of-5 threshold)
3. vaultTransactionExecute      — executes the stored vault transaction
```

### Defense point

The critical signing moment is **Transaction 1**. The parser decodes the nested `vaultTransactionCreate` and reveals `Drift: updateAdmin` with the new admin address — a signer reviewing this in a wallet would see the admin transfer before approving.

By Transaction 2, the inner instructions are already stored on-chain (not in the tx bytes), so `vaultTransactionExecute` only shows a reference to the vault transaction account. The defense must happen at Tx 1.

### Key fixes discovered during this POC
- `VaultTransactionMessage::deserialize` was reading instruction `data_len` as u8 instead of u16 LE, causing a 1-byte offset that made inner instruction discriminators unmatchable
- Disambiguated "Current admin" vs "New admin" labels when IDL account and arg names collide

## Test plan
- [x] All workspace tests pass
- [x] `parser_cli` correctly decodes both exploit transactions
- [x] Inner `updateAdmin` shows current and new admin addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)