### PR TITLE
feat: add Kamino Borrow visualizer preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/config.rs
@@ -1,0 +1,22 @@
+use super::KAMINO_BORROW_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct KaminoBorrowConfig;
+
+impl SolanaIntegrationConfig for KaminoBorrowConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(KAMINO_BORROW_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/kamino_borrow.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/kamino_borrow.json
@@ -1,0 +1,1461 @@
+{
+  "version": "1.18.0",
+  "name": "kamino_lending",
+  "instructions": [
+    {
+      "name": "initLendingMarket",
+      "accounts": [
+        { "name": "lendingMarketOwner", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": true, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "quoteCurrency", "type": { "array": ["u8", 32] } }
+      ]
+    },
+    {
+      "name": "updateLendingMarket",
+      "accounts": [
+        { "name": "signer", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": "u64" },
+        { "name": "value", "type": { "array": ["u8", 72] } }
+      ]
+    },
+    {
+      "name": "updateLendingMarketOwner",
+      "accounts": [
+        { "name": "lendingMarketOwnerCached", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": true, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "initReserve",
+      "accounts": [
+        { "name": "signer", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "feeReceiver", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralSupply", "isMut": true, "isSigner": false },
+        { "name": "initialLiquiditySource", "isMut": true, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "cloneReserveConfig",
+      "accounts": [
+        { "name": "signer", "isMut": false, "isSigner": true },
+        { "name": "targetLendingMarket", "isMut": false, "isSigner": false },
+        { "name": "sourceReserve", "isMut": false, "isSigner": false },
+        { "name": "targetReserve", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "customizations", "type": { "defined": "ReserveConfigCustomizationArgs" } }
+      ]
+    },
+    {
+      "name": "initFarmsForReserve",
+      "accounts": [
+        { "name": "lendingMarketOwner", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false },
+        { "name": "farmsGlobalConfig", "isMut": false, "isSigner": false },
+        { "name": "farmState", "isMut": true, "isSigner": false },
+        { "name": "farmsVaultAuthority", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": "u8" }
+      ]
+    },
+    {
+      "name": "updateReserveConfig",
+      "accounts": [
+        { "name": "signer", "isMut": false, "isSigner": true },
+        { "name": "globalConfig", "isMut": false, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": { "defined": "UpdateConfigMode" } },
+        { "name": "value", "type": "bytes" },
+        { "name": "skipConfigIntegrityValidation", "type": "bool" }
+      ]
+    },
+    {
+      "name": "redeemFees",
+      "accounts": [
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+        { "name": "reserveSupplyLiquidity", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawProtocolFee",
+      "accounts": [
+        { "name": "globalConfig", "isMut": false, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "feeVault", "isMut": true, "isSigner": false },
+        { "name": "feeCollectorAta", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "amount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "seedDepositOnInitReserve",
+      "accounts": [
+        { "name": "signer", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "initialLiquiditySource", "isMut": true, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "socializeLoss",
+      "accounts": [
+        { "name": "lendingMarketOwner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "socializeLossV2",
+      "accounts": [
+        {
+          "name": "socializeLossAccounts",
+          "accounts": [
+            { "name": "lendingMarketOwner", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "reserve", "isMut": true, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "markObligationForDeleveraging",
+      "accounts": [
+        { "name": "lendingMarketOwner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "autodeleverageTargetLtvPct", "type": "u8" }
+      ]
+    },
+    {
+      "name": "refreshReserve",
+      "accounts": [
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "pythOracle", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "switchboardPriceOracle", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "switchboardTwapOracle", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "scopePrices", "isMut": false, "isSigner": false, "isOptional": true }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshReservesBatch",
+      "accounts": [],
+      "args": [
+        { "name": "skipPriceUpdates", "type": "bool" }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidity",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "redeemReserveCollateral",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "userSourceCollateral", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "initObligation",
+      "accounts": [
+        { "name": "obligationOwner", "isMut": false, "isSigner": true },
+        { "name": "feePayer", "isMut": true, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "seed1Account", "isMut": false, "isSigner": false },
+        { "name": "seed2Account", "isMut": false, "isSigner": false },
+        { "name": "ownerUserMetadata", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "args", "type": { "defined": "InitObligationArgs" } }
+      ]
+    },
+    {
+      "name": "initObligationFarmsForReserve",
+      "accounts": [
+        { "name": "payer", "isMut": true, "isSigner": true },
+        { "name": "owner", "isMut": false, "isSigner": false },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveFarmState", "isMut": true, "isSigner": false },
+        { "name": "obligationFarm", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": "u8" }
+      ]
+    },
+    {
+      "name": "refreshObligationFarmsForReserve",
+      "accounts": [
+        { "name": "crank", "isMut": false, "isSigner": true },
+        {
+          "name": "baseAccounts",
+          "accounts": [
+            { "name": "obligation", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "reserve", "isMut": false, "isSigner": false },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false },
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": "u8" }
+      ]
+    },
+    {
+      "name": "refreshObligation",
+      "accounts": [
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "obligation", "isMut": true, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositObligationCollateral",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "depositReserve", "isMut": true, "isSigner": false },
+        { "name": "reserveDestinationCollateral", "isMut": true, "isSigner": false },
+        { "name": "userSourceCollateral", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "depositObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "depositReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveDestinationCollateral", "isMut": true, "isSigner": false },
+            { "name": "userSourceCollateral", "isMut": true, "isSigner": false },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateral",
+      "accounts": [
+        { "name": "owner", "isMut": true, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+        { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+        { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+            { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "borrowObligationLiquidity",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "borrowReserve", "isMut": true, "isSigner": false },
+        { "name": "borrowReserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "borrowReserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "referrerTokenState", "isMut": true, "isSigner": false, "isOptional": true },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "borrowObligationLiquidityV2",
+      "accounts": [
+        {
+          "name": "borrowAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "borrowReserve", "isMut": true, "isSigner": false },
+            { "name": "borrowReserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "borrowReserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "referrerTokenState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "repayObligationLiquidity",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "repayReserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "repayObligationLiquidityV2",
+      "accounts": [
+        {
+          "name": "repayAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "repayReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "repayAndWithdrawAndRedeem",
+      "accounts": [
+        {
+          "name": "repayAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "repayReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+            { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "collateralFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        {
+          "name": "debtFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "repayAmount", "type": "u64" },
+        { "name": "withdrawCollateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "depositAndWithdraw",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "reserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "reserveDestinationDepositCollateral", "isMut": true, "isSigner": false },
+            { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+            { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "depositFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        {
+          "name": "withdrawFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" },
+        { "name": "withdrawCollateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidityAndObligationCollateral",
+      "accounts": [
+        { "name": "owner", "isMut": true, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "reserveDestinationDepositCollateral", "isMut": true, "isSigner": false },
+        { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidityAndObligationCollateralV2",
+      "accounts": [
+        {
+          "name": "depositAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "reserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "reserveDestinationDepositCollateral", "isMut": true, "isSigner": false },
+            { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralAndRedeemReserveCollateral",
+      "accounts": [
+        { "name": "owner", "isMut": true, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralAndRedeemReserveCollateralV2",
+      "accounts": [
+        {
+          "name": "withdrawAccounts",
+          "accounts": [
+            { "name": "owner", "isMut": true, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveSourceCollateral", "isMut": true, "isSigner": false },
+            { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "placeholderUserDestinationCollateral", "isMut": false, "isSigner": false, "isOptional": true },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "liquidateObligationAndRedeemReserveCollateral",
+      "accounts": [
+        { "name": "liquidator", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "repayReserve", "isMut": true, "isSigner": false },
+        { "name": "repayReserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "repayReserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+        { "name": "withdrawReserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "withdrawReserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "withdrawReserveCollateralSupply", "isMut": true, "isSigner": false },
+        { "name": "withdrawReserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "withdrawReserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+        { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "repayLiquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "withdrawLiquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" },
+        { "name": "minAcceptableReceivedLiquidityAmount", "type": "u64" },
+        { "name": "maxAllowedLtvOverridePercent", "type": "u64" }
+      ]
+    },
+    {
+      "name": "liquidateObligationAndRedeemReserveCollateralV2",
+      "accounts": [
+        {
+          "name": "liquidationAccounts",
+          "accounts": [
+            { "name": "liquidator", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "repayReserve", "isMut": true, "isSigner": false },
+            { "name": "repayReserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "repayReserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "withdrawReserve", "isMut": true, "isSigner": false },
+            { "name": "withdrawReserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "withdrawReserveCollateralMint", "isMut": true, "isSigner": false },
+            { "name": "withdrawReserveCollateralSupply", "isMut": true, "isSigner": false },
+            { "name": "withdrawReserveLiquiditySupply", "isMut": true, "isSigner": false },
+            { "name": "withdrawReserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+            { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "repayLiquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "withdrawLiquidityTokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "collateralFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        {
+          "name": "debtFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" },
+        { "name": "minAcceptableReceivedLiquidityAmount", "type": "u64" },
+        { "name": "maxAllowedLtvOverridePercent", "type": "u64" }
+      ]
+    },
+    {
+      "name": "flashRepayReserveLiquidity",
+      "accounts": [
+        { "name": "userTransferAuthority", "isMut": false, "isSigner": true },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "userSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+        { "name": "referrerTokenState", "isMut": true, "isSigner": false, "isOptional": true },
+        { "name": "referrerAccount", "isMut": true, "isSigner": false, "isOptional": true },
+        { "name": "sysvarInfo", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" },
+        { "name": "borrowInstructionIndex", "type": "u8" }
+      ]
+    },
+    {
+      "name": "flashBorrowReserveLiquidity",
+      "accounts": [
+        { "name": "userTransferAuthority", "isMut": false, "isSigner": true },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveSourceLiquidity", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+        { "name": "referrerTokenState", "isMut": true, "isSigner": false, "isOptional": true },
+        { "name": "referrerAccount", "isMut": true, "isSigner": false, "isOptional": true },
+        { "name": "sysvarInfo", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "liquidityAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "requestElevationGroup",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "elevationGroup", "type": "u8" }
+      ]
+    },
+    {
+      "name": "initReferrerTokenState",
+      "accounts": [
+        { "name": "payer", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": false, "isSigner": false },
+        { "name": "referrer", "isMut": false, "isSigner": false },
+        { "name": "referrerTokenState", "isMut": true, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "initUserMetadata",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "feePayer", "isMut": true, "isSigner": true },
+        { "name": "userMetadata", "isMut": true, "isSigner": false },
+        { "name": "referrerUserMetadata", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "userLookupTable", "type": "publicKey" }
+      ]
+    },
+    {
+      "name": "withdrawReferrerFees",
+      "accounts": [
+        { "name": "referrer", "isMut": true, "isSigner": true },
+        { "name": "referrerTokenState", "isMut": true, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveSupplyLiquidity", "isMut": true, "isSigner": false },
+        { "name": "referrerTokenAccount", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "tokenProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "initReferrerStateAndShortUrl",
+      "accounts": [
+        { "name": "referrer", "isMut": true, "isSigner": true },
+        { "name": "referrerState", "isMut": true, "isSigner": false },
+        { "name": "referrerShortUrl", "isMut": true, "isSigner": false },
+        { "name": "referrerUserMetadata", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "shortUrl", "type": "string" }
+      ]
+    },
+    {
+      "name": "deleteReferrerStateAndShortUrl",
+      "accounts": [
+        { "name": "referrer", "isMut": true, "isSigner": true },
+        { "name": "referrerState", "isMut": true, "isSigner": false },
+        { "name": "shortUrl", "isMut": true, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "setObligationOrder",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "index", "type": "u8" },
+        { "name": "order", "type": { "defined": "ObligationOrder" } }
+      ]
+    },
+    {
+      "name": "setBorrowOrder",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": false, "isSigner": false },
+        { "name": "filledDebtDestination", "isMut": false, "isSigner": false },
+        { "name": "debtLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false },
+        { "name": "eventAuthority", "isMut": false, "isSigner": false },
+        { "name": "program", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "orderConfig", "type": { "defined": "BorrowOrderConfigArgs" } },
+        { "name": "minExpectedCurrentRemainingDebtAmount", "type": "u64" }
+      ]
+    },
+    {
+      "name": "updateObligationConfig",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "obligation", "isMut": true, "isSigner": false },
+        { "name": "borrowReserve", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "depositReserve", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": { "defined": "UpdateObligationConfigMode" } },
+        { "name": "value", "type": "bytes" }
+      ]
+    },
+    {
+      "name": "rolloverFixedTermBorrow",
+      "accounts": [
+        {
+          "name": "rolloverAccounts",
+          "accounts": [
+            { "name": "payer", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "sourceBorrowReserve", "isMut": true, "isSigner": false },
+            { "name": "targetBorrowReserve", "isMut": true, "isSigner": false },
+            { "name": "liquidityMint", "isMut": false, "isSigner": false },
+            { "name": "sourceBorrowReserveLiquidity", "isMut": true, "isSigner": false },
+            { "name": "targetBorrowReserveLiquidity", "isMut": true, "isSigner": false },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "sourceFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        {
+          "name": "targetFarmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "fillBorrowOrder",
+      "accounts": [
+        {
+          "name": "borrowAccounts",
+          "accounts": [
+            { "name": "payer", "isMut": false, "isSigner": true },
+            { "name": "obligation", "isMut": true, "isSigner": false },
+            { "name": "lendingMarket", "isMut": false, "isSigner": false },
+            { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+            { "name": "borrowReserve", "isMut": true, "isSigner": false },
+            { "name": "borrowReserveLiquidityMint", "isMut": false, "isSigner": false },
+            { "name": "reserveSourceLiquidity", "isMut": true, "isSigner": false },
+            { "name": "borrowReserveLiquidityFeeReceiver", "isMut": true, "isSigner": false },
+            { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+            { "name": "referrerTokenState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "tokenProgram", "isMut": false, "isSigner": false },
+            { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+          ]
+        },
+        {
+          "name": "farmsAccounts",
+          "accounts": [
+            { "name": "obligationFarmUserState", "isMut": true, "isSigner": false, "isOptional": true },
+            { "name": "reserveFarmState", "isMut": true, "isSigner": false, "isOptional": true }
+          ]
+        },
+        { "name": "farmsProgram", "isMut": false, "isSigner": false },
+        { "name": "eventAuthority", "isMut": false, "isSigner": false },
+        { "name": "program", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "enqueueToWithdraw",
+      "accounts": [
+        { "name": "owner", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "userSourceCollateralTa", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidityTa", "isMut": false, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": false, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "withdrawTicket", "isMut": true, "isSigner": false },
+        { "name": "ownerQueuedCollateralVault", "isMut": true, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "progressCallbackCustomAccount0", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "progressCallbackCustomAccount1", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "collateralAmount", "type": "u64" },
+        { "name": "progressCallbackType", "type": { "defined": "ProgressCallbackType" } }
+      ]
+    },
+    {
+      "name": "withdrawQueuedLiquidity",
+      "accounts": [
+        { "name": "payer", "isMut": true, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquidityMint", "isMut": false, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": true, "isSigner": false },
+        { "name": "reserveLiquiditySupply", "isMut": true, "isSigner": false },
+        { "name": "ownerQueuedCollateralVault", "isMut": true, "isSigner": false },
+        { "name": "userDestinationLiquidity", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "liquidityTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "withdrawTicket", "isMut": true, "isSigner": false },
+        { "name": "withdrawTicketOwner", "isMut": true, "isSigner": false },
+        { "name": "associatedTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "progressCallbackProgram", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "progressCallbackCustomAccount0", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "progressCallbackCustomAccount1", "isMut": false, "isSigner": false, "isOptional": true },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [],
+      "returns": "bool"
+    },
+    {
+      "name": "recoverInvalidTicketCollateral",
+      "accounts": [
+        { "name": "payer", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": false, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": false, "isSigner": false },
+        { "name": "ownerQueuedCollateralVault", "isMut": true, "isSigner": false },
+        { "name": "userSourceCollateral", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "withdrawTicket", "isMut": true, "isSigner": false },
+        { "name": "withdrawTicketOwner", "isMut": true, "isSigner": false },
+        { "name": "instructionSysvarAccount", "isMut": false, "isSigner": false }
+      ],
+      "args": [
+        { "name": "ticketSequenceNumber", "type": "u64" }
+      ]
+    },
+    {
+      "name": "cancelWithdrawTicket",
+      "accounts": [
+        { "name": "owner", "isMut": false, "isSigner": true },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "lendingMarketAuthority", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false },
+        { "name": "reserveCollateralMint", "isMut": false, "isSigner": false },
+        { "name": "ownerQueuedCollateralVault", "isMut": true, "isSigner": false },
+        { "name": "userDestinationCollateral", "isMut": true, "isSigner": false },
+        { "name": "collateralTokenProgram", "isMut": false, "isSigner": false },
+        { "name": "withdrawTicket", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "ticketSequenceNumber", "type": "u64" },
+        { "name": "collateralAmountToCancel", "type": "u64" }
+      ]
+    },
+    {
+      "name": "initGlobalConfig",
+      "accounts": [
+        { "name": "payer", "isMut": true, "isSigner": true },
+        { "name": "globalConfig", "isMut": true, "isSigner": false },
+        { "name": "programData", "isMut": false, "isSigner": false },
+        { "name": "systemProgram", "isMut": false, "isSigner": false },
+        { "name": "rent", "isMut": false, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateGlobalConfig",
+      "accounts": [
+        { "name": "globalAdmin", "isMut": false, "isSigner": true },
+        { "name": "globalConfig", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "mode", "type": { "defined": "UpdateGlobalConfigMode" } },
+        { "name": "value", "type": "bytes" }
+      ]
+    },
+    {
+      "name": "updateGlobalConfigAdmin",
+      "accounts": [
+        { "name": "pendingAdmin", "isMut": false, "isSigner": true },
+        { "name": "globalConfig", "isMut": true, "isSigner": false }
+      ],
+      "args": []
+    },
+    {
+      "name": "idlMissingTypes",
+      "accounts": [
+        { "name": "signer", "isMut": false, "isSigner": true },
+        { "name": "globalConfig", "isMut": false, "isSigner": false },
+        { "name": "lendingMarket", "isMut": false, "isSigner": false },
+        { "name": "reserve", "isMut": true, "isSigner": false }
+      ],
+      "args": [
+        { "name": "reserveFarmKind", "type": { "defined": "ReserveFarmKind" } },
+        { "name": "feeCalculation", "type": { "defined": "FeeCalculation" } },
+        { "name": "reserveStatus", "type": { "defined": "ReserveStatus" } },
+        { "name": "updateConfigMode", "type": { "defined": "UpdateConfigMode" } },
+        { "name": "updateLendingMarketConfigValue", "type": { "defined": "UpdateLendingMarketConfigValue" } },
+        { "name": "updateLendingMarketConfigMode", "type": { "defined": "UpdateLendingMarketMode" } }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "name": "ReserveConfigCustomizationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "overrideFixedRateBps", "type": "u8" },
+          { "name": "fixedBorrowRateBps", "type": "u32" },
+          { "name": "overrideDebtTermSeconds", "type": "u8" },
+          { "name": "debtTermSeconds", "type": "u64" },
+          { "name": "clearElevationGroups", "type": "u8" }
+        ]
+      }
+    },
+    {
+      "name": "BorrowOrderConfigArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "remainingDebtAmount", "type": "u64" },
+          { "name": "maxBorrowRateBps", "type": "u32" },
+          { "name": "minDebtTermSeconds", "type": "u64" },
+          { "name": "fillableUntilTimestamp", "type": "u64" },
+          { "name": "enableAutoRolloverOnFilledBorrows", "type": "bool" }
+        ]
+      }
+    },
+    {
+      "name": "InitObligationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "tag", "type": "u8" },
+          { "name": "id", "type": "u8" }
+        ]
+      }
+    },
+    {
+      "name": "ObligationOrder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "conditionThresholdSf", "type": "u128" },
+          { "name": "opportunityParameterSf", "type": "u128" },
+          { "name": "minExecutionBonusBps", "type": "u16" },
+          { "name": "maxExecutionBonusBps", "type": "u16" },
+          { "name": "conditionType", "type": "u8" },
+          { "name": "opportunityType", "type": "u8" },
+          { "name": "padding1", "type": { "array": ["u8", 10] } },
+          { "name": "padding2", "type": { "array": ["u128", 5] } }
+        ]
+      }
+    },
+    {
+      "name": "UpdateConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "UpdateLoanToValuePct" },
+          { "name": "UpdateMaxLiquidationBonusBps" },
+          { "name": "UpdateLiquidationThresholdPct" },
+          { "name": "UpdateProtocolLiquidationFee" },
+          { "name": "UpdateProtocolTakeRate" },
+          { "name": "UpdateFeesOriginationFee" },
+          { "name": "UpdateFeesFlashLoanFee" },
+          { "name": "DeprecatedUpdateFeesReferralFeeBps" },
+          { "name": "UpdateDepositLimit" },
+          { "name": "UpdateBorrowLimit" },
+          { "name": "UpdateTokenInfoLowerHeuristic" },
+          { "name": "UpdateTokenInfoUpperHeuristic" },
+          { "name": "UpdateTokenInfoExpHeuristic" },
+          { "name": "UpdateTokenInfoTwapDivergence" },
+          { "name": "UpdateTokenInfoScopeTwap" },
+          { "name": "UpdateTokenInfoScopeChain" },
+          { "name": "UpdateTokenInfoName" },
+          { "name": "UpdateTokenInfoPriceMaxAge" },
+          { "name": "UpdateTokenInfoTwapMaxAge" },
+          { "name": "UpdateScopePriceFeed" },
+          { "name": "UpdatePythPrice" },
+          { "name": "UpdateSwitchboardFeed" },
+          { "name": "UpdateSwitchboardTwapFeed" },
+          { "name": "UpdateBorrowRateCurve" },
+          { "name": "DeprecatedUpdateEntireReserveConfig" },
+          { "name": "UpdateDebtWithdrawalCap" },
+          { "name": "UpdateDepositWithdrawalCap" },
+          { "name": "DeprecatedUpdateDebtWithdrawalCapCurrentTotal" },
+          { "name": "DeprecatedUpdateDepositWithdrawalCapCurrentTotal" },
+          { "name": "UpdateBadDebtLiquidationBonusBps" },
+          { "name": "UpdateMinLiquidationBonusBps" },
+          { "name": "UpdateDeleveragingMarginCallPeriod" },
+          { "name": "UpdateBorrowFactor" },
+          { "name": "DeprecatedUpdateAssetTier" },
+          { "name": "UpdateElevationGroup" },
+          { "name": "UpdateDeleveragingThresholdDecreaseBpsPerDay" },
+          { "name": "DeprecatedUpdateMultiplierSideBoost" },
+          { "name": "DeprecatedUpdateMultiplierTagBoost" },
+          { "name": "UpdateReserveStatus" },
+          { "name": "UpdateFarmCollateral" },
+          { "name": "UpdateFarmDebt" },
+          { "name": "UpdateDisableUsageAsCollateralOutsideEmode" },
+          { "name": "UpdateBlockBorrowingAboveUtilizationPct" },
+          { "name": "UpdateBlockPriceUsage" },
+          { "name": "UpdateBorrowLimitOutsideElevationGroup" },
+          { "name": "UpdateBorrowLimitsInElevationGroupAgainstThisReserve" },
+          { "name": "UpdateHostFixedInterestRateBps" },
+          { "name": "UpdateAutodeleverageEnabled" },
+          { "name": "UpdateDeleveragingBonusIncreaseBpsPerDay" },
+          { "name": "UpdateProtocolOrderExecutionFee" },
+          { "name": "UpdateProposerAuthorityLock" },
+          { "name": "UpdateMinDeleveragingBonusBps" },
+          { "name": "UpdateBlockCTokenUsage" },
+          { "name": "UpdateDebtMaturityTimestamp" },
+          { "name": "UpdateDebtTermSeconds" },
+          { "name": "UpdateEarlyRepayRemainingInterestPct" },
+          { "name": "UpdateReserveEmergencyMode" }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketConfigValue",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "Bool", "fields": ["bool"] },
+          { "name": "U8", "fields": ["u8"] },
+          { "name": "U8Array", "fields": [{ "array": ["u8", 8] }] },
+          { "name": "U16", "fields": ["u16"] },
+          { "name": "U64", "fields": ["u64"] },
+          { "name": "U128", "fields": ["u128"] },
+          { "name": "Pubkey", "fields": ["publicKey"] },
+          { "name": "ElevationGroup", "fields": [{ "defined": "ElevationGroup" }] },
+          { "name": "Name", "fields": [{ "array": ["u8", 32] }] }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "UpdateOwner" },
+          { "name": "UpdateEmergencyMode" },
+          { "name": "UpdateLiquidationCloseFactor" },
+          { "name": "UpdateLiquidationMaxValue" },
+          { "name": "DeprecatedUpdateGlobalUnhealthyBorrow" },
+          { "name": "UpdateGlobalAllowedBorrow" },
+          { "name": "UpdateEmergencyCouncil" },
+          { "name": "UpdateMinFullLiquidationThreshold" },
+          { "name": "UpdateInsolvencyRiskLtv" },
+          { "name": "UpdateElevationGroup" },
+          { "name": "UpdateReferralFeeBps" },
+          { "name": "DeprecatedUpdateMultiplierPoints" },
+          { "name": "UpdatePriceRefreshTriggerToMaxAgePct" },
+          { "name": "UpdateAutodeleverageEnabled" },
+          { "name": "UpdateBorrowingDisabled" },
+          { "name": "UpdateMinNetValueObligationPostAction" },
+          { "name": "UpdateMinValueLtvSkipPriorityLiqCheck" },
+          { "name": "UpdateMinValueBfSkipPriorityLiqCheck" },
+          { "name": "UpdatePaddingFields" },
+          { "name": "UpdateName" },
+          { "name": "UpdateIndividualAutodeleverageMarginCallPeriodSecs" },
+          { "name": "UpdateInitialDepositAmount" },
+          { "name": "UpdateObligationOrderExecutionEnabled" },
+          { "name": "UpdateImmutableFlag" },
+          { "name": "UpdateObligationOrderCreationEnabled" },
+          { "name": "UpdateProposerAuthority" },
+          { "name": "UpdatePriceTriggeredLiquidationDisabled" },
+          { "name": "UpdateMatureReserveDebtLiquidationEnabled" },
+          { "name": "UpdateObligationBorrowDebtTermLiquidationEnabled" },
+          { "name": "UpdateBorrowOrderCreationEnabled" },
+          { "name": "UpdateBorrowOrderExecutionEnabled" },
+          { "name": "UpdateMinBorrowOrderFillValue" },
+          { "name": "UpdateWithdrawTicketIssuanceEnabled" },
+          { "name": "UpdateWithdrawTicketRedemptionEnabled" },
+          { "name": "UpdateMinWithdrawQueuedLiquidityValue" },
+          { "name": "UpdateFixedTermRolloverWindowDurationSeconds" },
+          { "name": "UpdateOpenTermRolloverWindowDurationSeconds" },
+          { "name": "UpdateObligationBorrowRolloverConfigurationEnabled" },
+          { "name": "UpdateTermBasedFullLiquidationDurationSecs" },
+          { "name": "UpdateObligationBorrowMigrationToFixedExecutionEnabled" },
+          { "name": "UpdateMinPartialRolloverValue" },
+          { "name": "UpdateWithdrawTicketCancellationEnabled" }
+        ]
+      }
+    },
+    {
+      "name": "UpdateGlobalConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "PendingAdmin" },
+          { "name": "FeeCollector" }
+        ]
+      }
+    },
+    {
+      "name": "UpdateObligationConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "FixedTermRolloverEnabled" },
+          { "name": "FixedTermRolloverMaxBorrowRateBps" },
+          { "name": "FixedTermRolloverMinDebtTermSeconds" },
+          { "name": "FixedTermRolloverOpenTermAllowed" },
+          { "name": "MigrationToFixedEnabled" }
+        ]
+      }
+    },
+    {
+      "name": "FeeCalculation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "Exclusive" },
+          { "name": "Inclusive" }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFarmKind",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "Collateral" },
+          { "name": "Debt" }
+        ]
+      }
+    },
+    {
+      "name": "ReserveStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "Active" },
+          { "name": "Obsolete" },
+          { "name": "Hidden" }
+        ]
+      }
+    },
+    {
+      "name": "ProgressCallbackType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          { "name": "None" },
+          { "name": "KlendQueueAccountingHandlerOnKvault" }
+        ]
+      }
+    },
+    {
+      "name": "ElevationGroup",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          { "name": "maxLiquidationBonusBps", "type": "u16" },
+          { "name": "id", "type": "u8" },
+          { "name": "ltvPct", "type": "u8" },
+          { "name": "liquidationThresholdPct", "type": "u8" },
+          { "name": "allowNewLoans", "type": "u8" },
+          { "name": "maxReservesAsCollateral", "type": "u8" },
+          { "name": "padding0", "type": "u8" },
+          { "name": "debtReserve", "type": "publicKey" },
+          { "name": "padding1", "type": { "array": ["u64", 4] } }
+        ]
+      }
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/mod.rs
@@ -1,0 +1,290 @@
+//! Kamino Borrow preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::KaminoBorrowConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const KAMINO_BORROW_PROGRAM_ID: &str = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
+
+const KAMINO_BORROW_IDL_JSON: &str = include_str!("kamino_borrow.json");
+
+static KAMINO_BORROW_CONFIG: KaminoBorrowConfig = KaminoBorrowConfig;
+
+pub struct KaminoBorrowVisualizer;
+
+impl InstructionVisualizer for KaminoBorrowVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let instruction_data_hex = hex::encode(&instruction.data);
+        let fallback_text = format!(
+            "Program ID: {}\nData: {instruction_data_hex}",
+            instruction.program_id,
+        );
+
+        let parsed = parse_kamino_borrow_instruction(&instruction.data, &instruction.accounts);
+
+        let (title, condensed_fields, expanded_fields) = match parsed {
+            Ok(parsed) => build_parsed_fields(&parsed, &instruction.program_id.to_string()),
+            Err(_) => build_fallback_fields(&instruction.program_id.to_string()),
+        };
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        let expanded_with_raw =
+            append_raw_data(expanded_fields, &instruction.data, &instruction_data_hex);
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_with_raw,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&KAMINO_BORROW_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Lending("Kamino Borrow")
+    }
+}
+
+fn get_kamino_borrow_idl() -> Option<Idl> {
+    decode_idl_data(KAMINO_BORROW_IDL_JSON).ok()
+}
+
+fn parse_kamino_borrow_instruction(
+    data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> Result<KaminoBorrowParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_kamino_borrow_idl().ok_or("Kamino Borrow IDL not available")?;
+    let parsed = parse_instruction_with_idl(data, KAMINO_BORROW_PROGRAM_ID, &idl)?;
+
+    let named_accounts = build_named_accounts(data, &idl, accounts);
+
+    Ok(KaminoBorrowParsedInstruction {
+        parsed,
+        named_accounts,
+    })
+}
+
+fn build_named_accounts(
+    data: &[u8],
+    idl: &Idl,
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named_accounts = HashMap::new();
+
+    let idl_instruction = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.len() >= disc.len() && data[..disc.len()] == *disc)
+    });
+
+    if let Some(idl_instruction) = idl_instruction {
+        for (index, account_meta) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+            }
+        }
+    }
+
+    named_accounts
+}
+
+struct KaminoBorrowParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: HashMap<String, String>,
+}
+
+fn build_parsed_fields(
+    instruction: &KaminoBorrowParsedInstruction,
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let parsed = &instruction.parsed;
+    let title = format!("Kamino Borrow: {}", parsed.instruction_name);
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    if let Ok(f) = create_text_field("Program", "Kamino Borrow") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        condensed_fields.push(f);
+    }
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            condensed_fields.push(f);
+        }
+    }
+
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Instruction", &parsed.instruction_name) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Discriminator", &parsed.discriminator) {
+        expanded_fields.push(f);
+    }
+
+    for (account_name, account_address) in &instruction.named_accounts {
+        if let Ok(f) = create_text_field(account_name, account_address) {
+            expanded_fields.push(f);
+        }
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        if let Ok(f) = create_text_field(key, &format_arg_value(value)) {
+            expanded_fields.push(f);
+        }
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn build_fallback_fields(
+    program_id: &str,
+) -> (
+    String,
+    Vec<AnnotatedPayloadField>,
+    Vec<AnnotatedPayloadField>,
+) {
+    let title = "Kamino Borrow: Unknown Instruction".to_string();
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    if let Ok(f) = create_text_field("Program", "Kamino Borrow") {
+        condensed_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        condensed_fields.push(f);
+    }
+
+    if let Ok(f) = create_text_field("Program ID", program_id) {
+        expanded_fields.push(f);
+    }
+    if let Ok(f) = create_text_field("Status", "Unknown instruction type") {
+        expanded_fields.push(f);
+    }
+
+    (title, condensed_fields, expanded_fields)
+}
+
+fn append_raw_data(
+    mut fields: Vec<AnnotatedPayloadField>,
+    data: &[u8],
+    hex_str: &str,
+) -> Vec<AnnotatedPayloadField> {
+    if let Ok(f) = create_raw_data_field(data, Some(hex_str.to_string())) {
+        fields.push(f);
+    }
+    fields
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kamino_borrow_idl_loads() {
+        let idl = get_kamino_borrow_idl();
+        assert!(idl.is_some(), "Kamino Borrow IDL should load successfully");
+        let idl = idl.unwrap();
+        assert!(!idl.instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_kamino_borrow_idl_has_discriminators() {
+        let idl = get_kamino_borrow_idl().unwrap();
+        for instruction in &idl.instructions {
+            assert!(
+                instruction.discriminator.is_some(),
+                "Instruction '{}' should have a computed discriminator",
+                instruction.name
+            );
+            let disc = instruction.discriminator.as_ref().unwrap();
+            assert_eq!(
+                disc.len(),
+                8,
+                "Discriminator for '{}' should be 8 bytes",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        let accounts = vec![];
+        let result = parse_kamino_borrow_instruction(&garbage_data, &accounts);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short_data = [0x01, 0x02, 0x03];
+        let accounts = vec![];
+        let result = parse_kamino_borrow_instruction(&short_data, &accounts);
+        assert!(result.is_err(), "Short data should return error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_borrow/mod.rs
@@ -9,7 +9,7 @@ use config::KaminoBorrowConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -114,8 +114,8 @@ fn build_named_accounts(
     data: &[u8],
     idl: &Idl,
     accounts: &[solana_sdk::instruction::AccountMeta],
-) -> HashMap<String, String> {
-    let mut named_accounts = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named_accounts = BTreeMap::new();
 
     let idl_instruction = idl.instructions.iter().find(|inst| {
         inst.discriminator
@@ -136,7 +136,7 @@ fn build_named_accounts(
 
 struct KaminoBorrowParsedInstruction {
     parsed: SolanaParsedInstructionData,
-    named_accounts: HashMap<String, String>,
+    named_accounts: BTreeMap<String, String>,
 }
 
 fn build_parsed_fields(

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -3,6 +3,7 @@ pub mod compute_budget;
 pub mod dflow_aggregator;
 pub mod jupiter_earn;
 pub mod jupiter_swap;
+pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
 pub mod stakepool;


### PR DESCRIPTION
## Why this PR exists

Kamino Borrow is a Solana lending program (`KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD`) not currently supported by the parser. Without a preset, transactions signing against it render as raw hex in wallets instead of decoded instruction names, named accounts, and typed arguments.

## What changed

- New `visualsign-solana` preset `kamino_borrow` with the program's Anchor IDL embedded as `kamino_borrow.json` (55 instructions covering init/refresh/deposit/borrow/repay/liquidate and their V2 variants).
- `KaminoBorrowVisualizer` implements `InstructionVisualizer` with `VisualizerKind::Lending(\"Kamino Borrow\")`, delegating parsing to `solana_parser::parse_instruction_with_idl` and mapping IDL account definitions to instruction accounts by index.
- Registered in `presets/mod.rs` (alphabetical); `build.rs` auto-discovers the visualizer.

<img width="732" height="3358" alt="image" src="https://github.com/user-attachments/assets/79239bee-5f38-4693-9563-4c9ee0bb97c9" />


## Why this is safe

- Pure addition: no existing preset, shared helper, or trait is modified. Other programs continue resolving to their current visualizers; only calls to the new program ID change behavior.
- Parsing failures (unknown discriminator, short data) fall back to a generic \"Unknown Instruction\" field set, so a malformed or future instruction still renders with program ID and raw hex rather than erroring.
- The generic IDL pattern is shared with the existing `jupiter_swap` and prior `squads_multisig` presets — no Kamino-specific decoding or unsafe deserialization.

#### Checks run (by agent)
- `cargo fmt -p visualsign-solana`
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings`
- `cargo test -p visualsign-solana` (all 4 new tests + existing suites pass)
- `make -C src test` (full workspace, no failures)

#### Manual steps needed (by human)
None — fully automated by CI.

## How this is maintainable

- Scaffolded via the `/solana-add-idl` skill, so a fresh agent can regenerate an equivalent preset from the skill's documented template.
- The preset follows the same generic IDL shape (`build_named_accounts` / `build_parsed_fields` / `build_fallback_fields` / `append_raw_data` / `format_arg_value`) used by other IDL-based presets; touching one teaches you the rest.
- Four unit tests pin the invariants: IDL loads, every instruction has an 8-byte Anchor discriminator, unknown discriminators error, and short data errors. A Kamino IDL update that drops or renames an instruction will surface in the discriminator test.
- The IDL JSON is checked in verbatim; re-fetching and diffing it is the upgrade path when Kamino ships a new program version.