### PR TITLE
feat: add Kamino Vault and Kamino Farms visualizer presets

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/config.rs
@@ -1,0 +1,22 @@
+use super::KAMINO_FARMS_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct KaminoFarmsConfig;
+
+impl SolanaIntegrationConfig for KaminoFarmsConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(KAMINO_FARMS_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/kamino_farms.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/kamino_farms.json
@@ -1,0 +1,2163 @@
+{
+  "version": "1.6.5",
+  "name": "farms",
+  "instructions": [
+    {
+      "name": "initializeGlobalConfig",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "treasuryVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateGlobalConfig",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        },
+        {
+          "name": "value",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "initializeFarm",
+      "accounts": [
+        {
+          "name": "farmAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeFarmDelegated",
+      "accounts": [
+        {
+          "name": "farmAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmDelegate",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initializeReward",
+      "accounts": [
+        {
+          "name": "farmAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rewardTreasuryVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "treasuryVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "addRewards",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rewardMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "payerRewardTokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "rewardIndex",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateFarmConfig",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u16"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "initializeUser",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegatee",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transferOwnership",
+      "accounts": [
+        {
+          "name": "oldOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "newOwner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oldUserState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newUserState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "rewardUserOnce",
+      "accounts": [
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "rewardIndex",
+          "type": "u64"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "expectedRewardIssuedUnclaimed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "refreshFarm",
+      "accounts": [
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "stake",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "setStakeDelegated",
+      "accounts": [
+        {
+          "name": "delegateAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "newAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "harvestReward",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userRewardTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rewardsVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rewardsTreasuryVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "rewardIndex",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "unstake",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "stakeSharesScaled",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "refreshUserState",
+      "accounts": [
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawUnstakedDeposits",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawTreasury",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardTreasuryVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "treasuryVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawDestinationTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositToFarmVault",
+      "accounts": [
+        {
+          "name": "depositor",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "depositorAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawFromFarmVault",
+      "accounts": [
+        {
+          "name": "withdrawAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawerTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawSlashedAmount",
+      "accounts": [
+        {
+          "name": "crank",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "slashedAmountSpillAddress",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateFarmAdmin",
+      "accounts": [
+        {
+          "name": "pendingFarmAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateGlobalConfigAdmin",
+      "accounts": [
+        {
+          "name": "pendingGlobalAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawReward",
+      "accounts": [
+        {
+          "name": "farmAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rewardMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rewardVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmVaultsAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "adminRewardTokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "rewardIndex",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "updateSecondDelegatedAuthority",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "newSecondDelegatedAuthority",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "idlMissingTypes",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "globalConfigOptionKind",
+          "type": {
+            "defined": "GlobalConfigOption"
+          }
+        },
+        {
+          "name": "farmConfigOptionKind",
+          "type": {
+            "defined": "FarmConfigOption"
+          }
+        },
+        {
+          "name": "timeUnit",
+          "type": {
+            "defined": "TimeUnit"
+          }
+        },
+        {
+          "name": "lockingMode",
+          "type": {
+            "defined": "LockingMode"
+          }
+        },
+        {
+          "name": "rewardType",
+          "type": {
+            "defined": "RewardType"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "FarmState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "farmAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "globalConfig",
+            "type": "publicKey"
+          },
+          {
+            "name": "token",
+            "type": {
+              "defined": "TokenInfo"
+            }
+          },
+          {
+            "name": "rewardInfos",
+            "type": {
+              "array": [
+                {
+                  "defined": "RewardInfo"
+                },
+                10
+              ]
+            }
+          },
+          {
+            "name": "numRewardTokens",
+            "type": "u64"
+          },
+          {
+            "name": "numUsers",
+            "docs": [
+              "Data used to calculate the rewards of the user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalStakedAmount",
+            "docs": [
+              "The number of token in the `farm_vault` staked (getting rewards and fees)",
+              "Set such as `farm_vault.amount = total_staked_amount + total_pending_amount`"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "farmVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmVaultsAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmVaultsAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "delegateAuthority",
+            "docs": [
+              "Only used for delegate farms",
+              "Set to `default()` otherwise"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "timeUnit",
+            "docs": [
+              "Raw representation of a `TimeUnit`",
+              "Seconds = 0, Slots = 1"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "isFarmFrozen",
+            "docs": [
+              "Automatically set to true in case of a full authority withdrawal",
+              "If true, the farm is frozen and no more deposits are allowed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "isFarmDelegated",
+            "docs": [
+              "Indicates if the farm is a delegate farm",
+              "If true, the farm is a delegate farm and the `delegate_authority` is set*"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "isRewardUserOnceEnabled",
+            "docs": [
+              "If set to 1, indicates that the \"reward user once\" feature is enabled"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "isHarvestingPermissionless",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "withdrawAuthority",
+            "docs": [
+              "Withdraw authority for the farm, allowed to lock deposited funds and withdraw them",
+              "Set to `default()` if unused (only the depositors can withdraw their funds)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "depositWarmupPeriod",
+            "docs": [
+              "Delay between a user deposit and the moment it is considered as staked",
+              "0 if unused"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "withdrawalCooldownPeriod",
+            "docs": [
+              "Delay between a user unstake and the ability to withdraw his deposit."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "totalActiveStakeScaled",
+            "docs": [
+              "Total active stake of tokens in the farm (scaled from `Decimal` representation)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalPendingStakeScaled",
+            "docs": [
+              "Total pending stake of tokens in the farm (scaled from `Decimal` representation).",
+              "(can be used by `withdraw_authority` but don't get rewards or fees)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "totalPendingAmount",
+            "docs": [
+              "Total pending amount of tokens in the farm"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "slashedAmountCurrent",
+            "docs": [
+              "Slashed amounts from early withdrawal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "slashedAmountCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "slashedAmountSpillAddress",
+            "type": "publicKey"
+          },
+          {
+            "name": "lockingMode",
+            "docs": [
+              "Locking stake"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lockingStartTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "lockingDuration",
+            "type": "u64"
+          },
+          {
+            "name": "lockingEarlyWithdrawalPenaltyBps",
+            "type": "u64"
+          },
+          {
+            "name": "depositCapAmount",
+            "type": "u64"
+          },
+          {
+            "name": "scopePrices",
+            "type": "publicKey"
+          },
+          {
+            "name": "scopeOraclePriceId",
+            "type": "u64"
+          },
+          {
+            "name": "scopeOracleMaxAge",
+            "type": "u64"
+          },
+          {
+            "name": "pendingFarmAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "strategyId",
+            "type": "publicKey"
+          },
+          {
+            "name": "delegatedRpsAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "vaultId",
+            "type": "publicKey"
+          },
+          {
+            "name": "secondDelegatedAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                74
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "globalAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "treasuryFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "treasuryVaultsAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "treasuryVaultsAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "pendingGlobalAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u128",
+                126
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "userId",
+            "type": "u64"
+          },
+          {
+            "name": "farmState",
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "isFarmDelegated",
+            "docs": [
+              "Indicate if this user state is part of a delegated farm"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "rewardsTallyScaled",
+            "docs": [
+              "Rewards tally used for computation of gained rewards",
+              "(scaled from `Decimal` representation)."
+            ],
+            "type": {
+              "array": [
+                "u128",
+                10
+              ]
+            }
+          },
+          {
+            "name": "rewardsIssuedUnclaimed",
+            "docs": [
+              "Number of reward tokens ready for claim"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          },
+          {
+            "name": "lastClaimTs",
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          },
+          {
+            "name": "activeStakeScaled",
+            "docs": [
+              "User stake deposited and usable, generating rewards and fees.",
+              "(scaled from `Decimal` representation)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeScaled",
+            "docs": [
+              "User stake deposited but not usable and not generating rewards yet.",
+              "(scaled from `Decimal` representation)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeTs",
+            "docs": [
+              "After this timestamp, pending user stake can be moved to user stake",
+              "Initialized to now() + delayed user stake period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pendingWithdrawalUnstakeScaled",
+            "docs": [
+              "User deposits unstaked, pending for withdrawal, not usable and not generating rewards.",
+              "(scaled from `Decimal` representation)."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pendingWithdrawalUnstakeTs",
+            "docs": [
+              "After this timestamp, user can withdraw their deposit."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "User bump used for account address validation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "delegatee",
+            "docs": [
+              "Delegatee used for initialisation - useful to check against"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "lastStakeTs",
+            "type": "u64"
+          },
+          {
+            "name": "rewardsIssuedCumulative",
+            "docs": [
+              "Cumulative rewards issued to the user - ONLY used for stats/analytics",
+              "DO NOT USE IN ANY CALCULATIONS",
+              "Old userStates will have this field populated only from the point of release",
+              "not reflecting any historical data before this was released"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                40
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OraclePrices",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracleMappings",
+            "type": "publicKey"
+          },
+          {
+            "name": "prices",
+            "type": {
+              "array": [
+                {
+                  "defined": "DatedPrice"
+                },
+                512
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "FarmConfigOption",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateRewardRps"
+          },
+          {
+            "name": "UpdateRewardMinClaimDuration"
+          },
+          {
+            "name": "WithdrawAuthority"
+          },
+          {
+            "name": "DepositWarmupPeriod"
+          },
+          {
+            "name": "WithdrawCooldownPeriod"
+          },
+          {
+            "name": "RewardType"
+          },
+          {
+            "name": "RpsDecimals"
+          },
+          {
+            "name": "LockingMode"
+          },
+          {
+            "name": "LockingStartTimestamp"
+          },
+          {
+            "name": "LockingDuration"
+          },
+          {
+            "name": "LockingEarlyWithdrawalPenaltyBps"
+          },
+          {
+            "name": "DepositCapAmount"
+          },
+          {
+            "name": "SlashedAmountSpillAddress"
+          },
+          {
+            "name": "ScopePricesAccount"
+          },
+          {
+            "name": "ScopeOraclePriceId"
+          },
+          {
+            "name": "ScopeOracleMaxAge"
+          },
+          {
+            "name": "UpdateRewardScheduleCurvePoints"
+          },
+          {
+            "name": "UpdatePendingFarmAdmin"
+          },
+          {
+            "name": "UpdateStrategyId"
+          },
+          {
+            "name": "UpdateDelegatedRpsAdmin"
+          },
+          {
+            "name": "UpdateVaultId"
+          },
+          {
+            "name": "UpdateExtraDelegatedAuthority"
+          },
+          {
+            "name": "UpdateIsRewardUserOnceEnabled"
+          },
+          {
+            "name": "UpdateDelegatedAuthority"
+          },
+          {
+            "name": "UpdateIsHarvestingPermissionless"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfigOption",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SetPendingGlobalAdmin"
+          },
+          {
+            "name": "SetTreasuryFeeBps"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockingMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Continuous"
+          },
+          {
+            "name": "WithExpiry"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token",
+            "type": {
+              "defined": "TokenInfo"
+            }
+          },
+          {
+            "name": "rewardsVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "rewardsAvailable",
+            "type": "u64"
+          },
+          {
+            "name": "rewardScheduleCurve",
+            "type": {
+              "defined": "RewardScheduleCurve"
+            }
+          },
+          {
+            "name": "minClaimDurationSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "lastIssuanceTs",
+            "type": "u64"
+          },
+          {
+            "name": "rewardsIssuedUnclaimed",
+            "type": "u64"
+          },
+          {
+            "name": "rewardsIssuedCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "rewardPerShareScaled",
+            "type": "u128"
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "name": "rewardType",
+            "type": "u8"
+          },
+          {
+            "name": "rewardsPerSecondDecimals",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardPerTimeUnitPoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tsStart",
+            "type": "u64"
+          },
+          {
+            "name": "rewardPerTimeUnit",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardScheduleCurve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "points",
+            "docs": [
+              "This is a stepwise function, meaning that each point represents",
+              "how many rewards are issued per time unit since the beginning",
+              "of that point until the beginning of the next point.",
+              "This is not a linear curve, there is no interpolation going on.",
+              "A curve can be [[t0, 100], [t1, 50], [t2, 0]]",
+              "meaning that from t0 to t1, 100 rewards are issued per time unit,",
+              "from t1 to t2, 50 rewards are issued per time unit, and after t2 it stops",
+              "Another curve, can be [[t0, 100], [u64::max, 0]]",
+              "meaning that from t0 to u64::max, 100 rewards are issued per time unit"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "RewardPerTimeUnitPoint"
+                },
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Proportional"
+          },
+          {
+            "name": "Constant"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TimeUnit",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Seconds"
+          },
+          {
+            "name": "Slots"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "decimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DatedPrice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": {
+              "defined": "Price"
+            }
+          },
+          {
+            "name": "lastUpdatedSlot",
+            "type": "u64"
+          },
+          {
+            "name": "unixTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "reserved2",
+            "type": {
+              "array": [
+                "u16",
+                3
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Price",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "StakeZero",
+      "msg": "Cannot stake 0 amount"
+    },
+    {
+      "code": 6001,
+      "name": "UnstakeZero",
+      "msg": "Cannot unstake 0 amount"
+    },
+    {
+      "code": 6002,
+      "name": "NothingToUnstake",
+      "msg": "Nothing to unstake"
+    },
+    {
+      "code": 6003,
+      "name": "NoRewardToHarvest",
+      "msg": "No reward to harvest"
+    },
+    {
+      "code": 6004,
+      "name": "NoRewardInList",
+      "msg": "Reward not present in reward list"
+    },
+    {
+      "code": 6005,
+      "name": "RewardAlreadyInitialized",
+      "msg": "Reward already initialized"
+    },
+    {
+      "code": 6006,
+      "name": "MaxRewardNumberReached",
+      "msg": "Max number of reward tokens reached"
+    },
+    {
+      "code": 6007,
+      "name": "RewardDoesNotExist",
+      "msg": "Reward does not exist"
+    },
+    {
+      "code": 6008,
+      "name": "WrongRewardVaultAccount",
+      "msg": "Reward vault exists but the account is wrong"
+    },
+    {
+      "code": 6009,
+      "name": "RewardVaultMismatch",
+      "msg": "Reward vault pubkey does not match staking pool vault"
+    },
+    {
+      "code": 6010,
+      "name": "RewardVaultAuthorityMismatch",
+      "msg": "Reward vault authority pubkey does not match staking pool vault"
+    },
+    {
+      "code": 6011,
+      "name": "NothingStaked",
+      "msg": "Nothing staked, cannot collect any rewards"
+    },
+    {
+      "code": 6012,
+      "name": "IntegerOverflow",
+      "msg": "Integer overflow"
+    },
+    {
+      "code": 6013,
+      "name": "ConversionFailure",
+      "msg": "Conversion failure"
+    },
+    {
+      "code": 6014,
+      "name": "UnexpectedAccount",
+      "msg": "Unexpected account in instruction"
+    },
+    {
+      "code": 6015,
+      "name": "OperationForbidden",
+      "msg": "Operation forbidden"
+    },
+    {
+      "code": 6016,
+      "name": "MathOverflow",
+      "msg": "Mathematical operation with overflow"
+    },
+    {
+      "code": 6017,
+      "name": "MinClaimDurationNotReached",
+      "msg": "Minimum claim duration has not been reached"
+    },
+    {
+      "code": 6018,
+      "name": "RewardsVaultHasDelegate",
+      "msg": "Reward vault has a delegate"
+    },
+    {
+      "code": 6019,
+      "name": "RewardsVaultHasCloseAuthority",
+      "msg": "Reward vault has a close authority"
+    },
+    {
+      "code": 6020,
+      "name": "FarmVaultHasDelegate",
+      "msg": "Farm vault has a delegate"
+    },
+    {
+      "code": 6021,
+      "name": "FarmVaultHasCloseAuthority",
+      "msg": "Farm vault has a close authority"
+    },
+    {
+      "code": 6022,
+      "name": "RewardsTreasuryVaultHasDelegate",
+      "msg": "Reward vault has a delegate"
+    },
+    {
+      "code": 6023,
+      "name": "RewardsTreasuryVaultHasCloseAuthority",
+      "msg": "Reward vault has a close authority"
+    },
+    {
+      "code": 6024,
+      "name": "UserAtaRewardVaultMintMissmatch",
+      "msg": "User ata and reward vault have different mints"
+    },
+    {
+      "code": 6025,
+      "name": "UserAtaFarmTokenMintMissmatch",
+      "msg": "User ata and farm token have different mints"
+    },
+    {
+      "code": 6026,
+      "name": "TokenFarmTokenMintMissmatch",
+      "msg": "Token mint and farm token have different mints"
+    },
+    {
+      "code": 6027,
+      "name": "RewardAtaRewardMintMissmatch",
+      "msg": "Reward ata mint is different than reward mint"
+    },
+    {
+      "code": 6028,
+      "name": "RewardAtaOwnerNotPayer",
+      "msg": "Reward ata owner is different than payer"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidGlobalConfigMode",
+      "msg": "Mode to update global_config is invalid"
+    },
+    {
+      "code": 6030,
+      "name": "RewardIndexOutOfRange",
+      "msg": "Reward Index is higher than number of rewards"
+    },
+    {
+      "code": 6031,
+      "name": "NothingToWithdraw",
+      "msg": "No tokens available to withdraw"
+    },
+    {
+      "code": 6032,
+      "name": "UserDelegatedFarmNonDelegatedMissmatch",
+      "msg": "user, user_ref, authority and payer must match for non-delegated farm"
+    },
+    {
+      "code": 6033,
+      "name": "AuthorityFarmDelegateMissmatch",
+      "msg": "Authority must match farm delegate authority"
+    },
+    {
+      "code": 6034,
+      "name": "FarmNotDelegated",
+      "msg": "Farm not delegated, can not complete operation"
+    },
+    {
+      "code": 6035,
+      "name": "FarmDelegated",
+      "msg": "Operation not allowed for delegated farm"
+    },
+    {
+      "code": 6036,
+      "name": "UnstakeNotElapsed",
+      "msg": "Unstake lockup period is not elapsed. Deposit is locked until end of unstake period"
+    },
+    {
+      "code": 6037,
+      "name": "PendingWithdrawalNotWithdrawnYet",
+      "msg": "Pending withdrawal already exist and not withdrawn yet"
+    },
+    {
+      "code": 6038,
+      "name": "DepositZero",
+      "msg": "Cannot deposit zero amount directly to farm vault"
+    },
+    {
+      "code": 6039,
+      "name": "InvalidConfigValue",
+      "msg": "Invalid config value"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidPenaltyPercentage",
+      "msg": "Invalid penalty percentage"
+    },
+    {
+      "code": 6041,
+      "name": "EarlyWithdrawalNotAllowed",
+      "msg": "Early withdrawal not allowed"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidLockingTimestamps",
+      "msg": "Invalid locking timestamps"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidRpsCurvePoint",
+      "msg": "Invalid reward rate curve point"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidTimestamp",
+      "msg": "Invalid timestamp"
+    },
+    {
+      "code": 6045,
+      "name": "DepositCapReached",
+      "msg": "Deposit cap reached"
+    },
+    {
+      "code": 6046,
+      "name": "MissingScopePrices",
+      "msg": "Missing Scope Prices"
+    },
+    {
+      "code": 6047,
+      "name": "ScopeOraclePriceTooOld",
+      "msg": "Scope Oracle Price Too Old"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidOracleConfig",
+      "msg": "Invalid Oracle Config"
+    },
+    {
+      "code": 6049,
+      "name": "CouldNotDeserializeScope",
+      "msg": "Could not deserialize scope"
+    },
+    {
+      "code": 6050,
+      "name": "RewardAtaOwnerNotAdmin",
+      "msg": "Reward ata owner is different than farm admin"
+    },
+    {
+      "code": 6051,
+      "name": "WithdrawRewardZeroAvailable",
+      "msg": "Cannot withdraw reward as available amount is zero"
+    },
+    {
+      "code": 6052,
+      "name": "RewardScheduleCurveSet",
+      "msg": "Cannot withdraw reward as reward schedule is set"
+    },
+    {
+      "code": 6053,
+      "name": "UnsupportedTokenExtension",
+      "msg": "Cannot initialize farm while having a mint with token22 and requested extensions"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidFarmConfigUpdateAuthority",
+      "msg": "Invalid authority for updating farm config"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidTransferOwnershipOldOwner",
+      "msg": "Invalid authority for transfer ownersip new user state initialization"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidTransferOwnershipFarmState",
+      "msg": "Invalid farm state for transfer ownership new user state initialization"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidTransferOwnershipUserStateOwnerDelegatee",
+      "msg": "Invalid user state for transfer ownership, owner must match delegatee"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidTransferOwnershipFarmStateLockingMode",
+      "msg": "Invalid farm state locking mode for transfer ownership, must be 0"
+    },
+    {
+      "code": 6059,
+      "name": "InvalidTransferOwnershipFarmStateWithdrawCooldownPeriod",
+      "msg": "Invalid farm state withdrawal cooldown period for transfer ownership, must be 0"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidTransferOwnershipStakeAmount",
+      "msg": "Invalid transfer ownership stake amount, must be equal to unstaked deposits"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidTransferOwnershipNewOwner",
+      "msg": "Invalid authority for transfer ownersip new user state initialization"
+    },
+    {
+      "code": 6062,
+      "name": "InvalidTransferOwnershipFarmStateDepositWarmupPeriod",
+      "msg": "Invalid farm state deposit warmup period for transfer ownership, must be 0 if old user has stake"
+    },
+    {
+      "code": 6063,
+      "name": "RewardUserOnceFeatureDisabled",
+      "msg": "Reward User Once feature is disabled"
+    },
+    {
+      "code": 6064,
+      "name": "InvalidDelegatedAuthorityUpdate",
+      "msg": "Can not set delegate_authority to default pubkey - farm is delegated"
+    },
+    {
+      "code": 6065,
+      "name": "UserTokenAccountOwnerMismatch",
+      "msg": "User token account owner does not match user state owner"
+    },
+    {
+      "code": 6066,
+      "name": "HarvestingNotPermissionlessPayerMismatch",
+      "msg": "Harvesting is not permissionless, payer does not match user state owner"
+    },
+    {
+      "code": 6067,
+      "name": "CurrentRewardIssuedUnclaimedMismatch",
+      "msg": "Current reward issued unclaimed does not match expected value"
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/mod.rs
@@ -1,0 +1,284 @@
+//! Kamino Farms preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::KaminoFarmsConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const KAMINO_FARMS_PROGRAM_ID: &str = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr";
+
+const KAMINO_FARMS_DISPLAY_NAME: &str = "Kamino Farms";
+
+const KAMINO_FARMS_IDL_JSON: &str = include_str!("kamino_farms.json");
+
+static KAMINO_FARMS_CONFIG: KaminoFarmsConfig = KaminoFarmsConfig;
+
+pub struct KaminoFarmsVisualizer;
+
+impl InstructionVisualizer for KaminoFarmsVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let parsed_result = parse_kamino_farms_instruction(&instruction.data);
+        let program_id_str = instruction.program_id.to_string();
+
+        let (condensed_fields, expanded_fields, title_text) = match &parsed_result {
+            Ok(parsed) => {
+                let named_accounts = match load_kamino_farms_idl() {
+                    Some(idl) => {
+                        build_named_accounts(idl, &instruction.data, &instruction.accounts)
+                    }
+                    None => HashMap::new(),
+                };
+                (
+                    build_condensed_fields(&parsed.instruction_name)?,
+                    build_parsed_fields(
+                        &program_id_str,
+                        parsed,
+                        &named_accounts,
+                        &instruction.data,
+                    )?,
+                    format!("{KAMINO_FARMS_DISPLAY_NAME}: {}", parsed.instruction_name),
+                )
+            }
+            Err(_) => (
+                build_fallback_condensed_fields()?,
+                build_fallback_fields(&program_id_str, &instruction.data)?,
+                format!("{KAMINO_FARMS_DISPLAY_NAME}: Unknown Instruction"),
+            ),
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title_text }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(SignablePayloadFieldListLayout {
+                fields: condensed_fields,
+            }),
+            expanded: Some(SignablePayloadFieldListLayout {
+                fields: expanded_fields,
+            }),
+        };
+
+        let fallback_text = format!(
+            "Program ID: {program_id_str}\nData: {}",
+            hex::encode(&instruction.data)
+        );
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&KAMINO_FARMS_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Lending(KAMINO_FARMS_DISPLAY_NAME)
+    }
+}
+
+/// Load and cache the bundled Kamino Farms IDL.
+fn load_kamino_farms_idl() -> Option<&'static Idl> {
+    static IDL: std::sync::OnceLock<Option<Idl>> = std::sync::OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(KAMINO_FARMS_IDL_JSON).ok())
+        .as_ref()
+}
+
+/// Parse an instruction's data using the bundled IDL.
+fn parse_kamino_farms_instruction(
+    data: &[u8],
+) -> Result<SolanaParsedInstructionData, VisualSignError> {
+    if data.len() < 8 {
+        return Err(VisualSignError::DecodeError(
+            "instruction data shorter than 8-byte discriminator".into(),
+        ));
+    }
+
+    let idl = load_kamino_farms_idl()
+        .ok_or_else(|| VisualSignError::DecodeError("failed to load Kamino Farms IDL".into()))?;
+
+    parse_instruction_with_idl(data, KAMINO_FARMS_PROGRAM_ID, idl)
+        .map_err(|e| VisualSignError::DecodeError(e.to_string()))
+}
+
+/// Build a map of IDL account name to pubkey by zipping instruction accounts with IDL accounts.
+fn build_named_accounts(
+    idl: &Idl,
+    instruction_data: &[u8],
+    instruction_accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named = HashMap::new();
+
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .map(|d| instruction_data.len() >= 8 && &instruction_data[0..8] == d.as_slice())
+            .unwrap_or(false)
+    }) else {
+        return named;
+    };
+
+    for (idx, account_meta) in instruction_accounts.iter().enumerate() {
+        if let Some(idl_account) = idl_instruction.accounts.get(idx) {
+            named.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+        }
+    }
+
+    named
+}
+
+/// Build the expanded fields shown when the IDL parsed successfully.
+fn build_parsed_fields(
+    program_id: &str,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program ID", program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    let mut account_entries: Vec<(&String, &String)> = named_accounts.iter().collect();
+    account_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, address) in account_entries {
+        fields.push(create_text_field(name, address)?);
+    }
+
+    let mut arg_entries: Vec<(&String, &serde_json::Value)> =
+        parsed.program_call_args.iter().collect();
+    arg_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, value) in arg_entries {
+        fields.push(create_text_field(name, &format_arg_value(value))?);
+    }
+
+    append_raw_data(&mut fields, data)?;
+
+    Ok(fields)
+}
+
+/// Build the expanded fields shown when IDL parsing failed.
+fn build_fallback_fields(
+    program_id: &str,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program ID", program_id)?,
+        create_text_field("Status", "IDL parsing failed - showing raw data")?,
+    ];
+    append_raw_data(&mut fields, data)?;
+    Ok(fields)
+}
+
+/// Build the condensed fields when parsing succeeded.
+fn build_condensed_fields(
+    instruction_name: &str,
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    Ok(vec![
+        create_text_field("Program", KAMINO_FARMS_DISPLAY_NAME)?,
+        create_text_field("Instruction", instruction_name)?,
+    ])
+}
+
+/// Build the condensed fields when parsing failed.
+fn build_fallback_condensed_fields() -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    Ok(vec![create_text_field(
+        "Program",
+        KAMINO_FARMS_DISPLAY_NAME,
+    )?])
+}
+
+fn append_raw_data(
+    fields: &mut Vec<AnnotatedPayloadField>,
+    data: &[u8],
+) -> Result<(), VisualSignError> {
+    fields.push(create_raw_data_field(data, Some(hex::encode(data)))?);
+    Ok(())
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kamino_farms_idl_loads() {
+        let idl = load_kamino_farms_idl().expect("IDL should load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should declare at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_kamino_farms_idl_has_discriminators() {
+        let idl = load_kamino_farms_idl().expect("IDL should load");
+        for instruction in &idl.instructions {
+            let discriminator = instruction.discriminator.as_ref().unwrap_or_else(|| {
+                panic!("instruction '{}' missing discriminator", instruction.name)
+            });
+            assert_eq!(
+                discriminator.len(),
+                8,
+                "instruction '{}' has non-8-byte discriminator",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage = [0xFFu8; 9];
+        let result = parse_kamino_farms_instruction(&garbage);
+        assert!(
+            result.is_err(),
+            "garbage discriminator should not match any instruction"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let too_short = [0x01u8, 0x02, 0x03];
+        let result = parse_kamino_farms_instruction(&too_short);
+        assert!(
+            result.is_err(),
+            "data shorter than discriminator should return error"
+        );
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_farms/mod.rs
@@ -9,7 +9,7 @@ use config::KaminoFarmsConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -45,7 +45,7 @@ impl InstructionVisualizer for KaminoFarmsVisualizer {
                     Some(idl) => {
                         build_named_accounts(idl, &instruction.data, &instruction.accounts)
                     }
-                    None => HashMap::new(),
+                    None => BTreeMap::new(),
                 };
                 (
                     build_condensed_fields(&parsed.instruction_name)?,
@@ -134,8 +134,8 @@ fn build_named_accounts(
     idl: &Idl,
     instruction_data: &[u8],
     instruction_accounts: &[solana_sdk::instruction::AccountMeta],
-) -> HashMap<String, String> {
-    let mut named = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named = BTreeMap::new();
 
     let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
         inst.discriminator
@@ -159,7 +159,7 @@ fn build_named_accounts(
 fn build_parsed_fields(
     program_id: &str,
     parsed: &SolanaParsedInstructionData,
-    named_accounts: &HashMap<String, String>,
+    named_accounts: &BTreeMap<String, String>,
     data: &[u8],
 ) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
     let mut fields = vec![

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/config.rs
@@ -1,0 +1,22 @@
+use super::KAMINO_VAULT_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct KaminoVaultConfig;
+
+impl SolanaIntegrationConfig for KaminoVaultConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(KAMINO_VAULT_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/kamino_vault.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/kamino_vault.json
@@ -1,0 +1,2735 @@
+{
+  "version": "2.1.0",
+  "name": "kamino_vault",
+  "instructions": [
+    {
+      "name": "initVault",
+      "accounts": [
+        {
+          "name": "adminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseTokenMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "adminTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateReserveAllocation",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ctokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveWhitelistEntry",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "reserveCollateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "weight",
+          "type": "u64"
+        },
+        {
+          "name": "cap",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSharesAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "buy",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSharesAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "accounts": [
+        {
+          "name": "withdrawFromAvailable",
+          "accounts": [
+            {
+              "name": "user",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "vaultState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "globalConfig",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "baseVaultAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "userTokenAta",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSharesAta",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "sharesMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "sharesTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "klendProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "eventAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "program",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "withdrawFromReserveAccounts",
+          "accounts": [
+            {
+              "name": "vaultState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "ctokenVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sharesAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "sell",
+      "accounts": [
+        {
+          "name": "withdrawFromAvailable",
+          "accounts": [
+            {
+              "name": "user",
+              "isMut": false,
+              "isSigner": true
+            },
+            {
+              "name": "vaultState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "globalConfig",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "baseVaultAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "userTokenAta",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "userSharesAta",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "sharesMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "sharesTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "klendProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "eventAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "program",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "withdrawFromReserveAccounts",
+          "accounts": [
+            {
+              "name": "vaultState",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "ctokenVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarket",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "lendingMarketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "reserveLiquiditySupply",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "reserveCollateralTokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "instructionSysvarAccount",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sharesAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "invest",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "payerTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ctokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "CPI accounts"
+          ]
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveWhitelistEntry",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateVaultConfig",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "entry",
+          "type": {
+            "defined": "VaultConfigField"
+          }
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "withdrawPendingFees",
+      "accounts": [
+        {
+          "name": "vaultAdminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ctokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false,
+          "docs": [
+            "CPI accounts"
+          ]
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateAdmin",
+      "accounts": [
+        {
+          "name": "pendingAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "giveUpPendingFees",
+      "accounts": [
+        {
+          "name": "vaultAdminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxAmountToGiveUp",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initializeSharesMetadata",
+      "accounts": [
+        {
+          "name": "vaultAdminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "name": "uri",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "updateSharesMetadata",
+      "accounts": [
+        {
+          "name": "vaultAdminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "metadataProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "name": "uri",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "withdrawFromAvailable",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userTokenAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSharesAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sharesAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "removeAllocation",
+      "accounts": [
+        {
+          "name": "vaultAdminAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initGlobalConfig",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateGlobalConfig",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "update",
+          "type": {
+            "defined": "UpdateGlobalConfigMode"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateGlobalConfigAdmin",
+      "accounts": [
+        {
+          "name": "pendingAdmin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "addUpdateWhitelistedReserve",
+      "accounts": [
+        {
+          "name": "globalAdmin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveWhitelistEntry",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "update",
+          "type": {
+            "defined": "UpdateReserveWhitelistMode"
+          }
+        }
+      ]
+    },
+    {
+      "name": "redeemInKind",
+      "accounts": [
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "vaultState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "globalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "baseVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ctokenVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userCtokenTa",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "ctokenMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSharesTa",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "sharesMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "sharesTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "klendProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "eventAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "sharesAmount",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Reserve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdate",
+            "type": {
+              "defined": "LastUpdate"
+            }
+          },
+          {
+            "name": "lendingMarket",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmCollateral",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmDebt",
+            "type": "publicKey"
+          },
+          {
+            "name": "liquidity",
+            "type": {
+              "defined": "ReserveLiquidity"
+            }
+          },
+          {
+            "name": "reserveLiquidityPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "collateral",
+            "type": {
+              "defined": "ReserveCollateral"
+            }
+          },
+          {
+            "name": "reserveCollateralPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "config",
+            "type": {
+              "defined": "ReserveConfig"
+            }
+          },
+          {
+            "name": "configPadding",
+            "type": {
+              "array": [
+                "u64",
+                116
+              ]
+            }
+          },
+          {
+            "name": "borrowedAmountOutsideElevationGroup",
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountsAgainstThisReserveInElevationGroups",
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                207
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "globalAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "pendingAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "withdrawalPenaltyLamports",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawalPenaltyBps",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                944
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveWhitelistEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "reserve",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistAddAllocation",
+            "type": "u8"
+          },
+          {
+            "name": "whitelistInvest",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                62
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaultAdminAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "tokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAvailable",
+            "type": "u64"
+          },
+          {
+            "name": "sharesIssued",
+            "type": "u64"
+          },
+          {
+            "name": "availableCrankFunds",
+            "type": "u64"
+          },
+          {
+            "name": "unallocatedWeight",
+            "type": "u64"
+          },
+          {
+            "name": "performanceFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "managementFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "lastFeeChargeTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "prevAumSf",
+            "type": "u128"
+          },
+          {
+            "name": "pendingFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "vaultAllocationStrategy",
+            "type": {
+              "array": [
+                {
+                  "defined": "VaultAllocation"
+                },
+                25
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u128",
+                256
+              ]
+            }
+          },
+          {
+            "name": "minDepositAmount",
+            "type": "u64"
+          },
+          {
+            "name": "minWithdrawAmount",
+            "type": "u64"
+          },
+          {
+            "name": "minInvestAmount",
+            "type": "u64"
+          },
+          {
+            "name": "minInvestDelaySlots",
+            "type": "u64"
+          },
+          {
+            "name": "crankFundFeePerReserve",
+            "type": "u64"
+          },
+          {
+            "name": "pendingAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "cumulativeEarnedInterestSf",
+            "type": "u128"
+          },
+          {
+            "name": "cumulativeMgmtFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "cumulativePerfFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                40
+              ]
+            }
+          },
+          {
+            "name": "vaultLookupTable",
+            "type": "publicKey"
+          },
+          {
+            "name": "vaultFarm",
+            "type": "publicKey"
+          },
+          {
+            "name": "creationTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "unallocatedTokensCap",
+            "type": "u64"
+          },
+          {
+            "name": "allocationAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "withdrawalPenaltyLamports",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawalPenaltyBps",
+            "type": "u64"
+          },
+          {
+            "name": "firstLossCapitalFarm",
+            "type": "publicKey"
+          },
+          {
+            "name": "allowAllocationsInWhitelistedReservesOnly",
+            "type": "u8"
+          },
+          {
+            "name": "allowInvestInWhitelistedReservesOnly",
+            "type": "u8"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u128",
+                238
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "LastUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "stale",
+            "type": "u8"
+          },
+          {
+            "name": "priceStatus",
+            "type": "u8"
+          },
+          {
+            "name": "placeholder",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BigFractionBytes",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveCollateral",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "mintTotalSupply",
+            "type": "u64"
+          },
+          {
+            "name": "supplyVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "assetTier",
+            "type": "u8"
+          },
+          {
+            "name": "hostFixedInterestRateBps",
+            "type": "u16"
+          },
+          {
+            "name": "minDeleveragingBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "blockCtokenUsage",
+            "type": "u8"
+          },
+          {
+            "name": "reserved1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocolOrderExecutionFeePct",
+            "type": "u8"
+          },
+          {
+            "name": "protocolTakeRatePct",
+            "type": "u8"
+          },
+          {
+            "name": "protocolLiquidationFeePct",
+            "type": "u8"
+          },
+          {
+            "name": "loanToValuePct",
+            "type": "u8"
+          },
+          {
+            "name": "liquidationThresholdPct",
+            "type": "u8"
+          },
+          {
+            "name": "minLiquidationBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "maxLiquidationBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "badDebtLiquidationBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "deleveragingMarginCallPeriodSecs",
+            "type": "u64"
+          },
+          {
+            "name": "deleveragingThresholdDecreaseBpsPerDay",
+            "type": "u64"
+          },
+          {
+            "name": "fees",
+            "type": {
+              "defined": "ReserveFees"
+            }
+          },
+          {
+            "name": "borrowRateCurve",
+            "type": {
+              "defined": "BorrowRateCurve"
+            }
+          },
+          {
+            "name": "borrowFactorPct",
+            "type": "u64"
+          },
+          {
+            "name": "depositLimit",
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimit",
+            "type": "u64"
+          },
+          {
+            "name": "tokenInfo",
+            "type": {
+              "defined": "TokenInfo"
+            }
+          },
+          {
+            "name": "depositWithdrawalCap",
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "debtWithdrawalCap",
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "elevationGroups",
+            "type": {
+              "array": [
+                "u8",
+                20
+              ]
+            }
+          },
+          {
+            "name": "disableUsageAsCollOutsideEmode",
+            "type": "u8"
+          },
+          {
+            "name": "utilizationLimitBlockBorrowingAbovePct",
+            "type": "u8"
+          },
+          {
+            "name": "autodeleverageEnabled",
+            "type": "u8"
+          },
+          {
+            "name": "proposerAuthorityLocked",
+            "type": "u8"
+          },
+          {
+            "name": "borrowLimitOutsideElevationGroup",
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimitAgainstThisCollateralInElevationGroup",
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          },
+          {
+            "name": "deleveragingBonusIncreaseBpsPerDay",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "originationFeeSf",
+            "type": "u64"
+          },
+          {
+            "name": "flashLoanFeeSf",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "supplyVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "feeVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "availableAmount",
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountSf",
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceSf",
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceLastUpdatedTs",
+            "type": "u64"
+          },
+          {
+            "name": "mintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "depositLimitCrossedTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimitCrossedTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "cumulativeBorrowRateBsf",
+            "type": {
+              "defined": "BigFractionBytes"
+            }
+          },
+          {
+            "name": "accumulatedProtocolFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "accumulatedReferrerFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "pendingReferrerFeesSf",
+            "type": "u128"
+          },
+          {
+            "name": "absoluteReferralRateSf",
+            "type": "u128"
+          },
+          {
+            "name": "tokenProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                51
+              ]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalCaps",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configCapacity",
+            "type": "i64"
+          },
+          {
+            "name": "currentTotal",
+            "type": "i64"
+          },
+          {
+            "name": "lastIntervalStartTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "configIntervalLengthSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceHeuristic",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lower",
+            "type": "u64"
+          },
+          {
+            "name": "upper",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PythConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ScopeConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceFeed",
+            "type": "publicKey"
+          },
+          {
+            "name": "priceChain",
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          },
+          {
+            "name": "twapChain",
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwitchboardConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceAggregator",
+            "type": "publicKey"
+          },
+          {
+            "name": "twapAggregator",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "heuristic",
+            "type": {
+              "defined": "PriceHeuristic"
+            }
+          },
+          {
+            "name": "maxTwapDivergenceBps",
+            "type": "u64"
+          },
+          {
+            "name": "maxAgePriceSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "maxAgeTwapSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "scopeConfiguration",
+            "type": {
+              "defined": "ScopeConfiguration"
+            }
+          },
+          {
+            "name": "switchboardConfiguration",
+            "type": {
+              "defined": "SwitchboardConfiguration"
+            }
+          },
+          {
+            "name": "pythConfiguration",
+            "type": {
+              "defined": "PythConfiguration"
+            }
+          },
+          {
+            "name": "blockPriceUsage",
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                19
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BorrowRateCurve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "points",
+            "type": {
+              "array": [
+                {
+                  "defined": "CurvePoint"
+                },
+                11
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurvePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "utilizationRateBps",
+            "type": "u32"
+          },
+          {
+            "name": "borrowRateBps",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateReserveWhitelistMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Invest",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "AddAllocation",
+            "fields": [
+              "u8"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultConfigField",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PerformanceFeeBps"
+          },
+          {
+            "name": "ManagementFeeBps"
+          },
+          {
+            "name": "MinDepositAmount"
+          },
+          {
+            "name": "MinWithdrawAmount"
+          },
+          {
+            "name": "MinInvestAmount"
+          },
+          {
+            "name": "MinInvestDelaySlots"
+          },
+          {
+            "name": "CrankFundFeePerReserve"
+          },
+          {
+            "name": "PendingVaultAdmin"
+          },
+          {
+            "name": "Name"
+          },
+          {
+            "name": "LookupTable"
+          },
+          {
+            "name": "Farm"
+          },
+          {
+            "name": "AllocationAdmin"
+          },
+          {
+            "name": "UnallocatedWeight"
+          },
+          {
+            "name": "UnallocatedTokensCap"
+          },
+          {
+            "name": "WithdrawalPenaltyLamports"
+          },
+          {
+            "name": "WithdrawalPenaltyBps"
+          },
+          {
+            "name": "FirstLossCapitalFarm"
+          },
+          {
+            "name": "AllowAllocationsInWhitelistedReservesOnly"
+          },
+          {
+            "name": "AllowInvestInWhitelistedReservesOnly"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultAllocation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reserve",
+            "type": "publicKey"
+          },
+          {
+            "name": "ctokenVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "targetAllocationWeight",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAllocationCap",
+            "type": "u64"
+          },
+          {
+            "name": "ctokenVaultBump",
+            "type": "u64"
+          },
+          {
+            "name": "configPadding",
+            "type": {
+              "array": [
+                "u64",
+                127
+              ]
+            }
+          },
+          {
+            "name": "ctokenAllocation",
+            "type": "u64"
+          },
+          {
+            "name": "lastInvestSlot",
+            "type": "u64"
+          },
+          {
+            "name": "tokenTargetAllocationSf",
+            "type": "u128"
+          },
+          {
+            "name": "statePadding",
+            "type": {
+              "array": [
+                "u64",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateGlobalConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PendingAdmin",
+            "fields": [
+              "publicKey"
+            ]
+          },
+          {
+            "name": "MinWithdrawalPenaltyLamports",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "MinWithdrawalPenaltyBPS",
+            "fields": [
+              "u64"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "name": "DepositResultEvent",
+      "fields": [
+        {
+          "name": "sharesToMint",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "tokenToDeposit",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "crankFundsToDeposit",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "DepositUserAtaBalanceEvent",
+      "fields": [
+        {
+          "name": "userAtaBalance",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "RedeemInKindResultEvent",
+      "fields": [
+        {
+          "name": "sharesToBurn",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "ctokensToSendToUser",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SharesToWithdrawEvent",
+      "fields": [
+        {
+          "name": "sharesAmount",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "userSharesBefore",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "WithdrawResultEvent",
+      "fields": [
+        {
+          "name": "sharesToBurn",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "availableToSendToUser",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "investedToDisinvestCtokens",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "investedLiquidityToSendToUser",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 7000,
+      "name": "DepositAmountsZero",
+      "msg": "Cannot deposit zero tokens"
+    },
+    {
+      "code": 7001,
+      "name": "SharesIssuedAmountDoesNotMatch",
+      "msg": "Post check failed on share issued"
+    },
+    {
+      "code": 7002,
+      "name": "MathOverflow",
+      "msg": "Math operation overflowed"
+    },
+    {
+      "code": 7003,
+      "name": "IntegerOverflow",
+      "msg": "Integer conversion overflowed"
+    },
+    {
+      "code": 7004,
+      "name": "WithdrawAmountBelowMinimum",
+      "msg": "Withdrawn amount is below minimum"
+    },
+    {
+      "code": 7005,
+      "name": "TooMuchLiquidityToWithdraw",
+      "msg": "TooMuchLiquidityToWithdraw"
+    },
+    {
+      "code": 7006,
+      "name": "ReserveAlreadyExists",
+      "msg": "ReserveAlreadyExists"
+    },
+    {
+      "code": 7007,
+      "name": "ReserveNotPartOfAllocations",
+      "msg": "ReserveNotPartOfAllocations"
+    },
+    {
+      "code": 7008,
+      "name": "CouldNotDeserializeAccountAsReserve",
+      "msg": "CouldNotDeserializeAccountAsReserve"
+    },
+    {
+      "code": 7009,
+      "name": "ReserveNotProvidedInTheAccounts",
+      "msg": "ReserveNotProvidedInTheAccounts"
+    },
+    {
+      "code": 7010,
+      "name": "ReserveAccountAndKeyMismatch",
+      "msg": "ReserveAccountAndKeyMismatch"
+    },
+    {
+      "code": 7011,
+      "name": "OutOfRangeOfReserveIndex",
+      "msg": "OutOfRangeOfReserveIndex"
+    },
+    {
+      "code": 7012,
+      "name": "CannotFindReserveInAllocations",
+      "msg": "OutOfRangeOfReserveIndex"
+    },
+    {
+      "code": 7013,
+      "name": "InvestAmountBelowMinimum",
+      "msg": "Invested amount is below minimum"
+    },
+    {
+      "code": 7014,
+      "name": "AdminAuthorityIncorrect",
+      "msg": "AdminAuthorityIncorrect"
+    },
+    {
+      "code": 7015,
+      "name": "BaseVaultAuthorityIncorrect",
+      "msg": "BaseVaultAuthorityIncorrect"
+    },
+    {
+      "code": 7016,
+      "name": "BaseVaultAuthorityBumpIncorrect",
+      "msg": "BaseVaultAuthorityBumpIncorrect"
+    },
+    {
+      "code": 7017,
+      "name": "TokenMintIncorrect",
+      "msg": "TokenMintIncorrect"
+    },
+    {
+      "code": 7018,
+      "name": "TokenMintDecimalsIncorrect",
+      "msg": "TokenMintDecimalsIncorrect"
+    },
+    {
+      "code": 7019,
+      "name": "TokenVaultIncorrect",
+      "msg": "TokenVaultIncorrect"
+    },
+    {
+      "code": 7020,
+      "name": "SharesMintDecimalsIncorrect",
+      "msg": "SharesMintDecimalsIncorrect"
+    },
+    {
+      "code": 7021,
+      "name": "SharesMintIncorrect",
+      "msg": "SharesMintIncorrect"
+    },
+    {
+      "code": 7022,
+      "name": "InitialAccountingIncorrect",
+      "msg": "InitialAccountingIncorrect"
+    },
+    {
+      "code": 7023,
+      "name": "ReserveIsStale",
+      "msg": "Reserve is stale and must be refreshed before any operation"
+    },
+    {
+      "code": 7024,
+      "name": "NotEnoughLiquidityDisinvestedToSendToUser",
+      "msg": "Not enough liquidity disinvested to send to user"
+    },
+    {
+      "code": 7025,
+      "name": "BPSValueTooBig",
+      "msg": "BPS value is greater than 10000"
+    },
+    {
+      "code": 7026,
+      "name": "DepositAmountBelowMinimum",
+      "msg": "Deposited amount is below minimum"
+    },
+    {
+      "code": 7027,
+      "name": "ReserveSpaceExhausted",
+      "msg": "Vault have no space for new reserves"
+    },
+    {
+      "code": 7028,
+      "name": "CannotWithdrawFromEmptyVault",
+      "msg": "Cannot withdraw from empty vault"
+    },
+    {
+      "code": 7029,
+      "name": "TokensDepositedAmountDoesNotMatch",
+      "msg": "TokensDepositedAmountDoesNotMatch"
+    },
+    {
+      "code": 7030,
+      "name": "AmountToWithdrawDoesNotMatch",
+      "msg": "Amount to withdraw does not match"
+    },
+    {
+      "code": 7031,
+      "name": "LiquidityToWithdrawDoesNotMatch",
+      "msg": "Liquidity to withdraw does not match"
+    },
+    {
+      "code": 7032,
+      "name": "UserReceivedAmountDoesNotMatch",
+      "msg": "User received amount does not match"
+    },
+    {
+      "code": 7033,
+      "name": "SharesBurnedAmountDoesNotMatch",
+      "msg": "Shares burned amount does not match"
+    },
+    {
+      "code": 7034,
+      "name": "DisinvestedLiquidityAmountDoesNotMatch",
+      "msg": "Disinvested liquidity amount does not match"
+    },
+    {
+      "code": 7035,
+      "name": "SharesMintedAmountDoesNotMatch",
+      "msg": "SharesMintedAmountDoesNotMatch"
+    },
+    {
+      "code": 7036,
+      "name": "AUMDecreasedAfterInvest",
+      "msg": "AUM decreased after invest"
+    },
+    {
+      "code": 7037,
+      "name": "AUMBelowPendingFees",
+      "msg": "AUM is below pending fees"
+    },
+    {
+      "code": 7038,
+      "name": "DepositAmountsZeroShares",
+      "msg": "Deposit amount results in 0 shares"
+    },
+    {
+      "code": 7039,
+      "name": "WithdrawResultsInZeroShares",
+      "msg": "Withdraw amount results in 0 shares"
+    },
+    {
+      "code": 7040,
+      "name": "CannotWithdrawZeroShares",
+      "msg": "Cannot withdraw zero shares"
+    },
+    {
+      "code": 7041,
+      "name": "ManagementFeeGreaterThanMaxAllowed",
+      "msg": "Management fee is greater than maximum allowed"
+    },
+    {
+      "code": 7042,
+      "name": "VaultAUMZero",
+      "msg": "Vault assets under management are empty"
+    },
+    {
+      "code": 7043,
+      "name": "MissingReserveForBatchRefresh",
+      "msg": "Missing reserve for batch refresh"
+    },
+    {
+      "code": 7044,
+      "name": "MinWithdrawAmountTooBig",
+      "msg": "Min withdraw amount is too big"
+    },
+    {
+      "code": 7045,
+      "name": "InvestTooSoon",
+      "msg": "Invest is called too soon after last invest"
+    },
+    {
+      "code": 7046,
+      "name": "WrongAdminOrAllocationAdmin",
+      "msg": "Wrong admin or allocation admin"
+    },
+    {
+      "code": 7047,
+      "name": "ReserveHasNonZeroAllocationOrCTokens",
+      "msg": "Reserve has non-zero allocation or ctokens so cannot be removed"
+    },
+    {
+      "code": 7048,
+      "name": "DepositAmountGreaterThanRequestedAmount",
+      "msg": "Deposit amount is greater than requested amount"
+    },
+    {
+      "code": 7049,
+      "name": "WithdrawAmountLessThanWithdrawalPenalty",
+      "msg": "Withdraw amount is less than withdrawal penalty"
+    },
+    {
+      "code": 7050,
+      "name": "CannotWithdrawZeroLamports",
+      "msg": "Cannot withdraw 0 lamports"
+    },
+    {
+      "code": 7051,
+      "name": "NoUpgradeAuthority",
+      "msg": "Cannot initialize global config because there is no upgrade authority to the program"
+    },
+    {
+      "code": 7052,
+      "name": "WithdrawalFeeBPSGreaterThanMaxAllowed",
+      "msg": "Withdrawal fee BPS is greater than maximum allowed"
+    },
+    {
+      "code": 7053,
+      "name": "WithdrawalFeeLamportsGreaterThanMaxAllowed",
+      "msg": "Withdrawal fee lamports is greater than maximum allowed"
+    },
+    {
+      "code": 7054,
+      "name": "ReserveNotWhitelisted",
+      "msg": "Reserve is not whitelisted"
+    },
+    {
+      "code": 7055,
+      "name": "InvalidBoolLikeValue",
+      "msg": "Invalid bool-like value passed in (should be 0 or 1)"
+    },
+    {
+      "code": 7056,
+      "name": "AUMDecreasedMoreThanExpected",
+      "msg": "AUM decreased more than expected during redeem in kind"
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/mod.rs
@@ -1,0 +1,284 @@
+//! Kamino Vault preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::KaminoVaultConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const KAMINO_VAULT_PROGRAM_ID: &str = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd";
+
+const KAMINO_VAULT_DISPLAY_NAME: &str = "Kamino Vault";
+
+const KAMINO_VAULT_IDL_JSON: &str = include_str!("kamino_vault.json");
+
+static KAMINO_VAULT_CONFIG: KaminoVaultConfig = KaminoVaultConfig;
+
+pub struct KaminoVaultVisualizer;
+
+impl InstructionVisualizer for KaminoVaultVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let parsed_result = parse_kamino_vault_instruction(&instruction.data);
+        let program_id_str = instruction.program_id.to_string();
+
+        let (condensed_fields, expanded_fields, title_text) = match &parsed_result {
+            Ok(parsed) => {
+                let named_accounts = match load_kamino_vault_idl() {
+                    Some(idl) => {
+                        build_named_accounts(idl, &instruction.data, &instruction.accounts)
+                    }
+                    None => HashMap::new(),
+                };
+                (
+                    build_condensed_fields(&parsed.instruction_name)?,
+                    build_parsed_fields(
+                        &program_id_str,
+                        parsed,
+                        &named_accounts,
+                        &instruction.data,
+                    )?,
+                    format!("{KAMINO_VAULT_DISPLAY_NAME}: {}", parsed.instruction_name),
+                )
+            }
+            Err(_) => (
+                build_fallback_condensed_fields()?,
+                build_fallback_fields(&program_id_str, &instruction.data)?,
+                format!("{KAMINO_VAULT_DISPLAY_NAME}: Unknown Instruction"),
+            ),
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title_text }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(SignablePayloadFieldListLayout {
+                fields: condensed_fields,
+            }),
+            expanded: Some(SignablePayloadFieldListLayout {
+                fields: expanded_fields,
+            }),
+        };
+
+        let fallback_text = format!(
+            "Program ID: {program_id_str}\nData: {}",
+            hex::encode(&instruction.data)
+        );
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&KAMINO_VAULT_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Lending(KAMINO_VAULT_DISPLAY_NAME)
+    }
+}
+
+/// Load and cache the bundled Kamino Vault IDL.
+fn load_kamino_vault_idl() -> Option<&'static Idl> {
+    static IDL: std::sync::OnceLock<Option<Idl>> = std::sync::OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(KAMINO_VAULT_IDL_JSON).ok())
+        .as_ref()
+}
+
+/// Parse an instruction's data using the bundled IDL.
+fn parse_kamino_vault_instruction(
+    data: &[u8],
+) -> Result<SolanaParsedInstructionData, VisualSignError> {
+    if data.len() < 8 {
+        return Err(VisualSignError::DecodeError(
+            "instruction data shorter than 8-byte discriminator".into(),
+        ));
+    }
+
+    let idl = load_kamino_vault_idl()
+        .ok_or_else(|| VisualSignError::DecodeError("failed to load Kamino Vault IDL".into()))?;
+
+    parse_instruction_with_idl(data, KAMINO_VAULT_PROGRAM_ID, idl)
+        .map_err(|e| VisualSignError::DecodeError(e.to_string()))
+}
+
+/// Build a map of IDL account name to pubkey by zipping instruction accounts with IDL accounts.
+fn build_named_accounts(
+    idl: &Idl,
+    instruction_data: &[u8],
+    instruction_accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named = HashMap::new();
+
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .map(|d| instruction_data.len() >= 8 && &instruction_data[0..8] == d.as_slice())
+            .unwrap_or(false)
+    }) else {
+        return named;
+    };
+
+    for (idx, account_meta) in instruction_accounts.iter().enumerate() {
+        if let Some(idl_account) = idl_instruction.accounts.get(idx) {
+            named.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+        }
+    }
+
+    named
+}
+
+/// Build the expanded fields shown when the IDL parsed successfully.
+fn build_parsed_fields(
+    program_id: &str,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program ID", program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    let mut account_entries: Vec<(&String, &String)> = named_accounts.iter().collect();
+    account_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, address) in account_entries {
+        fields.push(create_text_field(name, address)?);
+    }
+
+    let mut arg_entries: Vec<(&String, &serde_json::Value)> =
+        parsed.program_call_args.iter().collect();
+    arg_entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, value) in arg_entries {
+        fields.push(create_text_field(name, &format_arg_value(value))?);
+    }
+
+    append_raw_data(&mut fields, data)?;
+
+    Ok(fields)
+}
+
+/// Build the expanded fields shown when IDL parsing failed.
+fn build_fallback_fields(
+    program_id: &str,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program ID", program_id)?,
+        create_text_field("Status", "IDL parsing failed - showing raw data")?,
+    ];
+    append_raw_data(&mut fields, data)?;
+    Ok(fields)
+}
+
+/// Build the condensed fields when parsing succeeded.
+fn build_condensed_fields(
+    instruction_name: &str,
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    Ok(vec![
+        create_text_field("Program", KAMINO_VAULT_DISPLAY_NAME)?,
+        create_text_field("Instruction", instruction_name)?,
+    ])
+}
+
+/// Build the condensed fields when parsing failed.
+fn build_fallback_condensed_fields() -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    Ok(vec![create_text_field(
+        "Program",
+        KAMINO_VAULT_DISPLAY_NAME,
+    )?])
+}
+
+fn append_raw_data(
+    fields: &mut Vec<AnnotatedPayloadField>,
+    data: &[u8],
+) -> Result<(), VisualSignError> {
+    fields.push(create_raw_data_field(data, Some(hex::encode(data)))?);
+    Ok(())
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kamino_vault_idl_loads() {
+        let idl = load_kamino_vault_idl().expect("IDL should load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should declare at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_kamino_vault_idl_has_discriminators() {
+        let idl = load_kamino_vault_idl().expect("IDL should load");
+        for instruction in &idl.instructions {
+            let discriminator = instruction.discriminator.as_ref().unwrap_or_else(|| {
+                panic!("instruction '{}' missing discriminator", instruction.name)
+            });
+            assert_eq!(
+                discriminator.len(),
+                8,
+                "instruction '{}' has non-8-byte discriminator",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage = [0xFFu8; 9];
+        let result = parse_kamino_vault_instruction(&garbage);
+        assert!(
+            result.is_err(),
+            "garbage discriminator should not match any instruction"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let too_short = [0x01u8, 0x02, 0x03];
+        let result = parse_kamino_vault_instruction(&too_short);
+        assert!(
+            result.is_err(),
+            "data shorter than discriminator should return error"
+        );
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_vault/mod.rs
@@ -9,7 +9,7 @@ use config::KaminoVaultConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -45,7 +45,7 @@ impl InstructionVisualizer for KaminoVaultVisualizer {
                     Some(idl) => {
                         build_named_accounts(idl, &instruction.data, &instruction.accounts)
                     }
-                    None => HashMap::new(),
+                    None => BTreeMap::new(),
                 };
                 (
                     build_condensed_fields(&parsed.instruction_name)?,
@@ -134,8 +134,8 @@ fn build_named_accounts(
     idl: &Idl,
     instruction_data: &[u8],
     instruction_accounts: &[solana_sdk::instruction::AccountMeta],
-) -> HashMap<String, String> {
-    let mut named = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named = BTreeMap::new();
 
     let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
         inst.discriminator
@@ -159,7 +159,7 @@ fn build_named_accounts(
 fn build_parsed_fields(
     program_id: &str,
     parsed: &SolanaParsedInstructionData,
-    named_accounts: &HashMap<String, String>,
+    named_accounts: &BTreeMap<String, String>,
     data: &[u8],
 ) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
     let mut fields = vec![

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -2,6 +2,7 @@ pub mod associated_token_account;
 pub mod compute_budget;
 pub mod dflow_aggregator;
 pub mod jupiter_swap;
+pub mod kamino_vault;
 pub mod stakepool;
 pub mod swig_wallet;
 pub mod system;

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -2,6 +2,7 @@ pub mod associated_token_account;
 pub mod compute_budget;
 pub mod dflow_aggregator;
 pub mod jupiter_swap;
+pub mod kamino_farms;
 pub mod kamino_vault;
 pub mod stakepool;
 pub mod swig_wallet;


### PR DESCRIPTION
## Why this PR exists

Signing a Kamino Vault or Kamino Farms transaction currently falls through to the generic `unknown_program` visualizer, so wallets display "Unknown Program" with raw hex. Users need decoded instruction names and labeled accounts to verify what they are signing.

## What changed

- Added `kamino_vault` preset — program `KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd`, kind `Lending("Kamino Vault")`
- Added `kamino_farms` preset — program `FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr`, kind `Lending("Kamino Farms")`
- Each preset bundles the program's Anchor IDL (`include_str!`), decodes instruction discriminators and args via `solana_parser::parse_instruction_with_idl`, zips instruction accounts against the IDL to produce named-account fields, and falls back to raw hex if parsing fails
- Registered both modules in `presets/mod.rs`; `build.rs` auto-discovers the `KaminoVaultVisualizer` / `KaminoFarmsVisualizer` types from the directory name
 
### Overview
<img width="1260" height="2479" alt="image" src="https://github.com/user-attachments/assets/2cdf1cb8-3d7e-437a-8416-f2826a35c07f" />

### Deposit Instruction
<img width="1260" height="2484" alt="image" src="https://github.com/user-attachments/assets/4ce5aace-b762-4d77-871b-a3e33abc84c2" />

### Farm instruction
<img width="1260" height="2481" alt="image" src="https://github.com/user-attachments/assets/17071031-acd6-46d2-a784-1de8d2581091" />


## Why this is safe

- Each visualizer is gated on its program ID via `SolanaIntegrationConfig.can_handle`, so it is never invoked for other programs
- If the bundled IDL fails to load or an instruction's discriminator matches nothing, the fallback path emits program ID + raw hex with an "IDL parsing failed" status — no worse than the current `unknown_program` output
- No changes to core types, signing paths, or other chain parsers
- The IDLs provided were fetched directly by the user from on-chain via `anchor idl fetch`

### Checks run (by agent)
- `cargo fmt -p visualsign-solana`
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean
- `cargo test -p visualsign-solana` — 8 new tests pass (4 per preset)
- `make -C src test` — full workspace green
- `make -C src lint` — clean

### Manual steps needed (by human)
None — fully automated by CI.

## How this is maintainable

- Both presets follow an identical generic IDL-driven shape (`load_idl` → `parse_instruction_with_idl` → `build_named_accounts` → `build_parsed_fields` → fallback). Adding a new IDL-only preset is a name-substitution copy. The `/solana-add-idl` skill scaffolds exactly this shape.
- Each preset has 4 guard tests: IDL loads, every instruction has an 8-byte discriminator, short data errors, garbage discriminator errors. These will fail loudly if Kamino publishes an IDL that drops instructions or changes discriminator shapes, flagging the drift at CI time.
- `build.rs` auto-discovers visualizers by directory name matching `{PascalName}Visualizer`, so there is no central registry to drift out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)