### PR TITLE
ci: add parser_cli to StageX build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
         with:
           components: clippy, rustfmt
+          cache: false
 
       - name: Cache Rust dependencies
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -12,16 +12,15 @@ on:
       - "images/**"
       - "Makefile"
   pull_request:
-    paths:
-      - ".github/**"
-      - "src/**"
-      - "images/**"
-      - "Makefile"
+    types: [labeled]
   workflow_dispatch: # Allows manual invocation
 
 jobs:
   parser:
-    name: Build parser images
+    name: Build ${{ matrix.target.label || matrix.target.name }}
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.label.name == 'stagex'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -37,6 +36,8 @@ jobs:
       matrix:
         target:
           - name: parser_app
+          - name: parser_cli
+            label: "parser_cli (Solana)"
           - name: parser_gateway
     steps:
       - name: Checkout sources
@@ -47,7 +48,6 @@ jobs:
         uses: ./.github/actions/docker-setup
         with:
           dockerHub: ${{ secrets.DOCKERHUB_API_KEY }}
-          ghcr: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ${{ matrix.target.name }}
         shell: bash
@@ -57,6 +57,10 @@ jobs:
       - name: Load artifact to Docker
         run: |
           env -C out/${{ matrix.target.name }} tar -cf - . | docker load
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload to GHCR
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ out/parser_app/index.json: \
 	$(shell git ls-files images/parser_app src)
 	$(call build,parser_app)
 
+out/parser_cli/index.json: \
+	$(shell git ls-files images/parser_cli src)
+	$(call build,parser_cli)
+
 out/parser_gateway/index.json: \
 	$(shell git ls-files images/parser_gateway src)
 	$(call build,parser_gateway)

--- a/images/parser_cli/Containerfile
+++ b/images/parser_cli/Containerfile
@@ -1,0 +1,28 @@
+FROM stagex/pallet-rust:1.88.0@sha256:b9021d2b75eac64fe8b931d96dde63ef11792e5023cee77c3471ccc34a95a377 AS build
+
+# Rust configuration
+ENV RUSTFLAGS='-C target-feature=+crt-static'
+ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locked --release'
+
+# Directory for Rust artifacts
+ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
+
+# Load Rust sources
+ADD src /src
+WORKDIR /src/
+
+# pre-fetch all workspace deps; we need them to build with `--network=none` later
+RUN cargo fetch
+
+WORKDIR /src/parser/cli
+RUN --network=none <<-EOF
+    set -eu
+    cargo test ${CARGOFLAGS} --features solana
+    cargo build ${CARGOFLAGS} --features solana
+    mkdir -p /rootfs/usr/local/bin
+    mv ${RELEASE_DIR}/parser_cli /rootfs/usr/local/bin/
+EOF
+
+# Use busybox as a base so we can easily cp the pivot binary if needed
+FROM stagex/core-busybox:1.36.1@sha256:cac5d773db1c69b832d022c469ccf5f52daf223b91166e6866d42d6983a3b374 AS package
+COPY --from=build /rootfs/. .


### PR DESCRIPTION
## Summary

- Add `images/parser_cli/Containerfile` for Solana-only CLI build using StageX
- Add `parser_cli` target to `Makefile` and `stagex.yml` matrix
- **Incorporates PR #226**: stagex PR builds now require the `stagex` label instead of auto-triggering on path changes; GHCR login moved after build; disable setup-rust-toolchain built-in cache in main.yml

Replaces #232 (rebased). Stacked on #224.

## Test plan

- [ ] StageX build passes for `parser_cli` in CI (add `stagex` label to trigger)
- [ ] Existing `parser_app` and `parser_gateway` builds unaffected
- [ ] Push to main with relevant path changes still triggers the build
- [ ] GHCR push still works on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)