### PR TITLE
feat: add Onre App Solana IDL visualizer preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -6,6 +6,7 @@ pub mod jupiter_swap;
 pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
+pub mod onre_app;
 pub mod stakepool;
 pub mod swig_wallet;
 pub mod system;

--- a/src/chain_parsers/visualsign-solana/src/presets/onre_app/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/onre_app/config.rs
@@ -1,0 +1,23 @@
+use super::ONRE_APP_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct OnreAppConfig;
+
+impl SolanaIntegrationConfig for OnreAppConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs: HashMap<&'static str, HashMap<&'static str, Vec<&'static str>>> =
+                HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(ONRE_APP_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/onre_app/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/onre_app/mod.rs
@@ -1,0 +1,220 @@
+//! Onre App preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::OnreAppConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const ONRE_APP_PROGRAM_ID: &str = "onreuGhHHgVzMWSkj2oQDLDtvvGvoepBPkqyaubFcwe";
+
+const ONRE_APP_IDL_JSON: &str = include_str!("onre_app.json");
+
+static ONRE_APP_CONFIG: OnreAppConfig = OnreAppConfig;
+
+#[derive(Debug, Clone)]
+pub struct OnreAppParsedInstruction {
+    pub parsed: SolanaParsedInstructionData,
+    pub named_accounts: Vec<(String, String)>,
+}
+
+pub struct OnreAppVisualizer;
+
+impl InstructionVisualizer for OnreAppVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let instruction_number = context.instruction_index() + 1;
+        let program_id_str = instruction.program_id.to_string();
+        let instruction_data_hex = hex::encode(&instruction.data);
+
+        let decoded = parse_onre_app_instruction(&instruction.data, &instruction.accounts)
+            .map_err(|e| VisualSignError::DecodeError(e.to_string()))?;
+
+        let instruction_name = decoded.parsed.instruction_name.clone();
+        let summary = format!("Onre App: {instruction_name}");
+
+        let mut condensed_fields = vec![
+            create_text_field("Instruction", &summary)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        ];
+        for (key, value) in &decoded.parsed.program_call_args {
+            condensed_fields.push(
+                create_text_field(key, &format_arg_value(value))
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            );
+        }
+
+        let mut expanded_fields = vec![
+            create_text_field("Program ID", &program_id_str)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            create_text_field("Instruction", &instruction_name)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            create_text_field("Discriminator", &decoded.parsed.discriminator)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        ];
+        for (account_name, account_address) in &decoded.named_accounts {
+            expanded_fields.push(
+                create_text_field(account_name, account_address)
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            );
+        }
+        for (key, value) in &decoded.parsed.program_call_args {
+            expanded_fields.push(
+                create_text_field(key, &format_arg_value(value))
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            );
+        }
+        expanded_fields.push(
+            create_raw_data_field(&instruction.data, Some(instruction_data_hex.clone()))
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_fields,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 {
+                text: summary.clone(),
+            }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: "Onre App".to_string(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        let fallback_text = format!("Program ID: {program_id_str}\nData: {instruction_data_hex}");
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {instruction_number}"),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&ONRE_APP_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex("Onre App")
+    }
+}
+
+fn get_onre_app_idl() -> Result<Idl, Box<dyn std::error::Error>> {
+    decode_idl_data(ONRE_APP_IDL_JSON)
+}
+
+fn parse_onre_app_instruction(
+    data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> Result<OnreAppParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_onre_app_idl()?;
+    let parsed = parse_instruction_with_idl(data, ONRE_APP_PROGRAM_ID, &idl)?;
+
+    let mut named_accounts: Vec<(String, String)> = Vec::new();
+    if let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        if let Some(ref disc) = inst.discriminator {
+            data.len() >= 8 && &data[0..8] == disc.as_slice()
+        } else {
+            false
+        }
+    }) {
+        for (index, account_meta) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.push((idl_account.name.clone(), account_meta.pubkey.to_string()));
+            }
+        }
+    }
+
+    Ok(OnreAppParsedInstruction {
+        parsed,
+        named_accounts,
+    })
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_onre_app_idl_loads() {
+        let idl = get_onre_app_idl().expect("IDL should decode");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should contain instructions"
+        );
+    }
+
+    #[test]
+    fn test_onre_app_idl_has_discriminators() {
+        let idl = get_onre_app_idl().expect("IDL should decode");
+        for inst in &idl.instructions {
+            let disc = inst
+                .discriminator
+                .as_ref()
+                .unwrap_or_else(|| panic!("Instruction {} missing discriminator", inst.name));
+            assert_eq!(
+                disc.len(),
+                8,
+                "Instruction {} discriminator should be 8 bytes",
+                inst.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage: [u8; 9] = [0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x00];
+        let result = parse_onre_app_instruction(&garbage, &[]);
+        assert!(
+            result.is_err(),
+            "Unknown discriminator should produce an error"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short: [u8; 3] = [0x01, 0x02, 0x03];
+        let result = parse_onre_app_instruction(&short, &[]);
+        assert!(result.is_err(), "Short data should produce an error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/onre_app/onre_app.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/onre_app/onre_app.json
@@ -1,0 +1,8997 @@
+{
+  "address": "onreuGhHHgVzMWSkj2oQDLDtvvGvoepBPkqyaubFcwe",
+  "metadata": {
+    "name": "onreapp",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "docs": [
+    "The main program module for the Onre App.",
+    "",
+    "This module defines the entry points for all program instructions. It facilitates the creation",
+    "and management of offers where a \"boss\" provides one or two types of buy tokens in exchange for",
+    "sell tokens. A key feature is the dynamic pricing model for offers, where the amount of",
+    "sell token required can change over the offer's duration based on predefined parameters.",
+    "",
+    "Core functionalities include:",
+    "- Making offers with dynamic pricing (`make_offer`).",
+    "- Taking offers with current market pricing (`take_offer`, `take_offer_permissionless`).",
+    "- Managing offer vectors for price control (`add_offer_vector`, `delete_offer_vector`).",
+    "- Program state initialization and management (`initialize`, `set_boss`, `add_admin`, `remove_admin`).",
+    "- Vault operations for token deposits and withdrawals (`offer_vault_deposit`, `offer_vault_withdraw`).",
+    "- Market information queries (`get_nav`, `get_apy`, `get_tvl`, `get_circulating_supply`).",
+    "- Mint authority management (`transfer_mint_authority_to_program`, `transfer_mint_authority_to_boss`).",
+    "- Emergency controls (`set_kill_switch`) and approval mechanisms (`set_approver`).",
+    "",
+    "# Dynamic Pricing Model",
+    "The price for offers is determined by time-based vectors with APR (Annual Percentage Rate) growth:",
+    "- `base_time`: The timestamp when the vector becomes active.",
+    "- `base_price`: The initial price at the base_time with 9 decimal precision.",
+    "- `apr`: Annual percentage rate scaled by 1,000,000 (e.g., 1_000_000 = 1% APR).",
+    "- `price_fix_duration`: Duration in seconds for each discrete pricing step.",
+    "The price increases over time based on the APR, calculated in discrete intervals.",
+    "",
+    "# Security",
+    "- Access controls are enforced, for example, ensuring only the `boss` can create offers or update critical state.",
+    "- PDA (Program Derived Address) accounts are used for offer and token authorities, ensuring ownership.",
+    "- Events are emitted for significant actions (e.g., `OfferMadeOne`, `OfferTakenTwo`) for off-chain traceability."
+  ],
+  "instructions": [
+    {
+      "name": "accept_boss",
+      "docs": [
+        "Accepts the proposed boss transfer.",
+        "",
+        "Delegates to `accept_boss::accept_boss` to complete the ownership transfer.",
+        "This is the second step in a two-step ownership transfer process.",
+        "Only the proposed boss can call this instruction to accept and become the new boss.",
+        "Emits a `BossAcceptedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `AcceptBoss`."
+      ],
+      "discriminator": [
+        152,
+        63,
+        117,
+        209,
+        67,
+        11,
+        250,
+        242
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the boss and proposed_boss",
+            "",
+            "Must be mutable to allow boss field modification."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "new_boss",
+          "docs": [
+            "The proposed new boss account accepting the ownership transfer"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "add_admin",
+      "docs": [
+        "Adds a new admin to the state.",
+        "",
+        "Delegates to `admin::add_admin` to add a new admin to the admin list.",
+        "Only the boss can call this instruction to add new admins.",
+        "# Arguments",
+        "- `ctx`: Context for `AddAdmin`.",
+        "- `new_admin`: Public key of the new admin to be added."
+      ],
+      "discriminator": [
+        177,
+        236,
+        33,
+        205,
+        124,
+        152,
+        55,
+        186
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the admin list",
+            "",
+            "Must be mutable to allow admin list modifications and have the",
+            "boss account as the authorized signer for admin management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to add new admins"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "add_approver",
+      "docs": [
+        "Adds a trusted authority for approval verification.",
+        "",
+        "This instruction allows the boss to add an approver to one of the two available",
+        "approver slots. If both slots are already filled, the instruction will fail.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `AddApprover`.",
+        "- `approver`: Public key of the approver to add."
+      ],
+      "discriminator": [
+        213,
+        245,
+        135,
+        79,
+        129,
+        129,
+        22,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "approver",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "add_offer_vector",
+      "docs": [
+        "Adds a time vector to an existing offer.",
+        "",
+        "Delegates to `offer::add_offer_time_vector`.",
+        "Creates a new time vector with auto-generated vector_start_timestamp for the specified offer.",
+        "Emits a `OfferVectorAdded` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `AddOfferVector`.",
+        "- `start_time`: Unix timestamp when the vector becomes active.",
+        "- `base_time`: Unix timestamp when the vector becomes active.",
+        "- `base_price`: Price at the beginning of the vector.",
+        "- `apr`: Annual Percentage Rate (APR) (see OfferVector::apr for details).",
+        "- `price_fix_duration`: Duration in seconds for each price interval."
+      ],
+      "discriminator": [
+        198,
+        139,
+        180,
+        6,
+        156,
+        171,
+        188,
+        61
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account to which the pricing vector will be added",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains the array of pricing vectors for the offer."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to add pricing vectors to offers"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "start_time",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "base_time",
+          "type": "u64"
+        },
+        {
+          "name": "base_price",
+          "type": "u64"
+        },
+        {
+          "name": "apr",
+          "type": "u64"
+        },
+        {
+          "name": "price_fix_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "cancel_redemption_request",
+      "docs": [
+        "Cancels a redemption request.",
+        "",
+        "Delegates to `redemption::cancel_redemption_request`.",
+        "This instruction cancels a pending redemption request. The request can be cancelled",
+        "by the redeemer, redemption_admin, or boss. Upon cancellation, the status is changed",
+        "to cancelled and the amount is subtracted from the redemption offer's requested_redemptions.",
+        "The redemption request account is NOT closed.",
+        "Emits a `RedemptionRequestCancelledEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `CancelRedemptionRequest`.",
+        "",
+        "# Access Control",
+        "- Signer must be one of: redeemer, redemption_admin, or boss",
+        "- Request must be in pending state (status = 0)"
+      ],
+      "discriminator": [
+        77,
+        155,
+        4,
+        179,
+        114,
+        233,
+        162,
+        45
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing redemption_admin and boss for authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_offer",
+          "docs": [
+            "The redemption offer account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_in_mint",
+                "account": "RedemptionOffer"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_out_mint",
+                "account": "RedemptionOffer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_request",
+          "docs": [
+            "The redemption request account to cancel",
+            "Account is closed after cancellation and rent is returned to redemption_admin"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  114,
+                  101,
+                  113,
+                  117,
+                  101,
+                  115,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_request.offer",
+                "account": "RedemptionRequest"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_request.request_id",
+                "account": "RedemptionRequest"
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The signer who is cancelling the request",
+            "Can be either the redeemer, redemption_admin, or boss"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "redeemer",
+          "docs": [
+            "The redeemer's account (authority for the token account)"
+          ]
+        },
+        {
+          "name": "redemption_admin",
+          "docs": [
+            "Redemption admin receives the rent from closing the redemption request"
+          ],
+          "writable": true
+        },
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived authority that controls redemption vault token accounts",
+            "",
+            "This PDA manages the redemption vault token accounts and enables the program",
+            "to return locked tokens when requests are cancelled."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The token mint for token_in (input token)"
+          ]
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Redemption vault's token account serving as the source of locked tokens",
+            "",
+            "Contains the tokens that were locked when the request was created."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "redeemer_token_account",
+          "docs": [
+            "Redeemer's token account serving as the destination for returned tokens",
+            "",
+            "Receives back the tokens that were locked in the redemption request.",
+            "Created if needed in case the redeemer closed their account after locking all tokens."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redeemer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "clear_admins",
+      "docs": [
+        "Clears all admins from the state.",
+        "",
+        "Delegates to `admin::clear_admins` to remove all admins from the admin list.",
+        "Only the boss can call this instruction to clear all admins."
+      ],
+      "discriminator": [
+        39,
+        200,
+        132,
+        30,
+        196,
+        160,
+        73,
+        55
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the admin list to be cleared",
+            "",
+            "Must be mutable to allow admin list modifications and have the",
+            "boss account as the authorized signer for admin management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to clear all admin privileges"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_state",
+      "docs": [
+        "Closes the program state account and returns the rent to the boss.",
+        "",
+        "Delegates to `state_operations::close_state`.",
+        "This instruction permanently deletes the program's main state account",
+        "and transfers its rent balance back to the boss. Once closed, the state",
+        "cannot be recovered and the program becomes effectively non-functional.",
+        "Only the boss can call this instruction.",
+        "Emits a `StateClosedEvent` upon success.",
+        "",
+        "# Warning",
+        "This is a destructive operation that effectively disables the program.",
+        "Use with extreme caution.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `CloseState`."
+      ],
+      "discriminator": [
+        25,
+        1,
+        184,
+        101,
+        200,
+        245,
+        210,
+        246
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "The state account to be closed and its rent reclaimed",
+            "",
+            "This account is validated as a PDA derived from the \"state\" seed.",
+            "The account will be closed and its rent transferred to the boss.",
+            ""
+          ],
+          "writable": true
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to close the state and receive rent",
+            "",
+            "Must match the boss stored in the state account.",
+            "This signer will receive the rent from the closed state account."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program required for account closure and rent transfer"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "configure_max_supply",
+      "docs": [
+        "Configures the maximum supply cap for ONyc token minting.",
+        "",
+        "Delegates to `state_operations::configure_max_supply`.",
+        "This instruction allows the boss to set or update the maximum supply cap",
+        "that restricts ONyc token minting. Setting to 0 removes the cap.",
+        "Emits a `MaxSupplyConfigured` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `ConfigureMaxSupply`.",
+        "- `max_supply`: The maximum supply cap in base units (0 = no cap)."
+      ],
+      "discriminator": [
+        145,
+        100,
+        133,
+        229,
+        142,
+        59,
+        96,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the max supply configuration",
+            "",
+            "Must be mutable to allow max supply updates and have the boss account",
+            "as the authorized signer for supply cap management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to configure the max supply"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "max_supply",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_redemption_request",
+      "docs": [
+        "Creates a redemption request.",
+        "",
+        "Delegates to `redemption::create_redemption_request`.",
+        "This instruction creates a new redemption request that allows users to request",
+        "redemption of token_in tokens for token_out tokens at a future time. Anyone can",
+        "create a redemption request by paying for the PDA rent.",
+        "Emits a `RedemptionRequestCreatedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `CreateRedemptionRequest`.",
+        "- `amount`: Amount of token_in tokens to redeem."
+      ],
+      "discriminator": [
+        201,
+        53,
+        181,
+        254,
+        115,
+        137,
+        70,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account for kill switch validation"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_offer",
+          "docs": [
+            "The redemption offer account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_in_mint",
+                "account": "RedemptionOffer"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_out_mint",
+                "account": "RedemptionOffer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_request",
+          "docs": [
+            "The redemption request account",
+            "PDA derived from redemption_offer and its counter value"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  114,
+                  101,
+                  113,
+                  117,
+                  101,
+                  115,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.request_counter",
+                "account": "RedemptionOffer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redeemer",
+          "docs": [
+            "User requesting the redemption (pays for account creation)"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived authority that controls redemption vault token accounts",
+            "",
+            "This PDA manages the redemption vault token accounts and enables the program",
+            "to hold tokens until redemption requests are fulfilled or cancelled."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The token mint for token_in (input token)"
+          ]
+        },
+        {
+          "name": "redeemer_token_account",
+          "docs": [
+            "Redeemer's token account serving as the source of deposited tokens",
+            "",
+            "Must have sufficient balance to cover the requested amount."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redeemer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Redemption vault's token account serving as the destination for locked tokens",
+            "",
+            "Must exist. Stores tokens that are locked until the redemption request is",
+            "fulfilled or cancelled."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "delete_all_offer_vectors",
+      "docs": [
+        "Deletes all time vectors from an offer.",
+        "",
+        "Delegates to `offer::delete_all_offer_vectors`.",
+        "Removes all time vectors from the offer regardless of their timing (past, active, or future).",
+        "Only the boss can delete time vectors from offers.",
+        "Emits a `AllOfferVectorsDeletedEvent` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `DeleteAllOfferVectors`."
+      ],
+      "discriminator": [
+        26,
+        201,
+        38,
+        207,
+        76,
+        51,
+        79,
+        15
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account from which all pricing vectors will be deleted",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains the array of pricing vectors for the offer."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to delete pricing vectors from offers"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "delete_offer_vector",
+      "docs": [
+        "Deletes a time vector from an offer.",
+        "",
+        "Delegates to `offer::delete_offer_vector`.",
+        "Removes the specified time vector from the offer by setting it to default values.",
+        "Only the boss can delete time vectors from offers.",
+        "Emits a `OfferVectorDeleted` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `DeleteOfferVector`.",
+        "- `vector_start_time`: Start time of the vector to delete."
+      ],
+      "discriminator": [
+        87,
+        40,
+        79,
+        151,
+        78,
+        121,
+        46,
+        159
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account from which the pricing vector will be deleted",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains the array of pricing vectors for the offer."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to delete pricing vectors from offers"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "vector_start_time",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "fulfill_redemption_request",
+      "docs": [
+        "Fulfills a redemption request.",
+        "",
+        "Delegates to `redemption::fulfill_redemption_request`.",
+        "This instruction fulfills a pending redemption request by handling token operations:",
+        "- Burns token_in (ONyc) if program has mint authority, else sends to boss",
+        "- Mints token_out if program has mint authority, else transfers from vault",
+        "- Uses current price from the underlying offer to calculate token_out amount",
+        "Emits a `RedemptionRequestFulfilledEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `FulfillRedemptionRequest`.",
+        "",
+        "# Access Control",
+        "- Only redemption_admin can fulfill redemptions"
+      ],
+      "discriminator": [
+        140,
+        124,
+        139,
+        242,
+        179,
+        153,
+        208,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing redemption_admin and boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account that may receive tokens when program lacks mint authority"
+          ],
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "offer",
+          "docs": [
+            "The underlying offer that defines pricing"
+          ]
+        },
+        {
+          "name": "redemption_offer",
+          "docs": [
+            "The redemption offer account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_in_mint",
+                "account": "RedemptionOffer"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_out_mint",
+                "account": "RedemptionOffer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_request",
+          "docs": [
+            "The redemption request account to fulfill",
+            "Account is closed after fulfillment and rent is returned to redemption_admin"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  114,
+                  101,
+                  113,
+                  117,
+                  101,
+                  115,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_request.offer",
+                "account": "RedemptionRequest"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_request.request_id",
+                "account": "RedemptionRequest"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived redemption vault authority that controls token operations",
+            "",
+            "This PDA manages token transfers and burning operations."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_token_in_account",
+          "docs": [
+            "Redemption vault account for token_in (to receive tokens for burning or storage)",
+            "",
+            "Used as intermediate account when burning token_in or as permanent storage",
+            "when program lacks mint authority."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_out_account",
+          "docs": [
+            "Redemption vault account for token_out distribution when using transfer mechanism",
+            "",
+            "Source of output tokens when the program lacks mint authority",
+            "and must transfer from pre-funded vault instead of minting."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "Input token mint (typically ONyc)",
+            "",
+            "Must be mutable to allow burning operations when program has mint authority."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_in_program",
+          "docs": [
+            "Token program interface for input token operations"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "Output token mint (typically stablecoin like USDC)",
+            "",
+            "Must be mutable to allow minting operations when program has mint authority."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_out_program",
+          "docs": [
+            "Token program interface for output token operations"
+          ]
+        },
+        {
+          "name": "user_token_out_account",
+          "docs": [
+            "User's output token account (destination for redeemed tokens)",
+            "",
+            "Created automatically if it doesn't exist."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redeemer"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss_token_in_account",
+          "docs": [
+            "Boss's input token account for receiving tokens when program lacks mint authority",
+            "",
+            "Only used when program doesn't have mint authority of token_in."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived mint authority for direct token minting",
+            "",
+            "Used when the program has mint authority and can mint token_out directly."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "redeemer",
+          "docs": [
+            "The user who created the redemption request"
+          ]
+        },
+        {
+          "name": "redemption_admin",
+          "docs": [
+            "Redemption admin must sign to authorize fulfillment"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program required for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "get_apy",
+      "docs": [
+        "Gets the current APY (Annual Percentage Yield) for a specific offer.",
+        "",
+        "Delegates to `market_info::get_apy`.",
+        "This is a read-only instruction that calculates and returns the current APY",
+        "by converting the stored APR using daily compounding formula.",
+        "Emits a `GetAPYEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `GetAPY`.",
+        "",
+        "# Returns",
+        "- `Ok(apy)`: The calculated APY scaled by 1_000_000 (returns the mantissa, with scale=6)"
+      ],
+      "discriminator": [
+        194,
+        123,
+        183,
+        54,
+        181,
+        74,
+        194,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing the pricing vectors and APR data",
+            "",
+            "This account is validated as a PDA derived from the \"offer\" seed combined",
+            "with both token mint addresses. Contains the time-based pricing vectors",
+            "that include the APR values used for APY calculation."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation",
+            "",
+            "Must match the token_in_mint stored in the offer account to ensure",
+            "the correct offer is being queried. This validation prevents",
+            "accidental queries against incorrect token pairs."
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation",
+            "",
+            "Must match the token_out_mint stored in the offer account to ensure",
+            "the correct offer is being queried. This validation prevents",
+            "accidental queries against incorrect token pairs."
+          ]
+        }
+      ],
+      "args": [],
+      "returns": "u64"
+    },
+    {
+      "name": "get_circulating_supply",
+      "docs": [
+        "Delegates to `market_info::get_circulating_supply`.",
+        "This is a read-only instruction that calculates and returns the current circulating supply",
+        "for an offer based on the total token supply minus the vault amount.",
+        "circulating_supply = total_supply - vault_amount",
+        "Emits a `GetCirculatingSupplyEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `GetCirculatingSupply`.",
+        "",
+        "# Returns",
+        "- `Ok(circulating_supply)`: The calculated circulating supply for the offer in base units"
+      ],
+      "discriminator": [
+        132,
+        168,
+        96,
+        104,
+        217,
+        255,
+        111,
+        152
+      ],
+      "accounts": [
+        {
+          "name": "onyc_mint",
+          "docs": [
+            "The ONyc token mint containing total supply information"
+          ],
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the ONyc mint reference"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_authority",
+          "docs": [
+            "The vault authority PDA that controls vault token accounts"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "onyc_vault_account",
+          "docs": [
+            "The vault's ONyc token account to exclude from circulating supply",
+            "",
+            "This account holds tokens that are not considered in circulation.",
+            "The account address is validated to match the expected ATA address",
+            "and can be uninitialized (treated as zero balance)."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program for account validation"
+          ]
+        }
+      ],
+      "args": [],
+      "returns": "u64"
+    },
+    {
+      "name": "get_nav",
+      "docs": [
+        "Gets the current NAV (price) for a specific offer.",
+        "",
+        "Delegates to `market_info::get_nav`.",
+        "This is a read-only instruction that calculates and returns the current price",
+        "for an offer based on its time vectors and APR parameters.",
+        "Emits a `GetNAVEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `GetNAV`.",
+        "",
+        "# Returns",
+        "- `Ok(current_price)`: The calculated current price (mantissa) for the offer with scale=9"
+      ],
+      "discriminator": [
+        200,
+        89,
+        76,
+        53,
+        215,
+        218,
+        63,
+        21
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing pricing vectors and configuration",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains time-based pricing vectors for price calculation."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        }
+      ],
+      "args": [],
+      "returns": "u64"
+    },
+    {
+      "name": "get_nav_adjustment",
+      "docs": [
+        "Gets the NAV adjustment (price change) for a specific offer.",
+        "",
+        "Delegates to `market_info::get_nav_adjustment`.",
+        "This is a read-only instruction that calculates the price difference",
+        "between the current vector and the previous vector at the current time.",
+        "Returns a signed integer representing the price change.",
+        "Emits a `GetNavAdjustmentEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `GetNavAdjustment`.",
+        "",
+        "# Returns",
+        "- `Ok(adjustment)`: The calculated price adjustment (current - previous) as a signed integer,",
+        "returns the mantissa with scale=9"
+      ],
+      "discriminator": [
+        70,
+        198,
+        229,
+        129,
+        238,
+        233,
+        143,
+        94
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing pricing vectors for adjustment calculation",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains multiple time-based pricing vectors for comparison."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        }
+      ],
+      "args": [],
+      "returns": "i64"
+    },
+    {
+      "name": "get_tvl",
+      "docs": [
+        "Gets the current TVL (Total Value Locked) for a specific offer with 9 decimal precision",
+        "",
+        "Delegates to `market_info::get_tvl`.",
+        "This is a read-only instruction that calculates and returns the current TVL",
+        "for an offer based on the token_out supply and current NAV (price).",
+        "TVL = token_out_supply * current_NAV",
+        "Emits a `GetTVLEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `GetTVL`.",
+        "",
+        "# Returns",
+        "- `Ok(tvl)`: The calculated TVL (mantissa) for the offer with scale=9"
+      ],
+      "discriminator": [
+        88,
+        225,
+        219,
+        204,
+        86,
+        91,
+        184,
+        51
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing pricing vectors for current price calculation",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains time-based pricing vectors for TVL calculation."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account containing total supply information"
+          ]
+        },
+        {
+          "name": "vault_authority",
+          "docs": [
+            "The vault authority PDA that controls vault token accounts"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_token_out_account",
+          "docs": [
+            "The vault's token_out account to exclude from circulating supply",
+            "",
+            "This account holds tokens that should not be included in TVL calculations.",
+            "The account address is validated to match the expected ATA address",
+            "and can be uninitialized (treated as zero balance)."
+          ]
+        },
+        {
+          "name": "token_out_program",
+          "docs": [
+            "SPL Token program for vault account validation"
+          ]
+        }
+      ],
+      "args": [],
+      "returns": "u64"
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Initializes the program state and authority accounts.",
+        "",
+        "Delegates to `initialize::initialize` to set the initial boss in the state account."
+      ],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "The program state account to be created and initialized",
+            "",
+            "This account stores all global program configuration including:",
+            "- Boss public key (program authority)",
+            "- Kill switch state (initially disabled)",
+            "- ONyc mint reference",
+            "- Admin list (initially empty)",
+            "- Approver for signature verification (initially unset)",
+            "",
+            "The account is created as a PDA derived from the \"state\" seed to ensure",
+            "deterministic addressing and program ownership."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "The offer mint authority account to initialize, rent paid by `boss`."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "offer_vault_authority",
+          "docs": [
+            "The offer vault authority account to initialize, rent paid by `boss`."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The initial boss who will have full authority over the program",
+            "",
+            "This signer becomes the program's boss and gains the ability to:",
+            "- Create and manage offers",
+            "- Update program state (boss, admins, kill switch, approver)",
+            "- Perform administrative operations",
+            "- Pay for the state account creation"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "program",
+          "address": "onreuGhHHgVzMWSkj2oQDLDtvvGvoepBPkqyaubFcwe"
+        },
+        {
+          "name": "program_data",
+          "docs": [
+            "We'll verify its address in code."
+          ],
+          "optional": true
+        },
+        {
+          "name": "onyc_mint",
+          "docs": [
+            "The ONyc token mint that this program will manage",
+            "",
+            "This mint represents the protocol's native token and is used for:",
+            "- Token minting operations when program has mint authority",
+            "- Reference in various program calculations and operations"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Solana System program required for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_permissionless_authority",
+      "docs": [
+        "Initializes a permissionless account.",
+        "",
+        "Delegates to `initialize::initialize_permissionless_authority` to create a new permissionless account.",
+        "The account is created as a PDA with the seed \"permissionless-1\".",
+        "Only the boss can initialize permissionless accounts."
+      ],
+      "discriminator": [
+        89,
+        93,
+        43,
+        180,
+        148,
+        16,
+        238,
+        24
+      ],
+      "accounts": [
+        {
+          "name": "permissionless_authority",
+          "docs": [
+            "The permissionless account to be created.",
+            "",
+            "# Note",
+            "- Space is allocated as `8 + PermissionlessAuthority::INIT_SPACE` bytes",
+            "- Seeded with hardcoded \"permissionless-1\" for PDA derivation"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110,
+                  108,
+                  101,
+                  115,
+                  115,
+                  45,
+                  49
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "state",
+          "docs": [
+            "The program state account, used to verify boss authorization."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account that authorizes and pays for the permissionless account creation."
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Solana System program for account creation and rent payment."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "make_offer",
+      "docs": [
+        "Creates an offer.",
+        "",
+        "Delegates to `offer::make_offer`.",
+        "The price of the token_out changes over time based on `base_price`,",
+        "`end_price`, and `price_fix_duration` within the offer's active time window.",
+        "Emits a `OfferMade` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `MakeOffer`.",
+        "- `fee_basis_points`: Fee in basis points (e.g., 500 = 5%) charged when taking the offer."
+      ],
+      "discriminator": [
+        214,
+        98,
+        97,
+        35,
+        59,
+        12,
+        44,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "vault_authority",
+          "docs": [
+            "Program-derived authority that controls offer vault token accounts",
+            "",
+            "This PDA manages token transfers and burning operations when the program",
+            "has mint authority for efficient burn/mint architecture."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint for the offer"
+          ]
+        },
+        {
+          "name": "token_in_program",
+          "docs": [
+            "Token program interface for the input token"
+          ]
+        },
+        {
+          "name": "vault_token_in_account",
+          "docs": [
+            "Vault account for storing input tokens during burn/mint operations",
+            "",
+            "Created automatically if needed. Used for temporary token storage",
+            "when the program has mint authority and needs to burn tokens."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint for the offer"
+          ]
+        },
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account storing exchange configuration and pricing vectors",
+            "",
+            "This account is derived from token mint addresses ensuring unique",
+            "offers per token pair. Contains fee settings, approval requirements,",
+            "and pricing vector array for dynamic pricing."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to create offers and pay for account creation"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_basis_points",
+          "type": "u16"
+        },
+        {
+          "name": "needs_approval",
+          "type": "bool"
+        },
+        {
+          "name": "allow_permissionless",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "make_redemption_offer",
+      "docs": [
+        "Creates a redemption offer for converting output tokens from standard offers back",
+        "to input tokens.",
+        "",
+        "Delegates to `redemption::make_redemption_offer`.",
+        "This instruction initializes a new redemption offer that allows users to redeem",
+        "token_out tokens from standard Offer (e.g. ONyc) for token_in tokens (e.g., USDC) at",
+        "the current NAV price. The redemption offer is the inverse of the standard Offer.",
+        "",
+        "The redemption offer PDA is derived with reversed token order compared to the",
+        "original offer, reflecting the inverse nature of the redemption operation.",
+        "Emits a `RedemptionOfferCreatedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `MakeRedemptionOffer`.",
+        "- `fee_basis_points`: Fee in basis points (10000 = 100%) charged when fulfilling redemption requests",
+        "",
+        "# Access Control",
+        "- Only the boss or redemption_admin can call this instruction"
+      ],
+      "discriminator": [
+        6,
+        130,
+        180,
+        160,
+        163,
+        166,
+        51,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss and redemption_admin authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "offer",
+          "docs": [
+            "The original offer that this redemption offer is associated with",
+            "",
+            "The redemption offer uses the inverse token pair of the original offer.",
+            "The offer must be derived from redemption offer token_out_mint (token_in in original offer)",
+            "and token_in_mint (token_out in original offer)."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived authority that controls redemption offer vault token accounts",
+            "",
+            "This PDA manages token transfers for redemption operations."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint for redemptions (token_in_mint)",
+            "",
+            "This corresponds to the token_out_mint from the original offer."
+          ]
+        },
+        {
+          "name": "token_in_program",
+          "docs": [
+            "Token program interface for the input token"
+          ]
+        },
+        {
+          "name": "vault_token_in_account",
+          "docs": [
+            "Vault account for storing input tokens during redemption operations",
+            "",
+            "Created automatically if needed. Used for holding ONyc tokens before burning."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint for redemptions (e.g., USDC)",
+            "",
+            "This is the token_in_mint from the original offer."
+          ]
+        },
+        {
+          "name": "token_out_program",
+          "docs": [
+            "Token program interface for the output token"
+          ]
+        },
+        {
+          "name": "vault_token_out_account",
+          "docs": [
+            "Vault account for storing output tokens (e.g., USDC) for redemption payouts",
+            "",
+            "Created automatically if needed. Used for distributing stable tokens to redeemers."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "redemption_offer",
+          "docs": [
+            "The redemption offer account storing redemption configuration",
+            "",
+            "This account is derived from token mint addresses in the same order as Offer",
+            "but with the tokens reversed (token_in from Offer becomes token_out here)."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The account creating the redemption offer (must be boss or redemption_admin)"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_basis_points",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "mint_to",
+      "docs": [
+        "Mints ONyc tokens to the boss's account.",
+        "",
+        "Delegates to `state_operations::mint_to` to mint ONyc tokens.",
+        "Only the boss can call this instruction to mint ONyc tokens to their account.",
+        "The program must have mint authority for the ONyc token.",
+        "Emits a `OnycTokensMinted` event upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `MintTo`.",
+        "- `amount`: Amount of ONyc tokens to mint."
+      ],
+      "discriminator": [
+        241,
+        34,
+        48,
+        186,
+        37,
+        179,
+        123,
+        192
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "The program state account containing boss and ONyc mint validation"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss authorized to perform minting operations",
+            "",
+            "Must be the boss stored in the program state and pay for any",
+            "account creation if the token account doesn't exist."
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "onyc_mint",
+          "docs": [
+            "The ONyc token mint account for minting new tokens",
+            "",
+            "Must match the ONyc mint stored in program state and be mutable",
+            "to allow supply updates during minting."
+          ],
+          "writable": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "boss_onyc_account",
+          "docs": [
+            "The boss's ONyc token account to receive minted tokens",
+            "",
+            "If the account doesn't exist, it will be created automatically",
+            "as an Associated Token Account with the boss as the authority."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "onyc_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived account that serves as the mint authority",
+            "",
+            "This PDA must be the current mint authority for the ONyc token.",
+            "Validated to ensure the program has permission to mint tokens."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program for minting operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program required for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "offer_vault_deposit",
+      "docs": [
+        "Deposits tokens into the offer vault.",
+        "",
+        "Delegates to `vault_operations::offer_vault_deposit`.",
+        "Transfers tokens from boss's account to offer vault's token account for the specified mint.",
+        "Creates vault token account if it doesn't exist using init_if_needed.",
+        "Only the boss can call this instruction.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `OfferVaultDeposit`.",
+        "- `amount`: Amount of tokens to deposit."
+      ],
+      "discriminator": [
+        69,
+        131,
+        100,
+        85,
+        82,
+        151,
+        72,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "vault_authority",
+          "docs": [
+            "Program-derived authority that controls vault token accounts",
+            "",
+            "This PDA manages the vault token accounts and enables the program",
+            "to distribute tokens during offer executions."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint for the deposit operation"
+          ]
+        },
+        {
+          "name": "boss_token_account",
+          "docs": [
+            "Boss's token account serving as the source of deposited tokens",
+            "",
+            "Must have sufficient balance to cover the requested deposit amount."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Vault's token account serving as the destination for deposited tokens",
+            "",
+            "Created automatically if it doesn't exist. Stores tokens that can be",
+            "distributed during offer executions when minting is not available."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to deposit tokens and pay for account creation"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "offer_vault_withdraw",
+      "docs": [
+        "Withdraws tokens from the offer vault.",
+        "",
+        "Delegates to `vault_operations::offer_vault_withdraw`.",
+        "Transfers tokens from offer vault's token account to boss's account for the specified mint.",
+        "Creates boss token account if it doesn't exist using init_if_needed.",
+        "Only the boss can call this instruction.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `OfferVaultWithdraw`.",
+        "- `amount`: Amount of tokens to withdraw."
+      ],
+      "discriminator": [
+        230,
+        135,
+        129,
+        48,
+        138,
+        202,
+        20,
+        72
+      ],
+      "accounts": [
+        {
+          "name": "vault_authority",
+          "docs": [
+            "Program-derived authority that controls vault token accounts",
+            "",
+            "This PDA manages the vault token accounts and signs the withdrawal",
+            "transfer using program-derived signatures."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint for the withdrawal operation"
+          ]
+        },
+        {
+          "name": "boss_token_account",
+          "docs": [
+            "Boss's token account serving as the destination for withdrawn tokens",
+            "",
+            "Created automatically if it doesn't exist. Receives tokens withdrawn",
+            "from the vault for boss fund management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Vault's token account serving as the source of withdrawn tokens",
+            "",
+            "Must have sufficient balance to cover the requested withdrawal amount.",
+            "Controlled by the vault authority PDA."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to withdraw tokens and pay for account creation"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "propose_boss",
+      "docs": [
+        "Proposes a new boss for ownership transfer.",
+        "",
+        "Delegates to `propose_boss::propose_boss` to propose a new boss authority.",
+        "This is the first step in a two-step ownership transfer process.",
+        "The proposed boss must then call accept_boss to complete the transfer.",
+        "Emits a `BossProposedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `ProposeBoss`.",
+        "- `new_boss`: Public key of the proposed new boss."
+      ],
+      "discriminator": [
+        163,
+        199,
+        158,
+        47,
+        155,
+        78,
+        174,
+        173
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the boss authority",
+            "",
+            "Must be mutable to allow proposed_boss field modification and have the current",
+            "boss account as the authorized signer."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The current boss account proposing the ownership transfer"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_boss",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "redemption_vault_deposit",
+      "docs": [
+        "Deposits tokens into the redemption vault.",
+        "",
+        "Delegates to `vault_operations::redemption_vault_deposit`.",
+        "Transfers tokens from boss's account to redemption vault's token account for the specified mint.",
+        "Creates vault token account if it doesn't exist using init_if_needed.",
+        "Only the boss can call this instruction.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `RedemptionVaultDeposit`.",
+        "- `amount`: Amount of tokens to deposit."
+      ],
+      "discriminator": [
+        67,
+        104,
+        107,
+        131,
+        141,
+        2,
+        140,
+        122
+      ],
+      "accounts": [
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived authority that controls redemption vault token accounts",
+            "",
+            "This PDA manages the redemption vault token accounts and enables the program",
+            "to distribute tokens during redemption executions."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint for the deposit operation"
+          ]
+        },
+        {
+          "name": "boss_token_account",
+          "docs": [
+            "Boss's token account serving as the source of deposited tokens",
+            "",
+            "Must have sufficient balance to cover the requested deposit amount."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Redemption vault's token account serving as the destination for deposited tokens",
+            "",
+            "Created automatically if it doesn't exist. Stores tokens that can be",
+            "distributed during redemption executions when minting is not available."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to deposit tokens and pay for account creation"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "redemption_vault_withdraw",
+      "docs": [
+        "Withdraws tokens from the redemption vault.",
+        "",
+        "Delegates to `vault_operations::redemption_vault_withdraw`.",
+        "Transfers tokens from redemption vault's token account to boss's account for the specified mint.",
+        "Creates boss token account if it doesn't exist using init_if_needed.",
+        "Only the boss can call this instruction.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `RedemptionVaultWithdraw`.",
+        "- `amount`: Amount of tokens to withdraw."
+      ],
+      "discriminator": [
+        48,
+        214,
+        145,
+        15,
+        168,
+        122,
+        39,
+        48
+      ],
+      "accounts": [
+        {
+          "name": "redemption_vault_authority",
+          "docs": [
+            "Program-derived authority that controls redemption vault token accounts",
+            "",
+            "This PDA manages the redemption vault token accounts and signs the withdrawal",
+            "transfer using program-derived signatures."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "The token mint for the withdrawal operation"
+          ]
+        },
+        {
+          "name": "boss_token_account",
+          "docs": [
+            "Boss's token account serving as the destination for withdrawn tokens",
+            "",
+            "Created automatically if it doesn't exist. Receives tokens withdrawn",
+            "from the redemption vault for boss fund management.",
+            "Note: init_if_needed implies mutability."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_account",
+          "docs": [
+            "Redemption vault's token account serving as the source of withdrawn tokens",
+            "",
+            "Must have sufficient balance to cover the requested withdrawal amount.",
+            "Controlled by the redemption vault authority PDA."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "redemption_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to withdraw tokens and pay for account creation"
+          ],
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program interface for transfer operations"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program for account creation and rent payment"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "remove_admin",
+      "docs": [
+        "Removes an admin from the state.",
+        "",
+        "Delegates to `admin::remove_admin` to remove an admin from the admin list.",
+        "Only the boss can call this instruction to remove admins.",
+        "# Arguments",
+        "- `ctx`: Context for `RemoveAdmin`.",
+        "- `admin_to_remove`: Public key of the admin to be removed."
+      ],
+      "discriminator": [
+        74,
+        202,
+        71,
+        106,
+        252,
+        31,
+        72,
+        183
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the admin list to be modified",
+            "",
+            "Must be mutable to allow admin list modifications and have the",
+            "boss account as the authorized signer for admin management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to remove admin privileges"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "admin_to_remove",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "remove_approver",
+      "docs": [
+        "Removes a trusted authority from approval verification.",
+        "",
+        "This instruction allows the boss to remove an approver by their public key.",
+        "The approver must exist in either approver1 or approver2 slot, otherwise",
+        "the instruction will fail.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `RemoveApprover`.",
+        "- `approver`: Public key of the approver to remove."
+      ],
+      "discriminator": [
+        214,
+        72,
+        133,
+        48,
+        50,
+        58,
+        227,
+        224
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "approver",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_kill_switch",
+      "docs": [
+        "Enables or disables the kill switch.",
+        "",
+        "Delegates to `kill_switch::kill_switch` to change the kill switch state.",
+        "When enabled (true), the kill switch can halt critical program operations.",
+        "When disabled (false), normal program operations can proceed.",
+        "",
+        "Access control:",
+        "- Both boss and admins can enable the kill switch",
+        "- Only the boss can disable the kill switch",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `KillSwitch`.",
+        "- `enable`: True to enable the kill switch, false to disable it."
+      ],
+      "discriminator": [
+        228,
+        119,
+        172,
+        135,
+        209,
+        250,
+        172,
+        216
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the kill switch flag",
+            "",
+            "Must be mutable to allow kill switch state modifications.",
+            "The kill switch prevents offer operations when enabled."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "The account attempting to modify the kill switch (boss or admin)"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "set_onyc_mint",
+      "docs": [
+        "Sets the Onyc mint in the state.",
+        "",
+        "Delegates to `state_operations::set_onyc_mint` to change the Onyc mint.",
+        "Only the boss can call this instruction to set the Onyc mint.",
+        "Emits a `OnycMintSetEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `SetOnycMint`."
+      ],
+      "discriminator": [
+        177,
+        83,
+        119,
+        179,
+        44,
+        141,
+        201,
+        24
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the ONyc mint configuration",
+            "",
+            "Must be mutable to allow ONyc mint updates and have the boss account",
+            "as the authorized signer for mint configuration management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to configure the ONyc mint"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "onyc_mint",
+          "docs": [
+            "The ONyc token mint account to be set in program state"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_redemption_admin",
+      "docs": [
+        "Sets the redemption admin in the state.",
+        "",
+        "Delegates to `state_operations::set_redemption_admin` to change the redemption admin.",
+        "Only the boss can call this instruction to set the redemption admin.",
+        "Emits a `RedemptionAdminUpdatedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `SetRedemptionAdmin`.",
+        "- `new_redemption_admin`: Public key of the new redemption admin."
+      ],
+      "discriminator": [
+        122,
+        95,
+        205,
+        126,
+        218,
+        93,
+        18,
+        173
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing the redemption admin configuration",
+            "",
+            "Must be mutable to allow redemption admin updates and have the boss account",
+            "as the authorized signer for redemption admin configuration management."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to configure the redemption admin"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_redemption_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "take_offer",
+      "docs": [
+        "Takes a offer.",
+        "",
+        "Delegates to `offer::take_offer`.",
+        "Allows a user to exchange token_in for token_out based on the offer's dynamic price.",
+        "Emits a `TakeOfferEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `TakeOffer`.",
+        "- `token_in_amount`: Amount of token_in to provide."
+      ],
+      "discriminator": [
+        128,
+        156,
+        242,
+        207,
+        237,
+        192,
+        103,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing pricing vectors and exchange configuration",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains the pricing vectors used for dynamic price calculation."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing authorization and kill switch status"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to receive token_in payments",
+            "",
+            "Must match the boss stored in program state for security validation."
+          ],
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "vault_authority",
+          "docs": [
+            "Program-derived authority that controls vault token operations",
+            "",
+            "This PDA manages token transfers and burning operations for the",
+            "burn/mint architecture when program has mint authority."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_token_in_account",
+          "docs": [
+            "Vault account for temporary token_in storage during burn operations",
+            "",
+            "Used for burning input tokens when the program has mint authority",
+            "for efficient burn/mint token exchange architecture."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_out_account",
+          "docs": [
+            "Vault account for token_out distribution when using transfer mechanism",
+            "",
+            "Source of output tokens when the program lacks mint authority",
+            "and must transfer from pre-funded vault instead of minting."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "Input token mint account for the exchange",
+            "",
+            "Must be mutable to allow burning operations when program has mint authority.",
+            "Validated against the offer's expected token_in_mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_in_program",
+          "docs": [
+            "Token program interface for input token operations"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "Output token mint account for the exchange",
+            "",
+            "Must be mutable to allow minting operations when program has mint authority.",
+            "Validated against the offer's expected token_out_mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_out_program",
+          "docs": [
+            "Token program interface for output token operations"
+          ]
+        },
+        {
+          "name": "user_token_in_account",
+          "docs": [
+            "User's input token account for payment",
+            "",
+            "Source account from which the user pays token_in for the exchange.",
+            "Must have sufficient balance for the requested token_in_amount."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "user_token_out_account",
+          "docs": [
+            "User's output token account for receiving exchanged tokens",
+            "",
+            "Destination account where the user receives token_out from the exchange.",
+            "Created automatically if it doesn't exist using init_if_needed."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss_token_in_account",
+          "docs": [
+            "Boss's input token account for receiving payments",
+            "",
+            "Destination account where the boss receives token_in payments",
+            "from users taking offers."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived mint authority for direct token minting",
+            "",
+            "Used when the program has mint authority and can mint token_out",
+            "directly to users instead of transferring from vault."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "instructions_sysvar",
+          "docs": [
+            "Instructions sysvar for approval signature verification",
+            "",
+            "Required for cryptographic verification of approval messages",
+            "when offers require boss approval for execution."
+          ],
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "user",
+          "docs": [
+            "The user executing the offer and paying for account creation"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program required for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "approval_message",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "ApprovalMessage"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "take_offer_permissionless",
+      "docs": [
+        "Takes a offer using permissionless flow with intermediary accounts.",
+        "",
+        "Delegates to `offer::take_offer_permissionless`.",
+        "Similar to take_offer but routes token transfers through intermediary accounts",
+        "owned by the program instead of direct user-to-boss and vault-to-user transfers.",
+        "Emits a `TakeOfferPermissionlessEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `TakeOfferPermissionless`.",
+        "- `token_in_amount`: Amount of token_in to provide."
+      ],
+      "discriminator": [
+        37,
+        190,
+        224,
+        77,
+        197,
+        39,
+        203,
+        230
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account containing pricing vectors and configuration",
+            "",
+            "Must have allow_permissionless enabled for this instruction to succeed.",
+            "Contains pricing vectors for dynamic price calculation."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing authorization and kill switch status"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to receive token_in payments",
+            "",
+            "Must match the boss stored in program state for security validation."
+          ],
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "vault_authority",
+          "docs": [
+            "Program-derived authority that controls vault token operations",
+            "",
+            "This PDA manages token transfers and burning operations for the",
+            "burn/mint architecture when program has mint authority."
+          ]
+        },
+        {
+          "name": "vault_token_in_account",
+          "docs": [
+            "Vault account for temporary token_in storage during burn operations",
+            "",
+            "Used for burning input tokens when the program has mint authority",
+            "for efficient burn/mint token exchange architecture."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "vault_token_out_account",
+          "docs": [
+            "Vault account for token_out distribution when using transfer mechanism",
+            "",
+            "Source of output tokens when the program lacks mint authority",
+            "and must transfer from pre-funded vault instead of minting."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "permissionless_authority",
+          "docs": [
+            "Program-derived authority that controls intermediary token routing accounts",
+            "",
+            "This PDA manages the intermediary accounts used for permissionless token",
+            "routing, enabling secure transfers without direct user-boss relationships."
+          ]
+        },
+        {
+          "name": "permissionless_token_in_account",
+          "docs": [
+            "Intermediary account for routing token_in payments",
+            "",
+            "Temporary holding account that receives user payments before forwarding",
+            "to boss, enabling permissionless operations without direct relationships."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "permissionless_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "permissionless_token_out_account",
+          "docs": [
+            "Intermediary account for routing token_out distributions",
+            "",
+            "Temporary holding account that receives output tokens before forwarding",
+            "to user, completing the permissionless routing mechanism."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "permissionless_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "Input token mint account for the exchange",
+            "",
+            "Must be mutable to allow burning operations when program has mint authority.",
+            "Validated against the offer's expected token_in_mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_in_program",
+          "docs": [
+            "Token program interface for input token operations"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "Output token mint account for the exchange",
+            "",
+            "Must be mutable to allow minting operations when program has mint authority.",
+            "Validated against the offer's expected token_out_mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_out_program",
+          "docs": [
+            "Token program interface for output token operations"
+          ]
+        },
+        {
+          "name": "user_token_in_account",
+          "docs": [
+            "User's input token account for payment",
+            "",
+            "Source account from which the user pays token_in for the exchange.",
+            "Must have sufficient balance for the requested token_in_amount."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "user_token_out_account",
+          "docs": [
+            "User's output token account for receiving exchanged tokens",
+            "",
+            "Destination account where the user receives token_out from the exchange.",
+            "Created automatically if it doesn't exist using init_if_needed."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "boss_token_in_account",
+          "docs": [
+            "Boss's input token account for receiving payments",
+            "",
+            "Final destination account where the boss receives token_in payments",
+            "from users taking offers via intermediary routing."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "boss"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_program"
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived mint authority for direct token minting",
+            "",
+            "Used when the program has mint authority and can mint token_out",
+            "directly instead of transferring from vault."
+          ]
+        },
+        {
+          "name": "instructions_sysvar",
+          "docs": [
+            "Instructions sysvar for approval signature verification",
+            "",
+            "Required for cryptographic verification of approval messages",
+            "when offers require boss approval for execution."
+          ],
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "user",
+          "docs": [
+            "The user executing the offer and paying for account creation"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Program for automatic token account creation"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program required for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "token_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "approval_message",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "ApprovalMessage"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "transfer_mint_authority_to_boss",
+      "docs": [
+        "Transfers mint authority from a program-derived PDA back to the boss.",
+        "",
+        "Delegates to `mint_authority::transfer_mint_authority_to_boss`.",
+        "Only the boss can call this instruction to recover mint authority for a specific token.",
+        "This serves as an emergency recovery mechanism.",
+        "Emits a `MintAuthorityTransferredToBossEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `TransferMintAuthorityToBoss`."
+      ],
+      "discriminator": [
+        197,
+        61,
+        42,
+        52,
+        70,
+        93,
+        30,
+        125
+      ],
+      "accounts": [
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to recover mint authority",
+            "",
+            "Must be the current boss stored in program state and sign the transaction",
+            "to authorize the mint authority transfer."
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss validation"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The token mint whose authority will be transferred to the boss",
+            "",
+            "Must currently have the program PDA as its mint authority. The mint",
+            "will be updated to have the boss as the new mint authority."
+          ],
+          "writable": true
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived account that currently holds mint authority",
+            "",
+            "This PDA must be the current mint authority for the token. The program",
+            "uses this PDA's signature to authorize transferring authority to the boss."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program for mint authority operations"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_mint_authority_to_program",
+      "docs": [
+        "Transfers mint authority from the boss to a program-derived PDA.",
+        "",
+        "Delegates to `mint_authority::transfer_mint_authority_to_program`.",
+        "Only the boss can call this instruction to transfer mint authority for a specific token.",
+        "The PDA is derived from the MINT_AUTHORITY seed and can later be used to mint tokens.",
+        "Emits a `MintAuthorityTransferredToProgramEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `TransferMintAuthorityToProgram`."
+      ],
+      "discriminator": [
+        98,
+        112,
+        50,
+        135,
+        53,
+        6,
+        149,
+        232
+      ],
+      "accounts": [
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to transfer mint authority",
+            "",
+            "Must be the current boss stored in program state and currently hold",
+            "mint authority for the specified token."
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss validation"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "The token mint whose authority will be transferred to the program",
+            "",
+            "Must currently have the boss as its mint authority. After the transfer,",
+            "the program PDA will be able to mint tokens programmatically."
+          ],
+          "writable": true
+        },
+        {
+          "name": "mint_authority",
+          "docs": [
+            "Program-derived account that will become the new mint authority",
+            "",
+            "This PDA will receive mint authority and enable the program to mint",
+            "tokens directly for controlled supply management operations."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program for mint authority operations"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_offer_fee",
+      "docs": [
+        "Updates the fee basis points for an offer.",
+        "",
+        "Delegates to `offer::update_offer_fee`.",
+        "Allows the boss to modify the fee charged when users take the offer.",
+        "Emits a `OfferFeeUpdatedEvent` upon success.",
+        "",
+        "# Arguments",
+        "- `ctx`: Context for `UpdateOfferFee`.",
+        "- `new_fee_basis_points`: New fee in basis points (0-10000)."
+      ],
+      "discriminator": [
+        254,
+        162,
+        70,
+        248,
+        117,
+        70,
+        197,
+        118
+      ],
+      "accounts": [
+        {
+          "name": "offer",
+          "docs": [
+            "The offer account whose fee will be updated",
+            "",
+            "This account is validated as a PDA derived from token mint addresses",
+            "and contains the fee configuration to be modified."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_in_mint"
+              },
+              {
+                "kind": "account",
+                "path": "token_out_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_in_mint",
+          "docs": [
+            "The input token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "token_out_mint",
+          "docs": [
+            "The output token mint account for offer validation"
+          ]
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to update offer fees"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_fee_basis_points",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "update_redemption_offer_fee",
+      "docs": [
+        "Updates the fee configuration for a specific redemption offer.",
+        "",
+        "This instruction allows the boss to modify the fee charged when fulfilling",
+        "redemption requests for a specific redemption offer. Only the boss can call this instruction.",
+        "",
+        "# Arguments",
+        "* `ctx` - The instruction context",
+        "* `new_fee_basis_points` - New fee in basis points (10000 = 100%, 500 = 5%)",
+        "",
+        "# Access Control",
+        "- Boss only"
+      ],
+      "discriminator": [
+        73,
+        11,
+        35,
+        194,
+        219,
+        147,
+        159,
+        3
+      ],
+      "accounts": [
+        {
+          "name": "redemption_offer",
+          "docs": [
+            "The redemption offer account whose fee will be updated"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  100,
+                  101,
+                  109,
+                  112,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  111,
+                  102,
+                  102,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_in_mint",
+                "account": "RedemptionOffer"
+              },
+              {
+                "kind": "account",
+                "path": "redemption_offer.token_out_mint",
+                "account": "RedemptionOffer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "state",
+          "docs": [
+            "Program state account containing boss authorization"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boss",
+          "docs": [
+            "The boss account authorized to update redemption offer fees"
+          ],
+          "signer": true,
+          "relations": [
+            "state"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_fee_basis_points",
+          "type": "u16"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Offer",
+      "discriminator": [
+        215,
+        88,
+        60,
+        71,
+        170,
+        162,
+        73,
+        229
+      ]
+    },
+    {
+      "name": "PermissionlessAuthority",
+      "discriminator": [
+        241,
+        34,
+        5,
+        97,
+        43,
+        102,
+        149,
+        52
+      ]
+    },
+    {
+      "name": "RedemptionOffer",
+      "discriminator": [
+        170,
+        229,
+        178,
+        15,
+        184,
+        107,
+        140,
+        41
+      ]
+    },
+    {
+      "name": "RedemptionRequest",
+      "discriminator": [
+        117,
+        157,
+        214,
+        214,
+        64,
+        160,
+        31,
+        58
+      ]
+    },
+    {
+      "name": "State",
+      "discriminator": [
+        216,
+        146,
+        107,
+        94,
+        104,
+        75,
+        182,
+        177
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "AdminAddedEvent",
+      "discriminator": [
+        68,
+        183,
+        187,
+        200,
+        190,
+        214,
+        20,
+        77
+      ]
+    },
+    {
+      "name": "AdminRemovedEvent",
+      "discriminator": [
+        226,
+        5,
+        12,
+        53,
+        69,
+        56,
+        172,
+        132
+      ]
+    },
+    {
+      "name": "AdminsClearedEvent",
+      "discriminator": [
+        202,
+        81,
+        156,
+        32,
+        66,
+        208,
+        159,
+        153
+      ]
+    },
+    {
+      "name": "AllOfferVectorsDeletedEvent",
+      "discriminator": [
+        13,
+        237,
+        37,
+        22,
+        175,
+        128,
+        178,
+        200
+      ]
+    },
+    {
+      "name": "ApproverAddedEvent",
+      "discriminator": [
+        130,
+        197,
+        173,
+        181,
+        53,
+        38,
+        162,
+        134
+      ]
+    },
+    {
+      "name": "ApproverRemovedEvent",
+      "discriminator": [
+        234,
+        1,
+        25,
+        206,
+        97,
+        119,
+        7,
+        23
+      ]
+    },
+    {
+      "name": "BossAcceptedEvent",
+      "discriminator": [
+        11,
+        133,
+        76,
+        152,
+        219,
+        5,
+        220,
+        103
+      ]
+    },
+    {
+      "name": "BossProposedEvent",
+      "discriminator": [
+        22,
+        117,
+        195,
+        6,
+        169,
+        57,
+        141,
+        17
+      ]
+    },
+    {
+      "name": "GetAPYEvent",
+      "discriminator": [
+        235,
+        74,
+        195,
+        163,
+        16,
+        198,
+        159,
+        61
+      ]
+    },
+    {
+      "name": "GetCirculatingSupplyEvent",
+      "discriminator": [
+        2,
+        255,
+        109,
+        150,
+        90,
+        242,
+        104,
+        206
+      ]
+    },
+    {
+      "name": "GetNAVEvent",
+      "discriminator": [
+        112,
+        70,
+        141,
+        221,
+        181,
+        134,
+        99,
+        92
+      ]
+    },
+    {
+      "name": "GetNavAdjustmentEvent",
+      "discriminator": [
+        22,
+        137,
+        159,
+        134,
+        238,
+        37,
+        111,
+        158
+      ]
+    },
+    {
+      "name": "GetTVLEvent",
+      "discriminator": [
+        12,
+        82,
+        39,
+        27,
+        40,
+        162,
+        216,
+        88
+      ]
+    },
+    {
+      "name": "KillSwitchToggledEvent",
+      "discriminator": [
+        104,
+        2,
+        90,
+        20,
+        64,
+        132,
+        228,
+        122
+      ]
+    },
+    {
+      "name": "MaxSupplyConfiguredEvent",
+      "discriminator": [
+        180,
+        54,
+        16,
+        115,
+        92,
+        70,
+        168,
+        123
+      ]
+    },
+    {
+      "name": "MintAuthorityTransferredToBossEvent",
+      "discriminator": [
+        86,
+        223,
+        255,
+        189,
+        210,
+        62,
+        212,
+        151
+      ]
+    },
+    {
+      "name": "MintAuthorityTransferredToProgramEvent",
+      "discriminator": [
+        237,
+        15,
+        101,
+        27,
+        85,
+        70,
+        173,
+        232
+      ]
+    },
+    {
+      "name": "ONycMintUpdatedEvent",
+      "discriminator": [
+        221,
+        248,
+        176,
+        184,
+        134,
+        249,
+        29,
+        1
+      ]
+    },
+    {
+      "name": "OfferFeeUpdatedEvent",
+      "discriminator": [
+        65,
+        77,
+        241,
+        6,
+        23,
+        133,
+        45,
+        180
+      ]
+    },
+    {
+      "name": "OfferMadeEvent",
+      "discriminator": [
+        206,
+        97,
+        61,
+        193,
+        90,
+        177,
+        83,
+        200
+      ]
+    },
+    {
+      "name": "OfferTakenEvent",
+      "discriminator": [
+        64,
+        121,
+        49,
+        21,
+        184,
+        132,
+        139,
+        54
+      ]
+    },
+    {
+      "name": "OfferTakenPermissionlessEvent",
+      "discriminator": [
+        201,
+        45,
+        242,
+        200,
+        95,
+        48,
+        126,
+        143
+      ]
+    },
+    {
+      "name": "OfferVaultDepositEvent",
+      "discriminator": [
+        145,
+        212,
+        252,
+        95,
+        149,
+        4,
+        227,
+        27
+      ]
+    },
+    {
+      "name": "OfferVaultWithdrawEvent",
+      "discriminator": [
+        29,
+        35,
+        115,
+        218,
+        32,
+        155,
+        211,
+        94
+      ]
+    },
+    {
+      "name": "OfferVectorAddedEvent",
+      "discriminator": [
+        104,
+        34,
+        244,
+        250,
+        33,
+        201,
+        53,
+        103
+      ]
+    },
+    {
+      "name": "OfferVectorDeletedEvent",
+      "discriminator": [
+        11,
+        85,
+        222,
+        27,
+        101,
+        98,
+        160,
+        167
+      ]
+    },
+    {
+      "name": "OfferVectorEvictedEvent",
+      "discriminator": [
+        52,
+        231,
+        183,
+        68,
+        181,
+        24,
+        100,
+        243
+      ]
+    },
+    {
+      "name": "OnycTokensMintedEvent",
+      "discriminator": [
+        241,
+        171,
+        63,
+        134,
+        122,
+        8,
+        178,
+        120
+      ]
+    },
+    {
+      "name": "RedemptionAdminUpdatedEvent",
+      "discriminator": [
+        110,
+        117,
+        47,
+        219,
+        133,
+        230,
+        199,
+        178
+      ]
+    },
+    {
+      "name": "RedemptionOfferCreatedEvent",
+      "discriminator": [
+        171,
+        25,
+        200,
+        106,
+        108,
+        123,
+        70,
+        65
+      ]
+    },
+    {
+      "name": "RedemptionOfferFeeUpdatedEvent",
+      "discriminator": [
+        221,
+        254,
+        77,
+        118,
+        205,
+        154,
+        166,
+        156
+      ]
+    },
+    {
+      "name": "RedemptionRequestCancelledEvent",
+      "discriminator": [
+        51,
+        146,
+        195,
+        92,
+        134,
+        230,
+        73,
+        134
+      ]
+    },
+    {
+      "name": "RedemptionRequestCreatedEvent",
+      "discriminator": [
+        30,
+        61,
+        76,
+        2,
+        36,
+        82,
+        84,
+        201
+      ]
+    },
+    {
+      "name": "RedemptionRequestFulfilledEvent",
+      "discriminator": [
+        154,
+        40,
+        115,
+        4,
+        42,
+        232,
+        47,
+        230
+      ]
+    },
+    {
+      "name": "RedemptionVaultDepositEvent",
+      "discriminator": [
+        229,
+        187,
+        130,
+        152,
+        236,
+        139,
+        239,
+        108
+      ]
+    },
+    {
+      "name": "RedemptionVaultWithdrawEvent",
+      "discriminator": [
+        255,
+        92,
+        199,
+        233,
+        33,
+        6,
+        21,
+        78
+      ]
+    },
+    {
+      "name": "StateClosedEvent",
+      "discriminator": [
+        205,
+        52,
+        85,
+        250,
+        177,
+        119,
+        155,
+        198
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "Expired",
+      "msg": "The approval message has expired."
+    },
+    {
+      "code": 6001,
+      "name": "WrongProgram",
+      "msg": "The approval message is for the wrong program."
+    },
+    {
+      "code": 6002,
+      "name": "WrongUser",
+      "msg": "The approval message is for the wrong user."
+    },
+    {
+      "code": 6003,
+      "name": "MissingEd25519Ix",
+      "msg": "Missing Ed25519 instruction."
+    },
+    {
+      "code": 6004,
+      "name": "WrongIxProgram",
+      "msg": "The instruction is for the wrong program."
+    },
+    {
+      "code": 6005,
+      "name": "BadEd25519Accounts",
+      "msg": "Ed25519 instruction has accounts."
+    },
+    {
+      "code": 6006,
+      "name": "MalformedEd25519Ix",
+      "msg": "Malformed Ed25519 instruction."
+    },
+    {
+      "code": 6007,
+      "name": "MultipleSigs",
+      "msg": "Multiple signatures found in Ed25519 instruction."
+    },
+    {
+      "code": 6008,
+      "name": "WrongAuthority",
+      "msg": "The authority public key does not match."
+    },
+    {
+      "code": 6009,
+      "name": "MsgMismatch",
+      "msg": "The message in the Ed25519 instruction does not match the approval message."
+    },
+    {
+      "code": 6010,
+      "name": "MsgDeserialize",
+      "msg": "Failed to deserialize the approval message."
+    }
+  ],
+  "types": [
+    {
+      "name": "AdminAddedEvent",
+      "docs": [
+        "Event emitted when a new admin is successfully added",
+        "",
+        "Provides transparency for tracking admin privilege changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "docs": [
+              "The public key of the newly added admin"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss who added the admin"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AdminRemovedEvent",
+      "docs": [
+        "Event emitted when an admin is successfully removed",
+        "",
+        "Provides transparency for tracking admin privilege changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "docs": [
+              "The public key of the removed admin"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss who removed the admin"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AdminsClearedEvent",
+      "docs": [
+        "Event emitted when all admins are successfully cleared",
+        "",
+        "Provides transparency for tracking admin privilege changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "boss",
+            "docs": [
+              "The boss who cleared all admins"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllOfferVectorsDeletedEvent",
+      "docs": [
+        "Event emitted when all pricing vectors are deleted from an offer",
+        "",
+        "Provides transparency for tracking bulk pricing vector removals."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer from which vectors were deleted"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vectors_deleted_count",
+            "docs": [
+              "Number of vectors that were deleted (non-empty vectors)"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ApprovalMessage",
+      "docs": [
+        "Message structure for approval verification",
+        "",
+        "This structure contains the data required to verify that a user has received",
+        "approval from a trusted authority to perform a specific action within the program.",
+        "The message is signed by the trusted authority using Ed25519 signature.",
+        "",
+        "# Fields",
+        "- `program_id`: The ID of the program for which this approval is valid",
+        "- `user_pubkey`: The public key of the user who is approved to perform the action",
+        "- `expiry_unix`: Unix timestamp when this approval expires"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "program_id",
+            "docs": [
+              "The program ID this approval is valid for"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "user_pubkey",
+            "docs": [
+              "The user public key that is approved"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "expiry_unix",
+            "docs": [
+              "Unix timestamp when this approval expires"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ApproverAddedEvent",
+      "docs": [
+        "Event emitted when an approver is successfully added",
+        "",
+        "Provides transparency for tracking approver changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "approver",
+            "docs": [
+              "The public key of the newly added approver"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss who added the approver"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ApproverRemovedEvent",
+      "docs": [
+        "Event emitted when an approver is successfully removed",
+        "",
+        "Provides transparency for tracking approver changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "approver",
+            "docs": [
+              "The public key of the removed approver"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss who removed the approver"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BossAcceptedEvent",
+      "docs": [
+        "Event emitted when the boss authority is successfully transferred",
+        "",
+        "Provides transparency for tracking ownership transfers and authority changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_boss",
+            "docs": [
+              "The previous boss's public key before the update"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "new_boss",
+            "docs": [
+              "The new boss's public key after the update"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BossProposedEvent",
+      "docs": [
+        "Event emitted when a new boss is proposed",
+        "",
+        "Provides transparency for tracking ownership transfer proposals."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_boss",
+            "docs": [
+              "The current boss's public key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "proposed_boss",
+            "docs": [
+              "The proposed new boss's public key"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GetAPYEvent",
+      "docs": [
+        "Event emitted when APY calculation is successfully completed",
+        "",
+        "This event provides transparency for off-chain applications to track",
+        "APY queries and monitor yield calculation results for specific offers."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer for which APY was calculated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "apy",
+            "docs": [
+              "Calculated Annual Percentage Yield with scale=6 (1_000_000 = 100%)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "apr",
+            "docs": [
+              "Source Annual Percentage Rate with scale=6 used for calculation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Unix timestamp when the APY calculation was performed"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GetCirculatingSupplyEvent",
+      "docs": [
+        "Event emitted when circulating supply calculation is completed",
+        "",
+        "Provides transparency for tracking token supply distribution and vault holdings."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "circulating_supply",
+            "docs": [
+              "Calculated circulating supply (total_supply - vault_amount) in base units"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_supply",
+            "docs": [
+              "Total token supply from the mint account in base units"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "vault_amount",
+            "docs": [
+              "Vault token amount excluded from circulation in base units"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Unix timestamp when the calculation was performed"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GetNAVEvent",
+      "docs": [
+        "Event emitted when NAV (Net Asset Value) calculation is completed",
+        "",
+        "Provides transparency for tracking current pricing information for offers."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer for which NAV was calculated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "current_price",
+            "docs": [
+              "Current price with 9 decimal precision (scale=9)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Unix timestamp when the price calculation was performed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_price_change_timestamp",
+            "docs": [
+              "Unix timestamp when the next price change will occur"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GetNavAdjustmentEvent",
+      "docs": [
+        "Event emitted when NAV adjustment calculation is completed",
+        "",
+        "Provides transparency for tracking price changes between pricing vectors."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer for which adjustment was calculated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "current_price",
+            "docs": [
+              "Current price from the active vector with scale=9"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "previous_price",
+            "docs": [
+              "Previous price from the previous vector with scale=9 (None if first vector)"
+            ],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "adjustment",
+            "docs": [
+              "Price adjustment (current - previous) as signed value with scale=9"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Unix timestamp when the adjustment calculation was performed"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GetTVLEvent",
+      "docs": [
+        "Event emitted when TVL (Total Value Locked) calculation is completed",
+        "",
+        "Provides transparency for tracking total value metrics for offers."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer for which TVL was calculated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tvl",
+            "docs": [
+              "Calculated TVL in base units (circulating_supply * current_price / 10^9)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_price",
+            "docs": [
+              "Current price with scale=9 used for TVL calculation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_supply",
+            "docs": [
+              "Circulating token supply (total_supply - vault_amount) in base units"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Unix timestamp when the TVL calculation was performed"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "KillSwitchToggledEvent",
+      "docs": [
+        "Event emitted when the kill switch state is changed",
+        "",
+        "Provides transparency for tracking emergency control changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "enabled",
+            "docs": [
+              "Whether the kill switch was enabled (true) or disabled (false)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "signer",
+            "docs": [
+              "The account that toggled the kill switch"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MaxSupplyConfiguredEvent",
+      "docs": [
+        "Event emitted when the ONyc maximum supply is successfully configured",
+        "",
+        "Provides transparency for tracking max supply configuration changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_max_supply",
+            "docs": [
+              "The previous maximum supply cap (0 = no cap)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "new_max_supply",
+            "docs": [
+              "The new maximum supply cap (0 = no cap)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintAuthorityTransferredToBossEvent",
+      "docs": [
+        "Event emitted when mint authority is successfully transferred from program PDA to boss",
+        "",
+        "Provides transparency for tracking mint authority changes and emergency recovery operations."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The mint whose authority was transferred"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "old_authority",
+            "docs": [
+              "The previous authority (program PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "new_authority",
+            "docs": [
+              "The new authority (boss account)"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintAuthorityTransferredToProgramEvent",
+      "docs": [
+        "Event emitted when mint authority is successfully transferred from boss to program PDA",
+        "",
+        "Provides transparency for tracking mint authority changes and enabling programmatic control."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The mint whose authority was transferred"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "old_authority",
+            "docs": [
+              "The previous authority (boss account)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "new_authority",
+            "docs": [
+              "The new authority (program PDA)"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ONycMintUpdatedEvent",
+      "docs": [
+        "Event emitted when the ONyc token mint is successfully updated",
+        "",
+        "Provides transparency for tracking ONyc mint configuration changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_onyc_mint",
+            "docs": [
+              "The previous ONyc mint public key before the update"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "new_onyc_mint",
+            "docs": [
+              "The new ONyc mint public key after the update"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Offer",
+      "docs": [
+        "Token exchange offer with dynamic APR-based pricing",
+        "",
+        "Stores configuration for token pair exchanges with time-based pricing vectors",
+        "that implement compound interest growth using Annual Percentage Rate (APR).",
+        "Each offer is unique per token pair and supports up to 10 pricing vectors."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_in_mint",
+            "docs": [
+              "Input token mint for the exchange"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_out_mint",
+            "docs": [
+              "Output token mint for the exchange"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vectors",
+            "docs": [
+              "Array of pricing vectors defining price evolution over time"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "OfferVector"
+                  }
+                },
+                10
+              ]
+            }
+          },
+          {
+            "name": "fee_basis_points",
+            "docs": [
+              "Fee in basis points (10000 = 100%) charged when taking the offer"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump seed for account derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "needs_approval",
+            "docs": [
+              "Whether the offer requires boss approval for taking (0 = false, 1 = true)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "allow_permissionless",
+            "docs": [
+              "Whether the offer allows permissionless operations (0 = false, 1 = true)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Reserved space for future fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                131
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferFeeUpdatedEvent",
+      "docs": [
+        "Event emitted when an offer's fee is successfully updated",
+        "",
+        "Provides transparency for tracking fee changes and offer configuration modifications."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer whose fee was updated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "old_fee_basis_points",
+            "docs": [
+              "Previous fee in basis points (10000 = 100%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_basis_points",
+            "docs": [
+              "New fee in basis points (10000 = 100%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that authorized the fee update"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferMadeEvent",
+      "docs": [
+        "Event emitted when an offer is successfully created",
+        "",
+        "Provides transparency for tracking offer creation and configuration parameters."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the newly created offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_mint",
+            "docs": [
+              "The input token mint for the offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_out_mint",
+            "docs": [
+              "The output token mint for the offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_basis_points",
+            "docs": [
+              "Fee in basis points (10000 = 100%) charged when taking the offer"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that created and owns the offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "needs_approval",
+            "docs": [
+              "Whether the offer requires boss approval for taking"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "allow_permissionless",
+            "docs": [
+              "Whether the offer allows permissionless operations"
+            ],
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferTakenEvent",
+      "docs": [
+        "Event emitted when an offer is successfully taken",
+        "",
+        "Provides transparency for tracking offer execution and token exchange details."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer that was executed"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_amount",
+            "docs": [
+              "Amount of token_in paid by the user after fee deduction"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_out_amount",
+            "docs": [
+              "Amount of token_out received by the user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount",
+            "docs": [
+              "Fee amount deducted from the original token_in payment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "docs": [
+              "Public key of the user who executed the offer"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferTakenPermissionlessEvent",
+      "docs": [
+        "Event emitted when an offer is successfully executed via permissionless flow",
+        "",
+        "Provides transparency for tracking permissionless offer execution with intermediary routing."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer that was executed"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_amount",
+            "docs": [
+              "Amount of token_in paid by the user after fee deduction"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_out_amount",
+            "docs": [
+              "Amount of token_out received by the user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount",
+            "docs": [
+              "Fee amount deducted from the original token_in payment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "docs": [
+              "Public key of the user who executed the offer"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVaultDepositEvent",
+      "docs": [
+        "Event emitted when tokens are successfully deposited to the offer vault",
+        "",
+        "Provides transparency for tracking vault funding and token availability."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint that was deposited"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of tokens deposited to the vault"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that made the deposit"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVaultWithdrawEvent",
+      "docs": [
+        "Event emitted when tokens are successfully withdrawn from the offer vault",
+        "",
+        "Provides transparency for tracking vault withdrawals and fund management."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint that was withdrawn"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of tokens withdrawn from the vault"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that performed the withdrawal"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVector",
+      "docs": [
+        "Time-based pricing vector with APR-driven compound growth",
+        "",
+        "Defines price evolution over time using Annual Percentage Rate (APR) with",
+        "discrete pricing steps. Each vector becomes active at start_time and",
+        "implements compound interest pricing until the next vector activates."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "start_time",
+            "docs": [
+              "Calculated activation time: max(base_time, current_time) when vector was added"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_time",
+            "docs": [
+              "Original requested activation time before current_time adjustment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_price",
+            "docs": [
+              "Initial price with scale=9 (1_000_000_000 = 1.0) at vector start"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "apr",
+            "docs": [
+              "Annual Percentage Rate scaled by 1_000_000 (1_000_000 = 1% APR)",
+              "",
+              "Determines compound interest rate for price growth over time.",
+              "Scale=6 where 1_000_000 = 1% annual rate."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price_fix_duration",
+            "docs": [
+              "Duration in seconds for each discrete pricing step"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVectorAddedEvent",
+      "docs": [
+        "Event emitted when a pricing vector is successfully added to an offer",
+        "",
+        "Provides transparency for tracking pricing vector additions and configurations."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer to which the vector was added"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "start_time",
+            "docs": [
+              "Calculated start time when the vector becomes active (max(base_time, current_time))"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_time",
+            "docs": [
+              "Original base time specified for the vector"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_price",
+            "docs": [
+              "Base price with 9 decimal precision at the vector start"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "apr",
+            "docs": [
+              "Annual Percentage Rate scaled by 1,000,000 (1_000_000 = 1% APR)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price_fix_duration",
+            "docs": [
+              "Duration in seconds for each discrete pricing step"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVectorDeletedEvent",
+      "docs": [
+        "Event emitted when a pricing vector is successfully deleted from an offer",
+        "",
+        "Provides transparency for tracking pricing vector removals and offer configuration changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_pda",
+            "docs": [
+              "The PDA address of the offer from which the vector was deleted"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vector_start_time",
+            "docs": [
+              "Start time of the deleted pricing vector"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OfferVectorEvictedEvent",
+      "docs": [
+        "Event emitted when old pricing vectors are retired from an offer"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer_token_in_mint",
+            "docs": [
+              "The token in mint of the offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "offer_token_out_mint",
+            "docs": [
+              "The token out mint of the offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vector_start_time",
+            "docs": [
+              "Start time of the retired pricing vector"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OnycTokensMintedEvent",
+      "docs": [
+        "Event emitted when ONyc tokens are successfully minted to the boss account",
+        "",
+        "Provides transparency for tracking token minting operations performed by the boss."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "onyc_mint",
+            "docs": [
+              "The ONyc mint from which tokens were minted"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that received the newly minted tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "The amount of tokens minted in base units"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissionlessAuthority",
+      "docs": [
+        "Program-derived authority for permissionless token routing operations",
+        "",
+        "This PDA manages intermediary accounts used for permissionless offer execution,",
+        "enabling secure token routing without direct user-boss relationships."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "docs": [
+              "Optional name identifier for the authority (max 50 characters)"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionAdminUpdatedEvent",
+      "docs": [
+        "Event emitted when the redemption admin is successfully updated",
+        "",
+        "Provides transparency for tracking redemption admin configuration changes."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_redemption_admin",
+            "docs": [
+              "The previous redemption admin public key before the update"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "new_redemption_admin",
+            "docs": [
+              "The new redemption admin public key after the update"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionOffer",
+      "docs": [
+        "Redemption offer for converting ONyc tokens back to stable tokens",
+        "",
+        "Manages the redemption process where users can exchange ONyc (in-token)",
+        "for stable tokens like USDC (out-token) at the current NAV price.",
+        "This is the inverse of the standard Offer which exchanges stable tokens for ONyc."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer",
+            "docs": [
+              "Reference to the original Offer PDA that this redemption offer is associated with"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_mint",
+            "docs": [
+              "Input token mint for redemptions (e.g., ONyc)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_out_mint",
+            "docs": [
+              "Output token mint for redemptions (e.g., USDC)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "executed_redemptions",
+            "docs": [
+              "Cumulative total of all executed redemptions over the contract's lifetime",
+              "",
+              "This tracks the total amount of ONyc that has been redeemed and burned.",
+              "Uses u128 because cumulative redemptions can exceed the current total supply."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "requested_redemptions",
+            "docs": [
+              "Total amount of pending redemption requests",
+              "",
+              "This tracks ONyc tokens that are locked in pending redemption requests.",
+              "Uses u64 because pending redemptions cannot exceed the token's total supply."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_basis_points",
+            "docs": [
+              "Fee in basis points (1000 = 10%) charged when fulfilling redemption requests"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "request_counter",
+            "docs": [
+              "Counter for sequential redemption request numbering",
+              "Increments with each new redemption request created"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump seed for account derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Reserved space for future fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                109
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionOfferCreatedEvent",
+      "docs": [
+        "Event emitted when a redemption offer is successfully created",
+        "",
+        "Provides transparency for tracking redemption offer creation and configuration."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "redemption_offer_pda",
+            "docs": [
+              "The PDA address of the newly created redemption offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "offer",
+            "docs": [
+              "Reference to the original offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_mint",
+            "docs": [
+              "The input token mint for redemptions (ONyc)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_out_mint",
+            "docs": [
+              "The output token mint for redemptions (e.g., USDC)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_basis_points",
+            "docs": [
+              "Fee in basis points (10000 = 100%) charged when fulfilling redemption requests"
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionOfferFeeUpdatedEvent",
+      "docs": [
+        "Event emitted when a redemption offer's fee is successfully updated",
+        "",
+        "Provides transparency for tracking fee changes and redemption offer configuration modifications."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "redemption_offer_pda",
+            "docs": [
+              "The PDA address of the redemption offer whose fee was updated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "old_fee_basis_points",
+            "docs": [
+              "Previous fee in basis points (10000 = 100%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_basis_points",
+            "docs": [
+              "New fee in basis points (10000 = 100%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that authorized the fee update"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequest",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "offer",
+            "docs": [
+              "Reference to the RedemptionOffer PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "request_id",
+            "docs": [
+              "Unique sequential identifier for this request (counter value used for PDA derivation)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "redeemer",
+            "docs": [
+              "User requesting the redemption"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of token_in tokens requested for redemption"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump seed for account derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Reserved space for future fields"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                127
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequestCancelledEvent",
+      "docs": [
+        "Event emitted when a redemption request is successfully cancelled",
+        "",
+        "Provides transparency for tracking cancelled redemption requests."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "redemption_request_pda",
+            "docs": [
+              "The PDA address of the cancelled redemption request"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_offer",
+            "docs": [
+              "Reference to the redemption offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redeemer",
+            "docs": [
+              "User who requested the redemption"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of token_in tokens that was requested for redemption"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cancelled_by",
+            "docs": [
+              "The signer who cancelled the request"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequestCreatedEvent",
+      "docs": [
+        "Event emitted when a redemption request is successfully created",
+        "",
+        "Provides transparency for tracking redemption requests and their configuration."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "redemption_request_pda",
+            "docs": [
+              "The PDA address of the newly created redemption request"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_offer_pda",
+            "docs": [
+              "Reference to the redemption offer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redeemer",
+            "docs": [
+              "User requesting the redemption"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of token_in tokens requested for redemption"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "id",
+            "docs": [
+              "Unique identifier for this request (counter value used for PDA derivation)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionRequestFulfilledEvent",
+      "docs": [
+        "Event emitted when a redemption request is successfully fulfilled",
+        "",
+        "Provides transparency for tracking redemption fulfillment and token exchange details."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "redemption_request_pda",
+            "docs": [
+              "The PDA address of the fulfilled redemption request"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redemption_offer_pda",
+            "docs": [
+              "Reference to the redemption offer pda"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "redeemer",
+            "docs": [
+              "User who created the redemption request"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_in_net_amount",
+            "docs": [
+              "Net amount of token_in tokens burned/transferred (after fees)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_in_fee_amount",
+            "docs": [
+              "Fee amount deducted from token_in"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_out_amount",
+            "docs": [
+              "Amount of token_out tokens received by the user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_price",
+            "docs": [
+              "Current price used for the redemption"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionVaultDepositEvent",
+      "docs": [
+        "Event emitted when tokens are successfully deposited to the redemption vault",
+        "",
+        "Provides transparency for tracking redemption vault funding and token availability."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint that was deposited"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of tokens deposited to the vault"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that made the deposit"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RedemptionVaultWithdrawEvent",
+      "docs": [
+        "Event emitted when tokens are successfully withdrawn from the redemption vault",
+        "",
+        "Provides transparency for tracking redemption vault withdrawals and fund management."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint that was withdrawn"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Amount of tokens withdrawn from the vault"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that performed the withdrawal"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "State",
+      "docs": [
+        "Global program state containing governance and configuration settings",
+        "",
+        "Stores the core program authority structure, emergency controls, and trusted entities",
+        "used for authorization and approval verification across all program operations."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "boss",
+            "docs": [
+              "Primary program authority with full control over all operations"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "proposed_boss",
+            "docs": [
+              "Proposed new boss for two-step ownership transfer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "is_killed",
+            "docs": [
+              "Emergency kill switch to halt critical operations when activated"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "onyc_mint",
+            "docs": [
+              "ONyc token mint used for market calculations and operations"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "admins",
+            "docs": [
+              "Array of admin accounts authorized to enable the kill switch"
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                20
+              ]
+            }
+          },
+          {
+            "name": "approver1",
+            "docs": [
+              "First trusted authority for cryptographic approval verification"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "approver2",
+            "docs": [
+              "Second trusted authority for cryptographic approval verification"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump seed for account derivation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "max_supply",
+            "docs": [
+              "Optional maximum supply cap for ONyc token minting (0 = no cap)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "redemption_admin",
+            "docs": [
+              "Admin account authorized to manage ONr token mints and redemptions"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Reserved space for future program state extensions"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StateClosedEvent",
+      "docs": [
+        "Event emitted when the state account is successfully closed",
+        "",
+        "Provides transparency for tracking the closure of the program's main state account."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "state_pda",
+            "docs": [
+              "The PDA address of the state account that was closed"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boss",
+            "docs": [
+              "The boss account that initiated the closure and received the rent"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why this PR exists

The Onre App Solana program (`onreuGhHHgVzMWSkj2oQDLDtvvGvoepBPkqyaubFcwe`) has no visualizer preset, so wallets signing its offer/redemption instructions currently fall back to the generic unknown-program path with raw hex data instead of IDL-decoded fields.

## What changed

- New preset at `src/chain_parsers/visualsign-solana/src/presets/onre_app/` (`config.rs`, `mod.rs`, bundled `onre_app.json` IDL with 38 instructions).
- `OnreAppVisualizer` implements `InstructionVisualizer`: loads the bundled IDL via `include_str!` + `decode_idl_data`, parses instruction data with `parse_instruction_with_idl`, then emits program ID, instruction name, discriminator, named accounts (from IDL account order), parsed call args, and raw data.
- Registered as `VisualizerKind::Dex("Onre App")`.
- Added `pub mod onre_app;` to `presets/mod.rs` in alphabetical order. `build.rs` auto-discovers the visualizer struct — no further registration needed.
### Overview
<img width="862" height="884" alt="image" src="https://github.com/user-attachments/assets/010f79e1-8c04-411d-9862-247c4cd92d93" />

### Instruction
<img width="878" height="1590" alt="image" src="https://github.com/user-attachments/assets/e9d17f95-3cc9-4cb1-9b70-e55fd8b5c665" />

### Accounts
<img width="878" height="1590" alt="image" src="https://github.com/user-attachments/assets/52b98ef2-8d8c-4ba1-9a1a-96f4775d38ea" />



## Why this is safe

- Additive: no existing preset, core module, or public API is modified. Unmatched programs continue to hit `unknown_program` exactly as before.
- Parsing failures surface as `VisualSignError::DecodeError`, same error surface as other IDL-based presets (Jupiter, unknown_program).
- Data validation: rejects inputs `< 8` bytes before touching the IDL, and `parse_instruction_with_idl` validates discriminators against the IDL.
- The IDL is a static JSON blob fetched from `onre-finance/onre-sol@master/target/idl/onreapp.json`; it is embedded at compile time so runtime behavior cannot drift from what was reviewed.

### Checks run (by agent)

- `cargo build -p visualsign-solana` — passes
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — passes
- `cargo test -p visualsign-solana` — all tests pass, including the 4 required preset tests (`test_onre_app_idl_loads`, `test_onre_app_idl_has_discriminators`, `test_unknown_discriminator_returns_error`, `test_short_data_returns_error`)
- `make -C src test` — full workspace test suite green
- `cargo fmt -p visualsign-solana`

### Manual steps needed (by human)

None — fully automated by CI.

## How this is maintainable

- Follows the same generic-IDL preset pattern used by `unknown_program` and `jupiter_swap`: a reviewer familiar with either will recognize the structure immediately.
- `build.rs` auto-discovers `{PascalName}Visualizer` from any directory under `src/presets/`, so the wiring is implicit and cannot silently drift.
- IDL is bundled, not fetched at runtime — updating it is a deliberate check-in, and `test_onre_app_idl_has_discriminators` catches any malformed IDL at test time.
- Scaffold produced by the `/solana-add-idl` skill; the same skill can regenerate or add sibling presets with matching structure.