### PR TITLE
feat: add Neutral Trade Solana visualizer preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -7,6 +7,7 @@ pub mod jupiter_swap;
 pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
+pub mod neutral_trade;
 pub mod onre_app;
 pub mod stakepool;
 pub mod swig_wallet;

--- a/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/config.rs
@@ -1,0 +1,22 @@
+use super::NEUTRAL_TRADE_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct NeutralTradeConfig;
+
+impl SolanaIntegrationConfig for NeutralTradeConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(NEUTRAL_TRADE_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/mod.rs
@@ -1,0 +1,235 @@
+//! Neutral Trade program preset for Solana
+//!
+//! Parses Neutral Trade instructions using the bundled Anchor IDL.
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::NeutralTradeConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const NEUTRAL_TRADE_PROGRAM_ID: &str = "BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU";
+const NEUTRAL_TRADE_IDL_JSON: &str = include_str!("neutral_trade.json");
+const NEUTRAL_TRADE_DISPLAY_NAME: &str = "Neutral Trade";
+
+static NEUTRAL_TRADE_CONFIG: NeutralTradeConfig = NeutralTradeConfig;
+
+pub struct NeutralTradeVisualizer;
+
+impl InstructionVisualizer for NeutralTradeVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        if instruction.data.len() < 8 {
+            return Err(VisualSignError::DecodeError(
+                "Instruction data too short for Anchor discriminator".into(),
+            ));
+        }
+
+        let idl = load_idl()?;
+        let parsed = parse_instruction_with_idl(&instruction.data, NEUTRAL_TRADE_PROGRAM_ID, &idl)
+            .map_err(|e| {
+                VisualSignError::DecodeError(format!("Neutral Trade IDL parse failed: {e}"))
+            })?;
+
+        let named_accounts = build_named_accounts(instruction, &idl);
+
+        let program_id_str = instruction.program_id.to_string();
+        let instruction_data_hex = hex::encode(&instruction.data);
+        let instruction_title =
+            format!("{NEUTRAL_TRADE_DISPLAY_NAME}: {}", parsed.instruction_name);
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: build_condensed_fields(&instruction_title, &parsed)?,
+        };
+        let expanded = SignablePayloadFieldListLayout {
+            fields: build_parsed_fields(
+                &program_id_str,
+                &parsed,
+                &named_accounts,
+                &instruction.data,
+            )?,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 {
+                text: instruction_title.clone(),
+            }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: NEUTRAL_TRADE_DISPLAY_NAME.to_string(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text: format!(
+                        "Program ID: {program_id_str}\nData: {instruction_data_hex}"
+                    ),
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&NEUTRAL_TRADE_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Lending(NEUTRAL_TRADE_DISPLAY_NAME)
+    }
+}
+
+fn load_idl() -> Result<Idl, VisualSignError> {
+    decode_idl_data(NEUTRAL_TRADE_IDL_JSON)
+        .map_err(|e| VisualSignError::DecodeError(format!("Invalid Neutral Trade IDL: {e}")))
+}
+
+fn build_named_accounts(
+    instruction: &solana_sdk::instruction::Instruction,
+    idl: &Idl,
+) -> HashMap<String, String> {
+    let mut named_accounts = HashMap::new();
+
+    let matching_idl_instruction = idl.instructions.iter().find(|inst| {
+        if let Some(disc) = inst.discriminator.as_ref() {
+            instruction.data.len() >= 8 && &instruction.data[0..8] == disc.as_slice()
+        } else {
+            false
+        }
+    });
+
+    if let Some(idl_instruction) = matching_idl_instruction {
+        for (index, account_meta) in instruction.accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+            }
+        }
+    }
+
+    named_accounts
+}
+
+fn build_condensed_fields(
+    title: &str,
+    parsed: &SolanaParsedInstructionData,
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![create_text_field("Instruction", title)?];
+    for (key, value) in &parsed.program_call_args {
+        fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+    Ok(fields)
+}
+
+fn build_parsed_fields(
+    program_id: &str,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program", NEUTRAL_TRADE_DISPLAY_NAME)?,
+        create_text_field("Program ID", program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    for (name, address) in named_accounts {
+        fields.push(create_text_field(name, address)?);
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    append_raw_data(&mut fields, data)?;
+    Ok(fields)
+}
+
+fn append_raw_data(
+    fields: &mut Vec<AnnotatedPayloadField>,
+    data: &[u8],
+) -> Result<(), VisualSignError> {
+    fields.push(create_raw_data_field(data, Some(hex::encode(data)))?);
+    Ok(())
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_neutral_trade_idl_loads() {
+        let idl = load_idl().expect("IDL should load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL must contain instructions"
+        );
+    }
+
+    #[test]
+    fn test_neutral_trade_idl_has_discriminators() {
+        let idl = load_idl().expect("IDL should load");
+        for inst in &idl.instructions {
+            let disc = inst
+                .discriminator
+                .as_ref()
+                .unwrap_or_else(|| panic!("instruction '{}' has no discriminator", inst.name));
+            assert_eq!(
+                disc.len(),
+                8,
+                "instruction '{}' discriminator must be 8 bytes",
+                inst.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let idl = load_idl().expect("IDL should load");
+        let garbage = vec![0xFFu8; 9];
+        let result = parse_instruction_with_idl(&garbage, NEUTRAL_TRADE_PROGRAM_ID, &idl);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let idl = load_idl().expect("IDL should load");
+        let short = vec![0x01u8, 0x02, 0x03];
+        let result = parse_instruction_with_idl(&short, NEUTRAL_TRADE_PROGRAM_ID, &idl);
+        assert!(result.is_err(), "Short data should return error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/mod.rs
@@ -11,7 +11,7 @@ use config::NeutralTradeConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -110,8 +110,8 @@ fn load_idl() -> Result<Idl, VisualSignError> {
 fn build_named_accounts(
     instruction: &solana_sdk::instruction::Instruction,
     idl: &Idl,
-) -> HashMap<String, String> {
-    let mut named_accounts = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named_accounts = BTreeMap::new();
 
     let matching_idl_instruction = idl.instructions.iter().find(|inst| {
         if let Some(disc) = inst.discriminator.as_ref() {
@@ -146,7 +146,7 @@ fn build_condensed_fields(
 fn build_parsed_fields(
     program_id: &str,
     parsed: &SolanaParsedInstructionData,
-    named_accounts: &HashMap<String, String>,
+    named_accounts: &BTreeMap<String, String>,
     data: &[u8],
 ) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
     let mut fields = vec![

--- a/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/neutral_trade.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/neutral_trade/neutral_trade.json
@@ -1,0 +1,6299 @@
+{
+  "address": "BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU",
+  "metadata": {
+    "name": "ntbundle",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "add_strategy",
+      "discriminator": [
+        64,
+        123,
+        127,
+        227,
+        192,
+        234,
+        198,
+        20
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "receiver_address",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "allocation_bps",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "apply_fees_to_user",
+      "discriminator": [
+        26,
+        41,
+        103,
+        167,
+        61,
+        147,
+        141,
+        30
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account_owner",
+          "writable": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user_bundle_account_owner"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "change_bundle_master_admin",
+      "discriminator": [
+        255,
+        41,
+        246,
+        82,
+        7,
+        81,
+        174,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_master_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  77,
+                  65,
+                  83,
+                  84,
+                  69,
+                  82
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "change_manager",
+      "discriminator": [
+        97,
+        44,
+        74,
+        213,
+        119,
+        243,
+        203,
+        8
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_manager",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "close_user_bundle_account",
+      "discriminator": [
+        201,
+        195,
+        126,
+        228,
+        9,
+        173,
+        79,
+        215
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "distribute_to_receivers",
+      "discriminator": [
+        123,
+        169,
+        151,
+        143,
+        0,
+        82,
+        209,
+        145
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "receiver_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "receiver_ata",
+          "writable": true
+        },
+        {
+          "name": "asset_address"
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "enable_strategy",
+      "discriminator": [
+        245,
+        37,
+        61,
+        122,
+        99,
+        92,
+        182,
+        30
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "receiver_address",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "end_distribution",
+      "discriminator": [
+        201,
+        74,
+        167,
+        103,
+        102,
+        125,
+        0,
+        236
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_bundle",
+      "discriminator": [
+        93,
+        76,
+        148,
+        51,
+        99,
+        41,
+        179,
+        234
+      ],
+      "accounts": [
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_creator_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  67,
+                  82,
+                  69,
+                  65,
+                  84,
+                  79,
+                  82
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "treasury_account",
+          "writable": true
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "name"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "keeper",
+          "type": "pubkey"
+        },
+        {
+          "name": "deposit_fee",
+          "type": "u32"
+        },
+        {
+          "name": "withdrawal_fee",
+          "type": "u32"
+        },
+        {
+          "name": "performance_fee",
+          "type": "u32"
+        },
+        {
+          "name": "management_fee_bps",
+          "type": "u32"
+        },
+        {
+          "name": "oracle_buffer",
+          "type": "u64"
+        },
+        {
+          "name": "max_deposit_amount",
+          "type": "u64"
+        },
+        {
+          "name": "min_deposit_amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawal_delay",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawal_t_min",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_t_max",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_curve",
+          "type": "f32"
+        },
+        {
+          "name": "oracle_max_age",
+          "type": "i64"
+        },
+        {
+          "name": "oracle_update_time_limit",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_redemption_request_cutoff_ts",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_redemption_unlock_current_cycle_ts",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_redemption_unlock_next_cycle_ts",
+          "type": "i64"
+        },
+        {
+          "name": "permissionned",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "initialize_bundle_depositor",
+      "discriminator": [
+        126,
+        6,
+        242,
+        36,
+        22,
+        209,
+        35,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "user_bundle_account",
+          "docs": [
+            "each user gets one UserBundleAccount account; it will be created if it doesn't exist."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_bundle_master_account",
+      "discriminator": [
+        125,
+        166,
+        190,
+        35,
+        73,
+        169,
+        140,
+        206
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_master_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  77,
+                  65,
+                  83,
+                  84,
+                  69,
+                  82
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_permissioned_bundle_depositor",
+      "discriminator": [
+        157,
+        162,
+        213,
+        42,
+        205,
+        201,
+        37,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "user_bundle_account",
+          "docs": [
+            "each user gets one UserBundleAccount account; it will be created if it doesn't exist."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "manager_withdraw",
+      "discriminator": [
+        201,
+        248,
+        190,
+        143,
+        86,
+        43,
+        183,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "manager_token_account",
+          "writable": true
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "net_pending_transactions",
+      "discriminator": [
+        44,
+        219,
+        50,
+        19,
+        246,
+        252,
+        37,
+        163
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "pending_deposit_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pending_bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "pending_bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  69,
+                  78,
+                  68,
+                  73,
+                  78,
+                  71,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "pause_deposits_withdrawals",
+      "discriminator": [
+        106,
+        171,
+        198,
+        31,
+        183,
+        219,
+        159,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "pause",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "perform_refill",
+      "discriminator": [
+        241,
+        64,
+        6,
+        52,
+        58,
+        169,
+        15,
+        12
+      ],
+      "accounts": [
+        {
+          "name": "receiver_address",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "receiver_ata",
+          "writable": true
+        },
+        {
+          "name": "asset_address"
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "refill_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "process_deposit",
+      "discriminator": [
+        136,
+        162,
+        64,
+        35,
+        84,
+        200,
+        254,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user_bundle_account_owner"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pending_deposit_token_account",
+          "docs": [
+            "the account holding the user's deposited asset before allocation."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pending_bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "user_bundle_account_owner",
+          "docs": [
+            "the owner of the pending request (for event purposes)."
+          ]
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pending_bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  69,
+                  78,
+                  68,
+                  73,
+                  78,
+                  71,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "process_withdrawal",
+      "discriminator": [
+        51,
+        97,
+        236,
+        17,
+        37,
+        33,
+        196,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account_owner"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "pending_bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  69,
+                  78,
+                  68,
+                  73,
+                  78,
+                  71,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user_bundle_account_owner"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refund_deposit",
+      "discriminator": [
+        19,
+        19,
+        78,
+        50,
+        187,
+        10,
+        162,
+        229
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user_bundle_account_owner"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_bundle_account_owner",
+          "docs": [
+            "the owner of the pending request (for event purposes)."
+          ]
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_asset_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_strategy",
+      "discriminator": [
+        185,
+        238,
+        33,
+        91,
+        134,
+        210,
+        97,
+        26
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "receiver_address",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "request_deposit",
+      "discriminator": [
+        243,
+        202,
+        197,
+        215,
+        135,
+        97,
+        213,
+        109
+      ],
+      "accounts": [
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_token_account",
+          "docs": [
+            "user token account (source of funds)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pending_deposit_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pending_bundle_asset_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "asset_address"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "treasury_account",
+          "writable": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_address",
+          "writable": true
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "pending_bundle_asset_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  69,
+                  78,
+                  68,
+                  73,
+                  78,
+                  71,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  65,
+                  83,
+                  83,
+                  69,
+                  84,
+                  95,
+                  65,
+                  85,
+                  84,
+                  72,
+                  79,
+                  82,
+                  73,
+                  84,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "request_withdrawal",
+      "discriminator": [
+        251,
+        85,
+        121,
+        205,
+        56,
+        201,
+        12,
+        177
+      ],
+      "accounts": [
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_bundle_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  85,
+                  83,
+                  69,
+                  82,
+                  95,
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "shares_amount",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "set_bundle_creator",
+      "discriminator": [
+        190,
+        144,
+        93,
+        89,
+        14,
+        138,
+        195,
+        166
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_master_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  77,
+                  65,
+                  83,
+                  84,
+                  69,
+                  82
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "CHECK safe as only the pubkey is read"
+          ]
+        },
+        {
+          "name": "bundle_creator_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  67,
+                  82,
+                  69,
+                  65,
+                  84,
+                  79,
+                  82
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "allowed",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "set_delays",
+      "discriminator": [
+        18,
+        56,
+        143,
+        125,
+        147,
+        15,
+        199,
+        108
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "withdrawal_delay",
+          "type": "u64"
+        },
+        {
+          "name": "withdrawal_t_min",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_t_max",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_curve",
+          "type": "f32"
+        }
+      ]
+    },
+    {
+      "name": "set_fees",
+      "discriminator": [
+        137,
+        178,
+        49,
+        58,
+        0,
+        245,
+        242,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "treasury",
+          "type": "pubkey"
+        },
+        {
+          "name": "deposit_fee",
+          "type": "u32"
+        },
+        {
+          "name": "withdrawal_fee",
+          "type": "u32"
+        },
+        {
+          "name": "performance_fee",
+          "type": "u32"
+        },
+        {
+          "name": "management_fee_bps",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "set_keeper",
+      "discriminator": [
+        102,
+        94,
+        23,
+        78,
+        157,
+        222,
+        243,
+        214
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newkeeper",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_max_deposit_amount",
+      "discriminator": [
+        29,
+        66,
+        217,
+        12,
+        80,
+        248,
+        214,
+        9
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "max_deposit_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_min_deposit_amount",
+      "discriminator": [
+        224,
+        153,
+        215,
+        211,
+        233,
+        14,
+        124,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "min_deposit_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_oracle_buffer",
+      "discriminator": [
+        7,
+        196,
+        14,
+        82,
+        110,
+        244,
+        46,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "oracle_buffer",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_oracle_max_age",
+      "discriminator": [
+        75,
+        127,
+        254,
+        84,
+        122,
+        23,
+        122,
+        82
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "oracle_max_age",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "set_oracle_update_time_limit",
+      "discriminator": [
+        114,
+        2,
+        35,
+        146,
+        19,
+        99,
+        67,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "oracle_update_time_limit",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "set_withdrawal_redemption_schedule",
+      "discriminator": [
+        134,
+        108,
+        237,
+        103,
+        185,
+        13,
+        177,
+        105
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "withdrawal_redemption_request_cutoff_ts",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_redemption_unlock_current_cycle_ts",
+          "type": "i64"
+        },
+        {
+          "name": "withdrawal_redemption_unlock_next_cycle_ts",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "start_distribution",
+      "discriminator": [
+        118,
+        230,
+        215,
+        75,
+        83,
+        2,
+        163,
+        35
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_allocations",
+      "discriminator": [
+        229,
+        242,
+        146,
+        124,
+        44,
+        15,
+        130,
+        95
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "receiver_address",
+          "writable": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "strategy_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  83,
+                  84,
+                  82,
+                  65,
+                  84,
+                  69,
+                  71,
+                  89
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "receiver_address"
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "new_allocation_bps",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "update_oracle",
+      "discriminator": [
+        112,
+        41,
+        209,
+        18,
+        248,
+        226,
+        252,
+        188
+      ],
+      "accounts": [
+        {
+          "name": "keeper",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bundle_account",
+          "writable": true
+        },
+        {
+          "name": "bundle_temp_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  66,
+                  85,
+                  78,
+                  68,
+                  76,
+                  69,
+                  95,
+                  84,
+                  69,
+                  77,
+                  80,
+                  95,
+                  68,
+                  65,
+                  84,
+                  65
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  79,
+                  82,
+                  65,
+                  67,
+                  76,
+                  69
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bundle_account"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "new_equity",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Bundle",
+      "discriminator": [
+        15,
+        82,
+        167,
+        230,
+        37,
+        214,
+        82,
+        80
+      ]
+    },
+    {
+      "name": "BundleCreatorAccount",
+      "discriminator": [
+        210,
+        168,
+        93,
+        196,
+        184,
+        35,
+        210,
+        101
+      ]
+    },
+    {
+      "name": "BundleMasterAccount",
+      "discriminator": [
+        252,
+        50,
+        148,
+        252,
+        178,
+        231,
+        4,
+        149
+      ]
+    },
+    {
+      "name": "BundleTempData",
+      "discriminator": [
+        3,
+        137,
+        171,
+        33,
+        191,
+        15,
+        54,
+        4
+      ]
+    },
+    {
+      "name": "OracleData",
+      "discriminator": [
+        26,
+        131,
+        25,
+        110,
+        6,
+        141,
+        10,
+        37
+      ]
+    },
+    {
+      "name": "Strategy",
+      "discriminator": [
+        174,
+        110,
+        39,
+        119,
+        82,
+        106,
+        169,
+        102
+      ]
+    },
+    {
+      "name": "UserBundleAccount",
+      "discriminator": [
+        32,
+        181,
+        106,
+        26,
+        67,
+        130,
+        185,
+        241
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "Allocated",
+      "discriminator": [
+        146,
+        11,
+        194,
+        76,
+        4,
+        220,
+        226,
+        43
+      ]
+    },
+    {
+      "name": "AllocationsUpdated",
+      "discriminator": [
+        97,
+        171,
+        21,
+        101,
+        243,
+        48,
+        182,
+        32
+      ]
+    },
+    {
+      "name": "AssignedProfitShare",
+      "discriminator": [
+        13,
+        208,
+        181,
+        192,
+        192,
+        238,
+        120,
+        197
+      ]
+    },
+    {
+      "name": "AuthorizedReceiverAdded",
+      "discriminator": [
+        185,
+        19,
+        240,
+        219,
+        194,
+        25,
+        19,
+        234
+      ]
+    },
+    {
+      "name": "AuthorizedReceiverRemoved",
+      "discriminator": [
+        69,
+        73,
+        150,
+        51,
+        198,
+        98,
+        43,
+        0
+      ]
+    },
+    {
+      "name": "BundleCreatorAccountChanged",
+      "discriminator": [
+        82,
+        51,
+        169,
+        242,
+        101,
+        205,
+        39,
+        52
+      ]
+    },
+    {
+      "name": "BundleDepositorInitialized",
+      "discriminator": [
+        136,
+        231,
+        96,
+        201,
+        187,
+        244,
+        121,
+        42
+      ]
+    },
+    {
+      "name": "BundleMasterAccountInitialized",
+      "discriminator": [
+        238,
+        211,
+        137,
+        135,
+        255,
+        239,
+        90,
+        91
+      ]
+    },
+    {
+      "name": "BundleMasterAdminChanged",
+      "discriminator": [
+        220,
+        192,
+        90,
+        93,
+        19,
+        132,
+        73,
+        208
+      ]
+    },
+    {
+      "name": "ChangedCoreParams",
+      "discriminator": [
+        156,
+        119,
+        46,
+        221,
+        22,
+        121,
+        186,
+        53
+      ]
+    },
+    {
+      "name": "ChargedFeesToUser",
+      "discriminator": [
+        201,
+        63,
+        172,
+        93,
+        230,
+        105,
+        127,
+        255
+      ]
+    },
+    {
+      "name": "DelaysSet",
+      "discriminator": [
+        241,
+        35,
+        245,
+        242,
+        188,
+        53,
+        99,
+        208
+      ]
+    },
+    {
+      "name": "DepositRequested",
+      "discriminator": [
+        35,
+        33,
+        229,
+        138,
+        116,
+        238,
+        192,
+        22
+      ]
+    },
+    {
+      "name": "DepositedToDriftVault",
+      "discriminator": [
+        200,
+        86,
+        135,
+        159,
+        147,
+        246,
+        123,
+        85
+      ]
+    },
+    {
+      "name": "DistributedToReceivers",
+      "discriminator": [
+        204,
+        43,
+        29,
+        187,
+        40,
+        60,
+        126,
+        14
+      ]
+    },
+    {
+      "name": "DistributionEnded",
+      "discriminator": [
+        21,
+        180,
+        83,
+        66,
+        101,
+        235,
+        108,
+        208
+      ]
+    },
+    {
+      "name": "DistributionStarted",
+      "discriminator": [
+        148,
+        231,
+        87,
+        211,
+        194,
+        167,
+        104,
+        6
+      ]
+    },
+    {
+      "name": "DustSharesBurned",
+      "discriminator": [
+        166,
+        218,
+        110,
+        236,
+        33,
+        135,
+        162,
+        139
+      ]
+    },
+    {
+      "name": "InitializedNewVaultDepositor",
+      "discriminator": [
+        16,
+        182,
+        169,
+        250,
+        42,
+        81,
+        202,
+        173
+      ]
+    },
+    {
+      "name": "InitializedReceivers",
+      "discriminator": [
+        52,
+        175,
+        118,
+        72,
+        108,
+        236,
+        162,
+        134
+      ]
+    },
+    {
+      "name": "InitializedVault",
+      "discriminator": [
+        123,
+        23,
+        51,
+        180,
+        138,
+        156,
+        172,
+        91
+      ]
+    },
+    {
+      "name": "ManagerWithdrawal",
+      "discriminator": [
+        167,
+        6,
+        24,
+        193,
+        128,
+        74,
+        94,
+        207
+      ]
+    },
+    {
+      "name": "MaxDepositAmountSet",
+      "discriminator": [
+        204,
+        243,
+        42,
+        160,
+        116,
+        144,
+        207,
+        38
+      ]
+    },
+    {
+      "name": "MinDepositAmountSet",
+      "discriminator": [
+        143,
+        114,
+        126,
+        18,
+        32,
+        207,
+        22,
+        19
+      ]
+    },
+    {
+      "name": "NettingCompleted",
+      "discriminator": [
+        176,
+        162,
+        4,
+        24,
+        91,
+        47,
+        115,
+        81
+      ]
+    },
+    {
+      "name": "NewKeeperSet",
+      "discriminator": [
+        33,
+        68,
+        171,
+        11,
+        43,
+        129,
+        192,
+        45
+      ]
+    },
+    {
+      "name": "NewManagerSet",
+      "discriminator": [
+        215,
+        213,
+        93,
+        251,
+        202,
+        98,
+        253,
+        29
+      ]
+    },
+    {
+      "name": "OracleBufferSet",
+      "discriminator": [
+        188,
+        151,
+        124,
+        251,
+        253,
+        205,
+        187,
+        32
+      ]
+    },
+    {
+      "name": "OracleMaxAgeSet",
+      "discriminator": [
+        51,
+        17,
+        80,
+        99,
+        8,
+        112,
+        166,
+        44
+      ]
+    },
+    {
+      "name": "OracleUpdateTimeLimitSet",
+      "discriminator": [
+        196,
+        182,
+        75,
+        225,
+        80,
+        5,
+        111,
+        103
+      ]
+    },
+    {
+      "name": "OracleUpdated",
+      "discriminator": [
+        138,
+        9,
+        51,
+        219,
+        228,
+        198,
+        11,
+        147
+      ]
+    },
+    {
+      "name": "PausedDepositsWithdrawals",
+      "discriminator": [
+        131,
+        139,
+        248,
+        233,
+        29,
+        255,
+        148,
+        98
+      ]
+    },
+    {
+      "name": "Redeemed",
+      "discriminator": [
+        14,
+        29,
+        183,
+        71,
+        31,
+        165,
+        107,
+        38
+      ]
+    },
+    {
+      "name": "Refilled",
+      "discriminator": [
+        103,
+        127,
+        43,
+        0,
+        232,
+        50,
+        198,
+        85
+      ]
+    },
+    {
+      "name": "RefundedDeposit",
+      "discriminator": [
+        193,
+        61,
+        203,
+        180,
+        250,
+        38,
+        151,
+        31
+      ]
+    },
+    {
+      "name": "RequestedWithdrawalToDriftVault",
+      "discriminator": [
+        143,
+        146,
+        104,
+        155,
+        23,
+        243,
+        14,
+        231
+      ]
+    },
+    {
+      "name": "StrategyAdded",
+      "discriminator": [
+        248,
+        59,
+        8,
+        90,
+        242,
+        168,
+        247,
+        204
+      ]
+    },
+    {
+      "name": "StrategyEnabled",
+      "discriminator": [
+        105,
+        24,
+        77,
+        30,
+        163,
+        227,
+        107,
+        102
+      ]
+    },
+    {
+      "name": "StrategyRemoved",
+      "discriminator": [
+        118,
+        162,
+        92,
+        185,
+        73,
+        29,
+        245,
+        144
+      ]
+    },
+    {
+      "name": "UserBundleAccountClosed",
+      "discriminator": [
+        111,
+        102,
+        134,
+        54,
+        238,
+        23,
+        157,
+        183
+      ]
+    },
+    {
+      "name": "VaultNeutralFeeIncrementerSet",
+      "discriminator": [
+        7,
+        53,
+        169,
+        104,
+        118,
+        22,
+        134,
+        207
+      ]
+    },
+    {
+      "name": "WithdrawalRedemptionScheduleSet",
+      "discriminator": [
+        245,
+        195,
+        40,
+        76,
+        237,
+        247,
+        150,
+        107
+      ]
+    },
+    {
+      "name": "WithdrawalRequested",
+      "discriminator": [
+        75,
+        207,
+        21,
+        12,
+        160,
+        102,
+        150,
+        55
+      ]
+    },
+    {
+      "name": "WithdrawnFromDriftVault",
+      "discriminator": [
+        249,
+        177,
+        58,
+        24,
+        88,
+        115,
+        105,
+        193
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InsufficientFunds",
+      "msg": "Insufficient funds to process withdrawal"
+    },
+    {
+      "code": 6001,
+      "name": "AllocationAmountZero",
+      "msg": "Allocation amount must be > 0"
+    },
+    {
+      "code": 6002,
+      "name": "RedemptionAmountExceeded",
+      "msg": "Redemption exceeds bundle balance"
+    },
+    {
+      "code": 6003,
+      "name": "RefillAmountInvalid",
+      "msg": "Refill amount must be > 0"
+    },
+    {
+      "code": 6004,
+      "name": "UnauthorizedKeeperAction",
+      "msg": "Not bundle keeper"
+    },
+    {
+      "code": 6005,
+      "name": "UnauthorizedManagerAction",
+      "msg": "Not bundle manager"
+    },
+    {
+      "code": 6006,
+      "name": "UnauthorizedAdminAction",
+      "msg": "Not bundle admin"
+    },
+    {
+      "code": 6007,
+      "name": "UnauthorizedBundleCreator",
+      "msg": "Not whitelisted bundle creator"
+    },
+    {
+      "code": 6008,
+      "name": "CallerNotNeutralFeeIncrementer",
+      "msg": "Not neutral fee incrementer"
+    },
+    {
+      "code": 6009,
+      "name": "AmountMustBeBelowMax",
+      "msg": "Amount above max limit"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidNeutralFeeIncrementer",
+      "msg": "Invalid fee incrementer"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidReceiver",
+      "msg": "Invalid receiver address"
+    },
+    {
+      "code": 6012,
+      "name": "MathError",
+      "msg": "Math error"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidAllocations",
+      "msg": "Invalid allocations"
+    },
+    {
+      "code": 6014,
+      "name": "MustBeInWhitelist",
+      "msg": "Not in whitelist"
+    },
+    {
+      "code": 6015,
+      "name": "DistributionAlreadyStarted",
+      "msg": "Distribution already started"
+    },
+    {
+      "code": 6016,
+      "name": "DistributionNotStarted",
+      "msg": "Distribution not started"
+    },
+    {
+      "code": 6017,
+      "name": "LeftToDistributeNotZero",
+      "msg": "Distribution amount not zero"
+    },
+    {
+      "code": 6018,
+      "name": "ReceiverAlreadyAllocated",
+      "msg": "Receiver already allocated"
+    },
+    {
+      "code": 6019,
+      "name": "RawTransferReceiver",
+      "msg": "Not a raw transfer receiver"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidTwapPeriod",
+      "msg": "Invalid twap period"
+    },
+    {
+      "code": 6021,
+      "name": "RefillAmountExceeded",
+      "msg": "Refill amount exceeded"
+    },
+    {
+      "code": 6022,
+      "name": "PodTokenTotalSupplyZero",
+      "msg": "Pod token total supply is zero"
+    },
+    {
+      "code": 6023,
+      "name": "AllocationBpsGreaterThanGlobalAllocationBps",
+      "msg": "Allocation bps greater than global allocation bps"
+    },
+    {
+      "code": 6024,
+      "name": "EquityOutOfBufferBound",
+      "msg": "Equity out of buffer bound"
+    },
+    {
+      "code": 6025,
+      "name": "RedemptionAmountZero",
+      "msg": "Redemption amount must be > 0"
+    },
+    {
+      "code": 6026,
+      "name": "PendingDepositExists",
+      "msg": "Pending deposit exists"
+    },
+    {
+      "code": 6027,
+      "name": "InsufficientSharesBalance",
+      "msg": "Insufficient Shares balance"
+    },
+    {
+      "code": 6028,
+      "name": "PendingWithdrawalExists",
+      "msg": "Pending withdrawal exists"
+    },
+    {
+      "code": 6029,
+      "name": "PendingDepositOrWithdrawalExists",
+      "msg": "Pending deposit or withdrawal exists"
+    },
+    {
+      "code": 6030,
+      "name": "NoPendingWithdrawal",
+      "msg": "No pending withdrawal"
+    },
+    {
+      "code": 6031,
+      "name": "WithdrawalAlreadyProcessed",
+      "msg": "Withdrawal already processed"
+    },
+    {
+      "code": 6032,
+      "name": "PendingDepositAmountZero",
+      "msg": "Pending deposit amount is zero"
+    },
+    {
+      "code": 6033,
+      "name": "InsufficientBundleBalance",
+      "msg": "Insufficient bundle balance"
+    },
+    {
+      "code": 6034,
+      "name": "NoPendingTransactions",
+      "msg": "No pending transactions"
+    },
+    {
+      "code": 6035,
+      "name": "DepositsExtraInPendingsNotZero",
+      "msg": "Deposits extra in pendings not zero"
+    },
+    {
+      "code": 6036,
+      "name": "PendingTransactionsExist",
+      "msg": "Pending transactions exist"
+    },
+    {
+      "code": 6037,
+      "name": "ManagerSharesZero",
+      "msg": "Manager shares is zero"
+    },
+    {
+      "code": 6038,
+      "name": "PausedDepositsWithdrawals",
+      "msg": "Paused deposits withdrawals"
+    },
+    {
+      "code": 6039,
+      "name": "UnpausedDepositsWithdrawals",
+      "msg": "Unpaused deposits withdrawals"
+    },
+    {
+      "code": 6040,
+      "name": "NettingNotDone",
+      "msg": "Netting not done"
+    },
+    {
+      "code": 6041,
+      "name": "NettingAlreadyDone",
+      "msg": "Netting already done"
+    },
+    {
+      "code": 6042,
+      "name": "OracleNotUpdated",
+      "msg": "Oracle not updated"
+    },
+    {
+      "code": 6043,
+      "name": "MaxDepositAmountExceeded",
+      "msg": "Max deposit amount exceeded"
+    },
+    {
+      "code": 6044,
+      "name": "TotalAssetExceedNewMaxDepositAmount",
+      "msg": "Total asset exceed new max deposit amount"
+    },
+    {
+      "code": 6045,
+      "name": "AllocationBpsIsZero",
+      "msg": "Allocation bps is zero"
+    },
+    {
+      "code": 6046,
+      "name": "DepositAmountZero",
+      "msg": "Deposit amount is zero"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidWithdrawalDelay",
+      "msg": "Invalid withdrawal delay"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidWithdrawalCooldownPeriod",
+      "msg": "Invalid withdrawal cooldown period"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidOracleBuffer",
+      "msg": "Invalid oracle buffer"
+    },
+    {
+      "code": 6050,
+      "name": "ExcessivePerformanceFee",
+      "msg": "Excessive performance fee"
+    },
+    {
+      "code": 6051,
+      "name": "ExcessiveManagementFee",
+      "msg": "Excessive management fee"
+    },
+    {
+      "code": 6052,
+      "name": "ExcessiveDepositFee",
+      "msg": "Excessive deposit fee"
+    },
+    {
+      "code": 6053,
+      "name": "ExcessiveWithdrawFee",
+      "msg": "Excessive withdraw fee"
+    },
+    {
+      "code": 6054,
+      "name": "WithdrawalDelayNotMet",
+      "msg": "Withdrawal delay not met"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidAssetPrecision",
+      "msg": "Invalid asset precision"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidAssetAddress",
+      "msg": "Invalid asset address"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidPermissionnedDepositor",
+      "msg": "Invalid permissionned depositor"
+    },
+    {
+      "code": 6058,
+      "name": "PayerNotAuthority",
+      "msg": "Payer is not the authority"
+    },
+    {
+      "code": 6059,
+      "name": "StrategyAlreadyEnabled",
+      "msg": "Strategy is already enabled"
+    },
+    {
+      "code": 6060,
+      "name": "StrategyDisabled",
+      "msg": "Strategy is disabled"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidWithdrawalAmount",
+      "msg": "Invalid withdrawal amount"
+    },
+    {
+      "code": 6062,
+      "name": "BundleNotPermissionned",
+      "msg": "Not permissionned"
+    },
+    {
+      "code": 6063,
+      "name": "BundleIsPermissionned",
+      "msg": "Bundle is permissionned, use initialize_permissioned_bundle_depositor"
+    },
+    {
+      "code": 6064,
+      "name": "TooManyAllocatedReceivers",
+      "msg": "Too many allocated receivers"
+    },
+    {
+      "code": 6065,
+      "name": "OracleUpdateTooFrequent",
+      "msg": "Oracle update too frequent"
+    },
+    {
+      "code": 6066,
+      "name": "UserBundleAccountNotEmpty",
+      "msg": "User bundle account not empty"
+    },
+    {
+      "code": 6067,
+      "name": "MinDepositAmountNotMet",
+      "msg": "Min deposit amount not met"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidOracleMaxAge",
+      "msg": "Invalid oracle max age"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidOracleUpdateTimeLimit",
+      "msg": "Invalid oracle update time limit"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidWithdrawalRedemptionSchedule",
+      "msg": "Invalid withdrawal redemption schedule"
+    }
+  ],
+  "types": [
+    {
+      "name": "Allocated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "to",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "net_amount",
+            "type": "u64"
+          },
+          {
+            "name": "share_price",
+            "type": "u128"
+          },
+          {
+            "name": "user_shares_before",
+            "type": "u128"
+          },
+          {
+            "name": "user_shares_after",
+            "type": "u128"
+          },
+          {
+            "name": "total_shares",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllocationsUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "receiver_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "allocation_bps",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssignedProfitShare",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorizedReceiverAdded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allowed",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorizedReceiverRemoved",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allowed",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bundle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "manager",
+            "type": "pubkey"
+          },
+          {
+            "name": "keeper",
+            "type": "pubkey"
+          },
+          {
+            "name": "treasury_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "allocated_receivers",
+            "type": {
+              "vec": "pubkey"
+            }
+          },
+          {
+            "name": "bundle_underlying_balance",
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_amount",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawal_delay",
+            "type": "u64"
+          },
+          {
+            "name": "performance_fee",
+            "type": "u32"
+          },
+          {
+            "name": "management_fee_bps",
+            "type": "u32"
+          },
+          {
+            "name": "deposit_fee",
+            "type": "u32"
+          },
+          {
+            "name": "withdrawal_fee",
+            "type": "u32"
+          },
+          {
+            "name": "manager_pfee_shares",
+            "type": "u128"
+          },
+          {
+            "name": "current_allocation_bps",
+            "type": "u32"
+          },
+          {
+            "name": "oracle_buffer",
+            "type": "u64"
+          },
+          {
+            "name": "total_shares",
+            "type": "u128"
+          },
+          {
+            "name": "asset_precision",
+            "type": "u64"
+          },
+          {
+            "name": "asset_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "withdrawal_t_min",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_t_max",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_curve",
+            "type": "f32"
+          },
+          {
+            "name": "permissionned",
+            "type": "bool"
+          },
+          {
+            "name": "manager_mfee_shares",
+            "type": "u128"
+          },
+          {
+            "name": "min_deposit_amount",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_update_time_limit",
+            "type": "i64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_redemption_request_cutoff_ts",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_redemption_unlock_current_cycle_ts",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_redemption_unlock_next_cycle_ts",
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                207
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleCreatorAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allowed",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleCreatorAccountChanged",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "allowed",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleDepositorInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bundle_depositor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleMasterAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleMasterAccountInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleMasterAdminChanged",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BundleTempData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cumulative_pending_deposits",
+            "type": "u64"
+          },
+          {
+            "name": "pending_deposits_counter",
+            "type": "u64"
+          },
+          {
+            "name": "pending_withdrawals_counter",
+            "type": "u64"
+          },
+          {
+            "name": "pending_locked_withdrawals_counter",
+            "type": "u64"
+          },
+          {
+            "name": "last_total_shares_minted",
+            "type": "u128"
+          },
+          {
+            "name": "last_netting_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "is_netting_done",
+            "type": "bool"
+          },
+          {
+            "name": "distribution_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "is_distribution_started",
+            "type": "bool"
+          },
+          {
+            "name": "paused_deposits_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "left_to_distribute",
+            "type": "u64"
+          },
+          {
+            "name": "allocated_shares",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                168
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChangedCoreParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_fee",
+            "type": "u32"
+          },
+          {
+            "name": "withdrawal_fee",
+            "type": "u32"
+          },
+          {
+            "name": "performance_fee",
+            "type": "u32"
+          },
+          {
+            "name": "management_fee_bps",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ChargedFeesToUser",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_fee_shares",
+            "type": "u128"
+          },
+          {
+            "name": "total_fee_value",
+            "type": "u64"
+          },
+          {
+            "name": "management_fee_shares",
+            "type": "u128"
+          },
+          {
+            "name": "performance_fee_shares",
+            "type": "u128"
+          },
+          {
+            "name": "share_price",
+            "type": "u128"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DelaysSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "withdrawal_delay",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawal_t_min",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_t_max",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_curve",
+            "type": "f32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositRequested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "topping_up",
+            "type": "bool"
+          },
+          {
+            "name": "gross_amount",
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "net_amount",
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositedToDriftVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "to",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DistributedToReceivers",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DistributionEnded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DistributionStarted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DustSharesBurned",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u128"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializedNewVaultDepositor",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "keeper",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializedReceivers",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "manager",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializedVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "manager",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ManagerWithdrawal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "manager_shares",
+            "type": "u128"
+          },
+          {
+            "name": "redemption_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MaxDepositAmountSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_deposit_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinDepositAmountSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_deposit_amount",
+            "type": "u64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NettingCompleted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewKeeperSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "keeper",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewManagerSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "manager",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleBufferSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle_buffer",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "average_external_equity",
+            "type": "u64"
+          },
+          {
+            "name": "last_update_time",
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleMaxAgeSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle_max_age",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleUpdateTimeLimitSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle_update_time_limit",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "average_external_equity",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PausedDepositsWithdrawals",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Redeemed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "to",
+            "type": "pubkey"
+          },
+          {
+            "name": "net_amount",
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "gross_amount",
+            "type": "u64"
+          },
+          {
+            "name": "share_price",
+            "type": "u128"
+          },
+          {
+            "name": "user_shares_before",
+            "type": "u128"
+          },
+          {
+            "name": "user_shares_after",
+            "type": "u128"
+          },
+          {
+            "name": "total_shares_before",
+            "type": "u128"
+          },
+          {
+            "name": "total_shares_after",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Refilled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "refill_value",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RefundedDeposit",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RequestedWithdrawalToDriftVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "to",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Strategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "receiver_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "allocation_bps",
+            "type": "u32"
+          },
+          {
+            "name": "allowed",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyAdded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "receiver_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "allocation_bps",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "receiver_address",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyRemoved",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "receiver_address",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserBundleAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "last_deposit_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "shares",
+            "type": "u128"
+          },
+          {
+            "name": "pending_deposit",
+            "type": "u64"
+          },
+          {
+            "name": "pending_shares",
+            "type": "u128"
+          },
+          {
+            "name": "estimated_pending_withdrawal_value",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawal_available_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "last_withdrawal_process_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "last_high_water_mark",
+            "type": "u128"
+          },
+          {
+            "name": "hwm_per_share",
+            "type": "u128"
+          },
+          {
+            "name": "last_management_fee_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "net_deposits",
+            "type": "i128"
+          },
+          {
+            "name": "total_fee_charged",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                264
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserBundleAccountClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "user_bundle_account_key",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultNeutralFeeIncrementerSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "neutral_fee_incrementer",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalRedemptionScheduleSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "withdrawal_redemption_request_cutoff_ts",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_redemption_unlock_current_cycle_ts",
+            "type": "i64"
+          },
+          {
+            "name": "withdrawal_redemption_unlock_next_cycle_ts",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalRequested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u128"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "cooldown_period",
+            "type": "i64"
+          },
+          {
+            "name": "estimated_pending_withdrawal_value",
+            "type": "u64"
+          },
+          {
+            "name": "bundle_account_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "cooldown_end_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "estimated_net_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawnFromDriftVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "to",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why this PR exists

Wallet users signing Neutral Trade program transactions currently hit the `UnknownProgram` fallback — they see a base58 program ID and a hex blob, no named instruction or decoded fields. This PR adds a dedicated preset so Neutral Trade transactions render with the decoded instruction name, named accounts, and parsed arguments.

Program address: `BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU`

## What changed

- New preset directory `src/chain_parsers/visualsign-solana/src/presets/neutral_trade/` with `config.rs`, `mod.rs`, and the bundled on-chain IDL (`neutral_trade.json`).
- `NeutralTradeVisualizer` implements `InstructionVisualizer` using the workspace's generic IDL helpers (`solana_parser::decode_idl_data` + `parse_instruction_with_idl`); positional accounts are mapped to IDL account names by matching the 8-byte Anchor discriminator.
- Condensed preview shows `Neutral Trade: <instruction_name>` plus args; expanded view adds program ID, discriminator, named accounts, parsed args, and raw data hex.
- Classified as `VisualizerKind::Lending("Neutral Trade")` — the program is a pooled bundle with deposit/withdraw/strategies/fees/oracles.
- Registered alphabetically in `presets/mod.rs`; `build.rs` auto-wires `NeutralTradeVisualizer` into `available_visualizers()` via `to_pascal_case` on the directory name.

<img width="1260" height="1299" alt="image" src="https://github.com/user-attachments/assets/4a0abd85-8b63-45de-8b0c-762387b8d034" />


## Why this is safe

Purely additive. No existing preset, public type, or signature changed. Programs other than `BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU` are unaffected.

Built on the same IDL-parsing path already used by `presets/unknown_program/mod.rs` (see `try_parse_with_idl` at `unknown_program/mod.rs:300-339`) — no new parsing primitives or global state. Short (<8 byte) or unknown-discriminator data returns `VisualSignError::DecodeError` before any field is built (`neutral_trade/mod.rs:39-49`). The bundled IDL's on-chain metadata name `"ntbundle"` is preserved verbatim so the JSON still matches the deployed program's `compute_idl_hash`.

Workspace-level clippy denials (`unwrap_used`, `expect_used`, `panic`, `unsafe_code`) all pass in the new code.

### Checks run (by agent)

- `cargo fmt -p visualsign-solana` — clean
- `make -C src lint` (clippy `-D warnings`) — green
- `cargo test -p visualsign-solana --lib neutral_trade` — 4 new tests pass (IDL loads, every instruction has an 8-byte discriminator, unknown discriminator returns error, short data returns error)
- `make -C src test` — full workspace suite green

### Manual steps needed (by human)

None — fully automated by CI.

## How this is maintainable

The preset is data-driven: behavior lives in the bundled IDL. Regenerating `neutral_trade.json` from a newer on-chain IDL updates visualization without code changes.

The scaffold follows the same pattern every other Solana preset uses (`jupiter_swap`, `stakepool`, `swig_wallet`, `unknown_program`) — directory layout and `build.rs` auto-discovery are identical. A fresh engineer can read one neighbor and fully understand this one. The workflow is codified in `.claude/skills/solana-add-idl/SKILL.md`.

Workspace lint policy from `src/CLAUDE.md` prevents future edits from introducing `unwrap`, `expect`, or `panic`. The four in-module tests pin the contract: if the IDL is ever replaced with something malformed, `test_neutral_trade_idl_has_discriminators` catches it before merge.