### PR TITLE
ci: add surfpool integration workflow

### DIFF
--- a/.github/workflows/surfpool-solana.yml
+++ b/.github/workflows/surfpool-solana.yml
@@ -1,0 +1,64 @@
+name: "Surfpool Integration: Solana"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  surfpool:
+    if: contains(github.event.pull_request.labels.*.name, 'surfpool')
+    runs-on: ubuntu-latest-4-cores
+    permissions:
+      pull-requests: write
+    steps:
+      - name: git checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
+        with:
+          components: clippy, rustfmt
+      - name: Cache Rust dependencies
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src/target/
+          key: ${{ runner.os }}-cargo-surfpool-${{ hashFiles('src/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-surfpool-
+            ${{ runner.os }}-cargo-
+      - name: Install surfpool
+        run: cargo install surfpool --git https://github.com/txtx/surfpool --locked
+      - name: install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "21.4"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          df -h
+      - name: Run codegen
+        run: make -C src generated
+      - name: Run surfpool integration tests
+        id: surfpool
+        continue-on-error: true
+        env:
+          HELIUS_API_KEY: ${{ secrets.HELIUS_API_KEY }}
+        run: ./scripts/surfpool_fuzz_all_idls.sh
+      - name: Label PR on surfpool failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ steps.surfpool.outcome }}" = "failure" ]; then
+            gh pr edit "$PR_NUMBER" --add-label surfpool-failure || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label surfpool-failure || true
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/surfpool-solana.yml` triggered by the `surfpool` PR label
- Runs `surfpool_fuzz_all_idls.sh` against all 15 embedded IDLs
- Applies `surfpool-failure` label on failure, removes it on success
- Requires `HELIUS_API_KEY` repo secret for reliable mainnet RPC access

Stacked on #202.

## Test plan

- [ ] Verify workflow triggers when `surfpool` label is applied to a PR
- [ ] Confirm `surfpool-failure` label is applied/removed based on test outcome
- [ ] Ensure `HELIUS_API_KEY` secret is configured as a repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)