### PR TITLE
feat: add Meteora DAMM V2 Solana visualizer preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/config.rs
@@ -1,0 +1,22 @@
+use super::METEORA_DAMM_V2_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct MeteoraDammV2Config;
+
+impl SolanaIntegrationConfig for MeteoraDammV2Config {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(METEORA_DAMM_V2_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/meteora_damm_v2.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/meteora_damm_v2.json
@@ -1,0 +1,887 @@
+{
+  "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",
+  "metadata": {
+    "name": "cp_amm",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "add_liquidity",
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
+      "accounts": [
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "token_a_account", "writable": true},
+        {"name": "token_b_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint", "relations": ["pool"]},
+        {"name": "token_b_mint", "relations": ["pool"]},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "AddLiquidityParameters"}}}]
+    },
+    {
+      "name": "claim_position_fee",
+      "discriminator": [180, 38, 154, 17, 133, 33, 162, 211],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "token_a_account", "writable": true},
+        {"name": "token_b_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint", "relations": ["pool"]},
+        {"name": "token_b_mint", "relations": ["pool"]},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_protocol_fee",
+      "discriminator": [165, 228, 133, 48, 99, 249, 255, 33],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint", "relations": ["pool"]},
+        {"name": "token_b_mint", "relations": ["pool"]},
+        {"name": "token_a_account", "writable": true},
+        {"name": "token_b_account", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "max_amount_a", "type": "u64"},
+        {"name": "max_amount_b", "type": "u64"}
+      ]
+    },
+    {
+      "name": "claim_reward",
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "user_token_account", "writable": true},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "token_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u8"},
+        {"name": "skip_reward", "type": "u8"}
+      ]
+    },
+    {
+      "name": "close_config",
+      "discriminator": [145, 9, 72, 157, 95, 125, 61, 85],
+      "accounts": [
+        {"name": "config", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "accounts": [
+        {"name": "operator", "writable": true},
+        {"name": "signer", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position",
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "accounts": [
+        {"name": "position_nft_mint", "writable": true},
+        {"name": "position_nft_account", "writable": true},
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "owner", "signer": true},
+        {"name": "token_program", "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "close_token_badge",
+      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "accounts": [
+        {"name": "token_badge", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "create_config",
+      "discriminator": [201, 207, 243, 114, 75, 111, 47, 189],
+      "accounts": [
+        {"name": "config", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "index", "type": "u64"},
+        {"name": "config_parameters", "type": {"defined": {"name": "StaticConfigParameters"}}}
+      ]
+    },
+    {
+      "name": "create_dynamic_config",
+      "discriminator": [81, 251, 122, 78, 66, 57, 208, 82],
+      "accounts": [
+        {"name": "config", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "index", "type": "u64"},
+        {"name": "config_parameters", "type": {"defined": {"name": "DynamicConfigParameters"}}}
+      ]
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "accounts": [
+        {"name": "operator", "writable": true},
+        {"name": "whitelisted_address"},
+        {"name": "signer", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "permission", "type": "u128"}]
+    },
+    {
+      "name": "create_position",
+      "discriminator": [48, 215, 197, 153, 96, 203, 180, 133],
+      "accounts": [
+        {"name": "owner"},
+        {"name": "position_nft_mint", "writable": true, "signer": true},
+        {"name": "position_nft_account", "writable": true},
+        {"name": "pool", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "token_program", "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "create_token_badge",
+      "discriminator": [88, 206, 0, 91, 60, 175, 151, 118],
+      "accounts": [
+        {"name": "token_badge", "writable": true},
+        {"name": "token_mint"},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "dummy_ix",
+      "discriminator": [234, 95, 176, 185, 7, 42, 35, 159],
+      "accounts": [
+        {"name": "pod_aligned_fee_time_scheduler"},
+        {"name": "pod_aligned_fee_rate_limiter"},
+        {"name": "pod_aligned_fee_market_cap_scheduler"}
+      ],
+      "args": [{"name": "_ixs", "type": {"defined": {"name": "DummyParams"}}}]
+    },
+    {
+      "name": "fix_config_fee_params",
+      "discriminator": [38, 30, 216, 81, 250, 177, 243, 254],
+      "accounts": [
+        {"name": "config", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "BaseFeeParameters"}}}]
+    },
+    {
+      "name": "fix_pool_fee_params",
+      "discriminator": [132, 98, 81, 196, 44, 58, 120, 193],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "BaseFeeParameters"}}}]
+    },
+    {
+      "name": "fix_pool_layout_version",
+      "discriminator": [166, 158, 69, 35, 81, 167, 200, 215],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true}
+      ],
+      "args": []
+    },
+    {
+      "name": "fund_reward",
+      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "funder_token_account", "writable": true},
+        {"name": "funder", "signer": true},
+        {"name": "token_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u8"},
+        {"name": "amount", "type": "u64"},
+        {"name": "carry_forward", "type": "bool"}
+      ]
+    },
+    {
+      "name": "initialize_customizable_pool",
+      "discriminator": [20, 161, 241, 24, 189, 221, 180, 2],
+      "accounts": [
+        {"name": "creator"},
+        {"name": "position_nft_mint", "writable": true, "signer": true},
+        {"name": "position_nft_account", "writable": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "token_a_mint"},
+        {"name": "token_b_mint"},
+        {"name": "token_a_vault", "writable": true},
+        {"name": "token_b_vault", "writable": true},
+        {"name": "payer_token_a", "writable": true},
+        {"name": "payer_token_b", "writable": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "token_2022_program", "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "InitializeCustomizablePoolParameters"}}}]
+    },
+    {
+      "name": "initialize_pool",
+      "discriminator": [95, 180, 10, 172, 84, 174, 232, 40],
+      "accounts": [
+        {"name": "creator"},
+        {"name": "position_nft_mint", "writable": true, "signer": true},
+        {"name": "position_nft_account", "writable": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "config"},
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "token_a_mint"},
+        {"name": "token_b_mint"},
+        {"name": "token_a_vault", "writable": true},
+        {"name": "token_b_vault", "writable": true},
+        {"name": "payer_token_a", "writable": true},
+        {"name": "payer_token_b", "writable": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "token_2022_program", "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "InitializePoolParameters"}}}]
+    },
+    {
+      "name": "initialize_pool_with_dynamic_config",
+      "discriminator": [149, 82, 72, 197, 253, 252, 68, 15],
+      "accounts": [
+        {"name": "creator"},
+        {"name": "position_nft_mint", "writable": true, "signer": true},
+        {"name": "position_nft_account", "writable": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "pool_creator_authority", "signer": true, "relations": ["config"]},
+        {"name": "config"},
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "token_a_mint"},
+        {"name": "token_b_mint"},
+        {"name": "token_a_vault", "writable": true},
+        {"name": "token_b_vault", "writable": true},
+        {"name": "payer_token_a", "writable": true},
+        {"name": "payer_token_b", "writable": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "token_2022_program", "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "InitializeCustomizablePoolParameters"}}}]
+    },
+    {
+      "name": "initialize_reward",
+      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "signer", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "token_program"},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u8"},
+        {"name": "reward_duration", "type": "u64"},
+        {"name": "funder", "type": "pubkey"}
+      ]
+    },
+    {
+      "name": "lock_inner_position",
+      "discriminator": [72, 19, 49, 204, 18, 122, 23, 90],
+      "accounts": [
+        {"name": "pool", "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "VestingParameters"}}}]
+    },
+    {
+      "name": "lock_position",
+      "discriminator": [227, 62, 2, 252, 247, 10, 171, 185],
+      "accounts": [
+        {"name": "pool", "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "vesting", "writable": true, "signer": true},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "VestingParameters"}}}]
+    },
+    {
+      "name": "permanent_lock_position",
+      "discriminator": [165, 176, 125, 6, 231, 171, 186, 213],
+      "accounts": [
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "permanent_lock_liquidity", "type": "u128"}]
+    },
+    {
+      "name": "refresh_vesting",
+      "discriminator": [9, 94, 216, 14, 116, 204, 247, 0],
+      "accounts": [
+        {"name": "pool", "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "position_nft_account"},
+        {"name": "owner"}
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_all_liquidity",
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "token_a_account", "writable": true},
+        {"name": "token_b_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint", "relations": ["pool"]},
+        {"name": "token_b_mint", "relations": ["pool"]},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "token_a_amount_threshold", "type": "u64"},
+        {"name": "token_b_amount_threshold", "type": "u64"}
+      ]
+    },
+    {
+      "name": "remove_liquidity",
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true, "relations": ["position"]},
+        {"name": "position", "writable": true},
+        {"name": "token_a_account", "writable": true},
+        {"name": "token_b_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint", "relations": ["pool"]},
+        {"name": "token_b_mint", "relations": ["pool"]},
+        {"name": "position_nft_account"},
+        {"name": "owner", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "RemoveLiquidityParameters"}}}]
+    },
+    {
+      "name": "set_pool_status",
+      "discriminator": [112, 87, 135, 223, 83, 204, 132, 53],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "status", "type": "u8"}]
+    },
+    {
+      "name": "split_position",
+      "discriminator": [172, 241, 221, 138, 161, 29, 253, 42],
+      "accounts": [
+        {"name": "pool", "writable": true, "relations": ["first_position", "second_position"]},
+        {"name": "first_position", "writable": true},
+        {"name": "first_position_nft_account"},
+        {"name": "second_position", "writable": true},
+        {"name": "second_position_nft_account"},
+        {"name": "first_owner", "signer": true},
+        {"name": "second_owner", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "SplitPositionParameters"}}}]
+    },
+    {
+      "name": "split_position2",
+      "discriminator": [221, 147, 228, 207, 140, 212, 17, 119],
+      "accounts": [
+        {"name": "pool", "writable": true, "relations": ["first_position", "second_position"]},
+        {"name": "first_position", "writable": true},
+        {"name": "first_position_nft_account"},
+        {"name": "second_position", "writable": true},
+        {"name": "second_position_nft_account"},
+        {"name": "first_owner", "signer": true},
+        {"name": "second_owner", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "numerator", "type": "u32"}]
+    },
+    {
+      "name": "swap",
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "input_token_account", "writable": true},
+        {"name": "output_token_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint"},
+        {"name": "token_b_mint"},
+        {"name": "payer", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "referral_token_account", "writable": true, "optional": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "_params", "type": {"defined": {"name": "SwapParameters"}}}]
+    },
+    {
+      "name": "swap2",
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "input_token_account", "writable": true},
+        {"name": "output_token_account", "writable": true},
+        {"name": "token_a_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_b_vault", "writable": true, "relations": ["pool"]},
+        {"name": "token_a_mint"},
+        {"name": "token_b_mint"},
+        {"name": "payer", "signer": true},
+        {"name": "token_a_program"},
+        {"name": "token_b_program"},
+        {"name": "referral_token_account", "writable": true, "optional": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "_params", "type": {"defined": {"name": "SwapParameters2"}}}]
+    },
+    {
+      "name": "update_pool_fees",
+      "discriminator": [118, 217, 203, 179, 60, 8, 70, 89],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "params", "type": {"defined": {"name": "UpdatePoolFeesParameters"}}}]
+    },
+    {
+      "name": "update_reward_duration",
+      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "signer", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u8"},
+        {"name": "new_duration", "type": "u64"}
+      ]
+    },
+    {
+      "name": "update_reward_funder",
+      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "accounts": [
+        {"name": "pool", "writable": true},
+        {"name": "signer", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u8"},
+        {"name": "new_funder", "type": "pubkey"}
+      ]
+    },
+    {
+      "name": "withdraw_ineligible_reward",
+      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "funder_token_account", "writable": true},
+        {"name": "funder", "signer": true},
+        {"name": "token_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "reward_index", "type": "u8"}]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [213, 155, 187, 34, 56, 182, 91, 240],
+      "accounts": [
+        {"name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"},
+        {"name": "pool", "writable": true},
+        {"name": "token_vault", "writable": true},
+        {"name": "token_mint"},
+        {"name": "receiver_token", "writable": true},
+        {"name": "operator"},
+        {"name": "signer", "signer": true},
+        {"name": "token_program"},
+        {"name": "sysvar_instructions", "address": "Sysvar1nstructions1111111111111111111111111"}
+      ],
+      "args": [{"name": "max_amount", "type": "u64"}]
+    }
+  ],
+  "accounts": [
+    {"name": "Config", "discriminator": [155, 12, 170, 224, 30, 250, 204, 130]},
+    {"name": "Operator", "discriminator": [219, 31, 188, 145, 69, 139, 204, 117]},
+    {"name": "PodAlignedFeeMarketCapScheduler", "discriminator": [251, 130, 208, 253, 245, 27, 145, 203]},
+    {"name": "PodAlignedFeeRateLimiter", "discriminator": [160, 219, 8, 251, 179, 7, 16, 117]},
+    {"name": "PodAlignedFeeTimeScheduler", "discriminator": [239, 132, 138, 213, 67, 154, 130, 70]},
+    {"name": "Pool", "discriminator": [241, 154, 109, 4, 17, 177, 109, 188]},
+    {"name": "Position", "discriminator": [170, 188, 143, 228, 122, 64, 247, 208]},
+    {"name": "TokenBadge", "discriminator": [116, 219, 204, 229, 249, 116, 255, 150]},
+    {"name": "Vesting", "discriminator": [100, 149, 66, 138, 95, 200, 128, 241]}
+  ],
+  "events": [],
+  "errors": [],
+  "types": [
+    {
+      "name": "AddLiquidityParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "liquidity_delta", "type": "u128"},
+          {"name": "token_a_amount_threshold", "type": "u64"},
+          {"name": "token_b_amount_threshold", "type": "u64"}
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [{"name": "data", "type": {"array": ["u8", 27]}}]
+      }
+    },
+    {
+      "name": "DynamicConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [{"name": "pool_creator_authority", "type": "pubkey"}]
+      }
+    },
+    {
+      "name": "DynamicFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bin_step", "type": "u16"},
+          {"name": "bin_step_u128", "type": "u128"},
+          {"name": "filter_period", "type": "u16"},
+          {"name": "decay_period", "type": "u16"},
+          {"name": "reduction_factor", "type": "u16"},
+          {"name": "max_volatility_accumulator", "type": "u32"},
+          {"name": "variable_fee_control", "type": "u32"}
+        ]
+      }
+    },
+    {
+      "name": "BorshFeeMarketCapScheduler",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "cliff_fee_numerator", "type": "u64"},
+          {"name": "number_of_period", "type": "u16"},
+          {"name": "sqrt_price_step_bps", "type": "u32"},
+          {"name": "scheduler_expiration_duration", "type": "u32"},
+          {"name": "reduction_factor", "type": "u64"},
+          {"name": "base_fee_mode", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "BorshFeeRateLimiter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "cliff_fee_numerator", "type": "u64"},
+          {"name": "fee_increment_bps", "type": "u16"},
+          {"name": "max_limiter_duration", "type": "u32"},
+          {"name": "max_fee_bps", "type": "u32"},
+          {"name": "reference_amount", "type": "u64"},
+          {"name": "base_fee_mode", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "BorshFeeTimeScheduler",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "cliff_fee_numerator", "type": "u64"},
+          {"name": "number_of_period", "type": "u16"},
+          {"name": "period_frequency", "type": "u64"},
+          {"name": "reduction_factor", "type": "u64"},
+          {"name": "base_fee_mode", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "DummyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "borsh_fee_time_scheduler_params", "type": {"defined": {"name": "BorshFeeTimeScheduler"}}},
+          {"name": "borsh_fee_rate_limiter_params", "type": {"defined": {"name": "BorshFeeRateLimiter"}}},
+          {"name": "borsh_fee_market_cap_scheduler_params", "type": {"defined": {"name": "BorshFeeMarketCapScheduler"}}}
+        ]
+      }
+    },
+    {
+      "name": "InitializeCustomizablePoolParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "pool_fees", "type": {"defined": {"name": "PoolFeeParameters"}}},
+          {"name": "sqrt_min_price", "type": "u128"},
+          {"name": "sqrt_max_price", "type": "u128"},
+          {"name": "has_alpha_vault", "type": "bool"},
+          {"name": "liquidity", "type": "u128"},
+          {"name": "sqrt_price", "type": "u128"},
+          {"name": "activation_type", "type": "u8"},
+          {"name": "collect_fee_mode", "type": "u8"},
+          {"name": "activation_point", "type": {"option": "u64"}}
+        ]
+      }
+    },
+    {
+      "name": "InitializePoolParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "liquidity", "type": "u128"},
+          {"name": "sqrt_price", "type": "u128"},
+          {"name": "activation_point", "type": {"option": "u64"}}
+        ]
+      }
+    },
+    {
+      "name": "PoolFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "base_fee", "type": {"defined": {"name": "BaseFeeParameters"}}},
+          {"name": "compounding_fee_bps", "type": "u16"},
+          {"name": "padding", "type": "u8"},
+          {"name": "dynamic_fee", "type": {"option": {"defined": {"name": "DynamicFeeParameters"}}}}
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidityParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "liquidity_delta", "type": "u128"},
+          {"name": "token_a_amount_threshold", "type": "u64"},
+          {"name": "token_b_amount_threshold", "type": "u64"}
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "unlocked_liquidity_percentage", "type": "u8"},
+          {"name": "permanent_locked_liquidity_percentage", "type": "u8"},
+          {"name": "fee_a_percentage", "type": "u8"},
+          {"name": "fee_b_percentage", "type": "u8"},
+          {"name": "reward_0_percentage", "type": "u8"},
+          {"name": "reward_1_percentage", "type": "u8"},
+          {"name": "inner_vesting_liquidity_percentage", "type": "u8"},
+          {"name": "padding", "type": {"array": ["u8", 15]}}
+        ]
+      }
+    },
+    {
+      "name": "StaticConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "pool_fees", "type": {"defined": {"name": "PoolFeeParameters"}}},
+          {"name": "sqrt_min_price", "type": "u128"},
+          {"name": "sqrt_max_price", "type": "u128"},
+          {"name": "vault_config_key", "type": "pubkey"},
+          {"name": "pool_creator_authority", "type": "pubkey"},
+          {"name": "activation_type", "type": "u8"},
+          {"name": "collect_fee_mode", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount_in", "type": "u64"},
+          {"name": "minimum_amount_out", "type": "u64"}
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount_0", "type": "u64"},
+          {"name": "amount_1", "type": "u64"},
+          {"name": "swap_mode", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "UpdatePoolFeesParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "cliff_fee_numerator", "type": {"option": "u64"}},
+          {"name": "dynamic_fee", "type": {"option": {"defined": {"name": "DynamicFeeParameters"}}}}
+        ]
+      }
+    },
+    {
+      "name": "VestingParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "cliff_point", "type": {"option": "u64"}},
+          {"name": "period_frequency", "type": "u64"},
+          {"name": "cliff_unlock_liquidity", "type": "u128"},
+          {"name": "liquidity_per_period", "type": "u128"},
+          {"name": "number_of_period", "type": "u16"}
+        ]
+      }
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/mod.rs
@@ -1,0 +1,194 @@
+//! Meteora DAMM V2 preset implementation for Solana
+//!
+//! IDL-based visualizer for Meteora's DAMM V2 (constant-product AMM) program.
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::MeteoraDammV2Config;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::BTreeMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const METEORA_DAMM_V2_PROGRAM_ID: &str = "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
+
+const DISPLAY_NAME: &str = "Meteora DAMM V2";
+
+static METEORA_DAMM_V2_CONFIG: MeteoraDammV2Config = MeteoraDammV2Config;
+
+pub struct MeteoraDammV2Visualizer;
+
+impl InstructionVisualizer for MeteoraDammV2Visualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let data = &instruction.data;
+        let program_id = instruction.program_id.to_string();
+        let instruction_data_hex = hex::encode(data);
+
+        let (parsed, named_accounts) =
+            parse_meteora_damm_v2_instruction(data, &instruction.accounts)
+                .map_err(|e| VisualSignError::DecodeError(e.to_string()))?;
+
+        let instruction_title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);
+
+        let mut condensed_fields = vec![create_text_field("Instruction", &instruction_title)?];
+        for (key, value) in &parsed.program_call_args {
+            condensed_fields.push(create_text_field(key, &format_arg_value(value))?);
+        }
+
+        let mut expanded_fields = vec![
+            create_text_field("Program ID", &program_id)?,
+            create_text_field("Instruction", &parsed.instruction_name)?,
+            create_text_field("Discriminator", &parsed.discriminator)?,
+        ];
+        // Iterate the local BTreeMap so the rendered field order is deterministic.
+        // (`parsed.named_accounts` from solana_parser is `HashMap`, so iteration there
+        // is non-deterministic.)
+        for (account_name, account_address) in &named_accounts {
+            expanded_fields.push(create_text_field(account_name, account_address)?);
+        }
+        for (key, value) in &parsed.program_call_args {
+            expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+        }
+        expanded_fields.push(create_raw_data_field(
+            data,
+            Some(instruction_data_hex.clone()),
+        )?);
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 {
+                text: instruction_title.clone(),
+            }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(SignablePayloadFieldListLayout {
+                fields: condensed_fields,
+            }),
+            expanded: Some(SignablePayloadFieldListLayout {
+                fields: expanded_fields,
+            }),
+        };
+
+        let fallback_text = format!("Program ID: {program_id}\nData: {instruction_data_hex}");
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&METEORA_DAMM_V2_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(DISPLAY_NAME)
+    }
+}
+
+fn load_idl() -> Result<Idl, Box<dyn std::error::Error>> {
+    let json = include_str!("meteora_damm_v2.json");
+    decode_idl_data(json)
+}
+
+fn parse_meteora_damm_v2_instruction(
+    data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> Result<(SolanaParsedInstructionData, BTreeMap<String, String>), Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Instruction data too short for Anchor discriminator".into());
+    }
+
+    let idl = load_idl()?;
+    let parsed = parse_instruction_with_idl(data, METEORA_DAMM_V2_PROGRAM_ID, &idl)?;
+
+    let mut named_accounts = BTreeMap::new();
+    if let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.len() >= 8 && &data[0..8] == disc.as_slice())
+    }) {
+        for (index, account_meta) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+            }
+        }
+    }
+    Ok((parsed, named_accounts))
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meteora_damm_v2_idl_loads() {
+        let idl = load_idl().expect("IDL should load");
+        assert!(!idl.instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_meteora_damm_v2_idl_has_discriminators() {
+        let idl = load_idl().expect("IDL should load");
+        for inst in &idl.instructions {
+            let disc = inst
+                .discriminator
+                .as_ref()
+                .unwrap_or_else(|| panic!("Instruction {} missing discriminator", inst.name));
+            assert_eq!(
+                disc.len(),
+                8,
+                "Instruction {} discriminator must be 8 bytes",
+                inst.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage = [0xAA_u8; 9];
+        let result = parse_meteora_damm_v2_instruction(&garbage, &[]);
+        assert!(
+            result.is_err(),
+            "Unknown discriminator should return an error"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short = [0x01_u8, 0x02, 0x03];
+        let result = parse_meteora_damm_v2_instruction(&short, &[]);
+        assert!(result.is_err(), "Data shorter than 8 bytes must error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -7,6 +7,7 @@ pub mod jupiter_swap;
 pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
+pub mod meteora_damm_v2;
 pub mod neutral_trade;
 pub mod onre_app;
 pub mod stakepool;


### PR DESCRIPTION
## Why this PR exists

Solana transactions that touch Meteora's DAMM V2 program (`cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`) currently fall through to the generic unknown-program visualizer. Signers see raw program ID + hex instead of an IDL-decoded instruction name, decoded args, and named accounts.

## What changed

- New preset `chain_parsers/visualsign-solana/src/presets/meteora_damm_v2/` with:
  - `meteora_damm_v2.json` — the program's Anchor IDL, embedded via `include_str!`
  - `config.rs` — `MeteoraDammV2Config` registering the program ID with a `*,*` instruction match (all instructions handled)
  - `mod.rs` — `MeteoraDammV2Visualizer` that parses via `solana_parser::parse_instruction_with_idl`, maps each on-chain account meta to its IDL account name, and renders a preview layout with `DISPLAY_NAME = "Meteora DAMM V2"` (kind `Dex`)
- Registered `pub mod meteora_damm_v2;` in `presets/mod.rs` (alphabetical). The crate's `build.rs` already auto-discovers `{Pascal}Visualizer` from any directory under `src/presets/`, so no manual registration is needed.

<img width="732" height="2349" alt="image" src="https://github.com/user-attachments/assets/99403a14-f330-471e-bb51-6042c593400b" />


## Why this is safe

- **Additive only.** No existing preset, trait, or public type is modified. Visualizer dispatch iterates in order and falls through, so if the new preset errors the unknown-program visualizer still runs.
- **IDL-driven, no hand-rolled decoders.** All instruction parsing goes through the upstream `solana_parser` crate using the embedded IDL. There is no chain-specific math or custom decode logic that could misrepresent amounts.
- **Parse failures are surfaced as errors, not panics.** `parse_meteora_damm_v2_instruction` returns `Err` for data shorter than 8 bytes and for unknown discriminators, covered by tests. Clippy-denied `.unwrap()`/`.expect()`/`panic!()` are absent from non-test code.
- **Risk: IDL drift.** If Meteora upgrades the program and changes instructions, the embedded IDL will get stale and new instructions will fall back to the unknown-program visualizer — degraded UX, not incorrect decoding.

### Checks run (by agent)
- `cargo fmt -p visualsign-solana`
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean
- `cargo test -p visualsign-solana --lib meteora_damm_v2` — 4/4 pass
- `make -C src test` — full workspace green
- `rg 'meteora_cp_amm|MeteoraCpAmm|METEORA_CP_AMM|Meteora CP-AMM' src/` — no stale references from the earlier scaffold/rename

### Manual steps needed (by human)
None — fully automated by CI.

## How this is maintainable

- **Pattern is established in-tree.** The preset follows the same IDL-based shape as `jupiter_swap` and `unknown_program`; a reader familiar with either can understand this one without extra context.
- **Auto-discovery removes registration drift.** `build.rs` generates the visualizer list at compile time from directory names — no central registry to forget to update.
- **Tests guard the essentials.** IDL loads, every instruction has an 8-byte discriminator, short data errors, and unknown discriminator errors. A breaking IDL edit trips the discriminator test immediately.
- **Adding the next Solana program** is just another sibling directory plus one line in `presets/mod.rs`; see `CLAUDE.md` "Architecture → Workspace Layout" and the `/solana-add-idl` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)