### PR TITLE
style: move use imports to module top in lib_test.rs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Raw tx bytes → ChainPlugin (CLI) or gRPC request
 - Fixture-based snapshot tests: `tests/fixtures/{name}.input` + `{name}.expected` pairs per chain crate
 - Integration tests in `integration/tests/` use gRPC client against built binaries
 - `test_utils` module in `visualsign` provides shared test helpers
+- Place all `use` imports at the top of the test module, not inside individual test functions
 
 ### Local Dev Container
 

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -1,3 +1,7 @@
+use alloy_consensus::TxEip1559;
+use alloy_primitives::U256;
+use alloy_rlp::Encodable;
+use alloy_sol_types::{SolCall, sol};
 use generated::parser::{Abi, ChainMetadata, EthereumMetadata, chain_metadata::Metadata};
 use std::collections::HashMap;
 use std::fs;
@@ -165,9 +169,6 @@ fn test_abi_from_metadata_decodes_function() {
     // We use an ERC-20 transfer calldata (selector 0xa9059cbb) sent to a contract
     // address that is NOT in the built-in visualizer registry, so the dynamic ABI
     // path via metadata is the only way the function name can appear in the output.
-    use alloy_primitives::U256;
-    use alloy_sol_types::{SolCall, sol};
-
     sol! {
         function transfer(address to, uint256 amount) external returns (bool);
     }
@@ -186,7 +187,6 @@ fn test_abi_from_metadata_decodes_function() {
         .parse()
         .unwrap();
 
-    use alloy_consensus::TxEip1559;
     let tx = TxEip1559 {
         chain_id: 1,
         nonce: 0,
@@ -199,7 +199,6 @@ fn test_abi_from_metadata_decodes_function() {
     };
 
     // RLP-encode as unsigned EIP-1559 (type 0x02)
-    use alloy_rlp::Encodable;
     let mut buf = Vec::new();
     buf.push(0x02); // EIP-1559 type byte
     tx.encode(&mut buf);


### PR DESCRIPTION
## Summary
- Moves 4 inline `use` statements from inside `test_abi_from_metadata_decodes_function` to the module-level import block, addressing Prasanna's review comments on #216
- Adds import placement convention to `CLAUDE.md` Testing Patterns section

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — passes
- [x] `cargo test -p visualsign-ethereum` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)