### PR TITLE
feat: add Meteora DLMM Solana preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/config.rs
@@ -1,0 +1,22 @@
+use super::METEORA_DLMM_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct MeteoraDlmmConfig;
+
+impl SolanaIntegrationConfig for MeteoraDlmmConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(METEORA_DLMM_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/meteora_dlmm.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/meteora_dlmm.json
@@ -1,0 +1,856 @@
+{
+  "address": "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
+  "metadata": {
+    "name": "lb_clmm",
+    "version": "0.11.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "add_liquidity",
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameter"}}}]
+    },
+    {
+      "name": "add_liquidity2",
+      "discriminator": [228, 162, 78, 28, 70, 219, 116, 115],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameter"}}},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy",
+      "discriminator": [7, 3, 150, 127, 148, 40, 61, 200],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameterByStrategy"}}}]
+    },
+    {
+      "name": "add_liquidity_by_strategy2",
+      "discriminator": [3, 221, 149, 218, 111, 141, 118, 213],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameterByStrategy"}}},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy_one_side",
+      "discriminator": [41, 5, 238, 175, 100, 225, 6, 205],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token", "writable": true},
+        {"name": "reserve", "writable": true},
+        {"name": "token_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameterByStrategyOneSide"}}}]
+    },
+    {
+      "name": "add_liquidity_by_weight",
+      "discriminator": [28, 140, 238, 99, 231, 162, 21, 149],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityParameterByWeight"}}}]
+    },
+    {
+      "name": "add_liquidity_one_side",
+      "discriminator": [94, 155, 103, 151, 70, 95, 220, 165],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token", "writable": true},
+        {"name": "reserve", "writable": true},
+        {"name": "token_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "liquidity_parameter", "type": {"defined": {"name": "LiquidityOneSideParameter"}}}]
+    },
+    {
+      "name": "add_liquidity_one_side_precise",
+      "discriminator": [161, 194, 103, 84, 171, 71, 250, 154],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token", "writable": true},
+        {"name": "reserve", "writable": true},
+        {"name": "token_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "parameter", "type": {"defined": {"name": "AddLiquiditySingleSidePreciseParameter"}}}]
+    },
+    {
+      "name": "add_liquidity_one_side_precise2",
+      "discriminator": [33, 51, 163, 201, 117, 98, 125, 231],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token", "writable": true},
+        {"name": "reserve", "writable": true},
+        {"name": "token_mint"},
+        {"name": "sender", "signer": true},
+        {"name": "token_program"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "liquidity_parameter", "type": {"defined": {"name": "AddLiquiditySingleSidePreciseParameter2"}}},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "claim_fee",
+      "discriminator": [169, 32, 79, 137, 136, 232, 70, 137],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_fee2",
+      "discriminator": [112, 191, 101, 171, 28, 144, 127, 187],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "token_program_x"},
+        {"name": "token_program_y"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "min_bin_id", "type": "i32"},
+        {"name": "max_bin_id", "type": "i32"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "claim_reward",
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "user_token_account", "writable": true},
+        {"name": "token_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "reward_index", "type": "u64"}]
+    },
+    {
+      "name": "claim_reward2",
+      "discriminator": [190, 3, 127, 119, 178, 87, 157, 183],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "position", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "reward_vault", "writable": true},
+        {"name": "reward_mint"},
+        {"name": "user_token_account", "writable": true},
+        {"name": "token_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "reward_index", "type": "u64"},
+        {"name": "min_bin_id", "type": "i32"},
+        {"name": "max_bin_id", "type": "i32"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "close_position",
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position2",
+      "discriminator": [174, 90, 35, 115, 186, 40, 147, 226],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position_if_empty",
+      "discriminator": [59, 124, 212, 118, 91, 152, 110, 157],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "rent_receiver", "writable": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_position",
+      "discriminator": [219, 192, 234, 71, 190, 191, 102, 80],
+      "accounts": [
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "position", "writable": true, "signer": true},
+        {"name": "lb_pair"},
+        {"name": "owner", "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "rent"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "lower_bin_id", "type": "i32"},
+        {"name": "width", "type": "i32"}
+      ]
+    },
+    {
+      "name": "initialize_position2",
+      "discriminator": [143, 19, 242, 145, 213, 15, 104, 115],
+      "accounts": [
+        {"name": "payer", "writable": true, "signer": true},
+        {"name": "position", "writable": true, "signer": true},
+        {"name": "lb_pair"},
+        {"name": "owner", "signer": true},
+        {"name": "system_program", "address": "11111111111111111111111111111111"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "lower_bin_id", "type": "i32"},
+        {"name": "width", "type": "i32"}
+      ]
+    },
+    {
+      "name": "remove_all_liquidity",
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_liquidity",
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "bin_liquidity_removal", "type": {"vec": {"defined": {"name": "BinLiquidityReduction"}}}}]
+    },
+    {
+      "name": "remove_liquidity2",
+      "discriminator": [230, 215, 82, 127, 241, 101, 227, 146],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "bin_liquidity_removal", "type": {"vec": {"defined": {"name": "BinLiquidityReduction"}}}},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range",
+      "discriminator": [26, 82, 102, 152, 240, 74, 105, 26],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "from_bin_id", "type": "i32"},
+        {"name": "to_bin_id", "type": "i32"},
+        {"name": "bps_to_remove", "type": "u16"}
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range2",
+      "discriminator": [204, 2, 195, 145, 53, 145, 145, 205],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "writable": true, "optional": true},
+        {"name": "user_token_x", "writable": true},
+        {"name": "user_token_y", "writable": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "sender", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "from_bin_id", "type": "i32"},
+        {"name": "to_bin_id", "type": "i32"},
+        {"name": "bps_to_remove", "type": "u16"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "swap",
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "amount_in", "type": "u64"},
+        {"name": "min_amount_out", "type": "u64"}
+      ]
+    },
+    {
+      "name": "swap2",
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "amount_in", "type": "u64"},
+        {"name": "min_amount_out", "type": "u64"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "swap_exact_out",
+      "discriminator": [250, 73, 101, 33, 38, 207, 75, 184],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "max_in_amount", "type": "u64"},
+        {"name": "out_amount", "type": "u64"}
+      ]
+    },
+    {
+      "name": "swap_exact_out2",
+      "discriminator": [43, 215, 247, 132, 137, 60, 243, 81],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "max_in_amount", "type": "u64"},
+        {"name": "out_amount", "type": "u64"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "swap_with_price_impact",
+      "discriminator": [56, 173, 230, 208, 173, 228, 156, 205],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "token_y_program", "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "amount_in", "type": "u64"},
+        {"name": "active_id", "type": {"option": "i32"}},
+        {"name": "max_price_impact_bps", "type": "u16"}
+      ]
+    },
+    {
+      "name": "swap_with_price_impact2",
+      "discriminator": [74, 98, 192, 214, 177, 51, 75, 51],
+      "accounts": [
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_bitmap_extension", "optional": true},
+        {"name": "reserve_x", "writable": true},
+        {"name": "reserve_y", "writable": true},
+        {"name": "user_token_in", "writable": true},
+        {"name": "user_token_out", "writable": true},
+        {"name": "token_x_mint"},
+        {"name": "token_y_mint"},
+        {"name": "oracle", "writable": true},
+        {"name": "host_fee_in", "writable": true, "optional": true},
+        {"name": "user", "signer": true},
+        {"name": "token_x_program"},
+        {"name": "token_y_program"},
+        {"name": "memo_program", "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [
+        {"name": "amount_in", "type": "u64"},
+        {"name": "active_id", "type": {"option": "i32"}},
+        {"name": "max_price_impact_bps", "type": "u16"},
+        {"name": "remaining_accounts_info", "type": {"defined": {"name": "RemainingAccountsInfo"}}}
+      ]
+    },
+    {
+      "name": "update_fees_and_rewards",
+      "discriminator": [154, 230, 250, 13, 236, 209, 75, 223],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "lb_pair", "writable": true},
+        {"name": "bin_array_lower", "writable": true},
+        {"name": "bin_array_upper", "writable": true},
+        {"name": "owner", "signer": true}
+      ],
+      "args": []
+    },
+    {
+      "name": "update_position_operator",
+      "discriminator": [202, 184, 103, 143, 180, 191, 116, 217],
+      "accounts": [
+        {"name": "position", "writable": true},
+        {"name": "owner", "signer": true},
+        {"name": "event_authority"},
+        {"name": "program"}
+      ],
+      "args": [{"name": "operator", "type": "pubkey"}]
+    }
+  ],
+  "types": [
+    {
+      "name": "BinLiquidityDistribution",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bin_id", "type": "i32"},
+          {"name": "distribution_x", "type": "u16"},
+          {"name": "distribution_y", "type": "u16"}
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityReduction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bin_id", "type": "i32"},
+          {"name": "bps_to_remove", "type": "u16"}
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistributionByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bin_id", "type": "i32"},
+          {"name": "weight", "type": "u16"}
+        ]
+      }
+    },
+    {
+      "name": "CompressedBinDepositAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bin_id", "type": "i32"},
+          {"name": "amount", "type": "u32"}
+        ]
+      }
+    },
+    {
+      "name": "StrategyType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {"name": "SpotOneSide"},
+          {"name": "CurveOneSide"},
+          {"name": "BidAskOneSide"},
+          {"name": "SpotBalanced"},
+          {"name": "CurveBalanced"},
+          {"name": "BidAskBalanced"},
+          {"name": "SpotImBalanced"},
+          {"name": "CurveImBalanced"},
+          {"name": "BidAskImBalanced"}
+        ]
+      }
+    },
+    {
+      "name": "StrategyParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "min_bin_id", "type": "i32"},
+          {"name": "max_bin_id", "type": "i32"},
+          {"name": "strategy_type", "type": {"defined": {"name": "StrategyType"}}},
+          {"name": "parameteres", "type": {"array": ["u8", 64]}}
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount_x", "type": "u64"},
+          {"name": "amount_y", "type": "u64"},
+          {"name": "bin_liquidity_dist", "type": {"vec": {"defined": {"name": "BinLiquidityDistribution"}}}}
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount_x", "type": "u64"},
+          {"name": "amount_y", "type": "u64"},
+          {"name": "active_id", "type": "i32"},
+          {"name": "max_active_bin_slippage", "type": "i32"},
+          {"name": "strategy_parameters", "type": {"defined": {"name": "StrategyParameters"}}}
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategyOneSide",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount", "type": "u64"},
+          {"name": "active_id", "type": "i32"},
+          {"name": "max_active_bin_slippage", "type": "i32"},
+          {"name": "strategy_parameters", "type": {"defined": {"name": "StrategyParameters"}}}
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount_x", "type": "u64"},
+          {"name": "amount_y", "type": "u64"},
+          {"name": "active_id", "type": "i32"},
+          {"name": "max_active_bin_slippage", "type": "i32"},
+          {"name": "bin_liquidity_dist", "type": {"vec": {"defined": {"name": "BinLiquidityDistributionByWeight"}}}}
+        ]
+      }
+    },
+    {
+      "name": "LiquidityOneSideParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "amount", "type": "u64"},
+          {"name": "active_id", "type": "i32"},
+          {"name": "max_active_bin_slippage", "type": "i32"},
+          {"name": "bin_liquidity_dist", "type": {"vec": {"defined": {"name": "BinLiquidityDistributionByWeight"}}}}
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bins", "type": {"vec": {"defined": {"name": "CompressedBinDepositAmount"}}}},
+          {"name": "decompress_multiplier", "type": "u64"}
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "bins", "type": {"vec": {"defined": {"name": "CompressedBinDepositAmount"}}}},
+          {"name": "decompress_multiplier", "type": "u64"},
+          {"name": "max_amount", "type": "u64"}
+        ]
+      }
+    },
+    {
+      "name": "AccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {"name": "TransferHookX"},
+          {"name": "TransferHookY"},
+          {"name": "TransferHookReward"},
+          {"name": "TransferHookMultiReward", "fields": ["u8"]}
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "accounts_type", "type": {"defined": {"name": "AccountsType"}}},
+          {"name": "length", "type": "u8"}
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "slices", "type": {"vec": {"defined": {"name": "RemainingAccountsSlice"}}}}
+        ]
+      }
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/meteora_dlmm/mod.rs
@@ -1,0 +1,330 @@
+//! Meteora DLMM preset implementation for Solana
+//!
+//! Generic IDL-driven visualizer for the Meteora DLMM (lb_clmm) program.
+//! Uses the bundled IDL to decode instructions and render their arguments
+//! and named accounts into a VisualSign preview layout.
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::MeteoraDlmmConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const METEORA_DLMM_PROGRAM_ID: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
+const METEORA_DLMM_DISPLAY_NAME: &str = "Meteora DLMM";
+const METEORA_DLMM_IDL_JSON: &str = include_str!("meteora_dlmm.json");
+
+static METEORA_DLMM_CONFIG: MeteoraDlmmConfig = MeteoraDlmmConfig;
+
+pub struct MeteoraDlmmVisualizer;
+
+#[derive(Debug, Clone)]
+struct MeteoraDlmmParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: Vec<(String, String)>,
+}
+
+impl InstructionVisualizer for MeteoraDlmmVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let data = &instruction.data;
+        if data.len() < 8 {
+            return Err(VisualSignError::DecodeError(
+                "Instruction data shorter than 8-byte discriminator".into(),
+            ));
+        }
+
+        let idl = get_meteora_dlmm_idl()
+            .ok_or_else(|| VisualSignError::DecodeError("Meteora DLMM IDL not available".into()))?;
+
+        let parsed = parse_instruction_with_idl(data, METEORA_DLMM_PROGRAM_ID, idl)
+            .map_err(|e| VisualSignError::DecodeError(e.to_string()))?;
+
+        let named_accounts = build_named_accounts(idl, instruction);
+
+        let parsed_instruction = MeteoraDlmmParsedInstruction {
+            parsed,
+            named_accounts,
+        };
+
+        let instruction_text = format!(
+            "{METEORA_DLMM_DISPLAY_NAME}: {}",
+            parsed_instruction.parsed.instruction_name
+        );
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: build_condensed_fields(&instruction_text, &parsed_instruction)?,
+        };
+
+        let expanded = SignablePayloadFieldListLayout {
+            fields: build_expanded_fields(
+                &parsed_instruction,
+                &instruction.program_id.to_string(),
+                data,
+            )?,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 {
+                text: instruction_text.clone(),
+            }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        let fallback_text = format!(
+            "Program ID: {}\nData: {}",
+            instruction.program_id,
+            hex::encode(data)
+        );
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&METEORA_DLMM_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(METEORA_DLMM_DISPLAY_NAME)
+    }
+}
+
+fn get_meteora_dlmm_idl() -> Option<&'static Idl> {
+    static IDL: std::sync::OnceLock<Option<Idl>> = std::sync::OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(METEORA_DLMM_IDL_JSON).ok())
+        .as_ref()
+}
+
+fn build_named_accounts(
+    idl: &Idl,
+    instruction: &solana_sdk::instruction::Instruction,
+) -> Vec<(String, String)> {
+    let data = &instruction.data;
+    if data.len() < 8 {
+        return Vec::new();
+    }
+
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| &data[0..8] == disc.as_slice())
+    }) else {
+        return Vec::new();
+    };
+
+    instruction
+        .accounts
+        .iter()
+        .zip(idl_instruction.accounts.iter())
+        .map(|(meta, idl_account)| (idl_account.name.clone(), meta.pubkey.to_string()))
+        .collect()
+}
+
+fn build_condensed_fields(
+    instruction_text: &str,
+    parsed: &MeteoraDlmmParsedInstruction,
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Instruction", instruction_text)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    ];
+
+    for (key, value) in &parsed.parsed.program_call_args {
+        fields.push(
+            create_text_field(key, &format_arg_value(value))
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+    }
+
+    Ok(fields)
+}
+
+fn build_expanded_fields(
+    parsed: &MeteoraDlmmParsedInstruction,
+    program_id: &str,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Program ID", program_id)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        create_text_field("Instruction", &parsed.parsed.instruction_name)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        create_text_field("Discriminator", &parsed.parsed.discriminator)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    ];
+
+    for (name, address) in &parsed.named_accounts {
+        fields.push(
+            create_text_field(name, address)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+    }
+
+    for (key, value) in &parsed.parsed.program_call_args {
+        fields.push(
+            create_text_field(key, &format_arg_value(value))
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+    }
+
+    fields.push(
+        create_raw_data_field(data, Some(hex::encode(data)))
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    );
+
+    Ok(fields)
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_meteora_dlmm_idl_loads() {
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL must contain at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_meteora_dlmm_idl_has_discriminators() {
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+        for inst in &idl.instructions {
+            let disc = inst
+                .discriminator
+                .as_ref()
+                .unwrap_or_else(|| panic!("Instruction {} missing discriminator", inst.name));
+            assert_eq!(
+                disc.len(),
+                8,
+                "Instruction {} has {}-byte discriminator, expected 8",
+                inst.name,
+                disc.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+        let garbage = [0u8; 9];
+        let result = parse_instruction_with_idl(&garbage, METEORA_DLMM_PROGRAM_ID, idl);
+        assert!(
+            result.is_err(),
+            "Unknown discriminator must fail IDL parsing"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        // Directly exercise the length guard via the visualizer contract: data < 8 must error.
+        // parse_instruction_with_idl itself also rejects short data, so assert that path.
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+        let short = [0u8; 3];
+        let result = parse_instruction_with_idl(&short, METEORA_DLMM_PROGRAM_ID, idl);
+        assert!(result.is_err(), "Data shorter than 8 bytes must fail");
+    }
+
+    #[test]
+    fn test_swap_instruction_parses() {
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+        // swap discriminator + amount_in=1000 (u64 LE) + min_amount_out=900 (u64 LE)
+        let mut data = vec![248, 198, 158, 145, 225, 117, 135, 200];
+        data.extend_from_slice(&1000u64.to_le_bytes());
+        data.extend_from_slice(&900u64.to_le_bytes());
+
+        let parsed = parse_instruction_with_idl(&data, METEORA_DLMM_PROGRAM_ID, idl)
+            .expect("swap must parse");
+        assert_eq!(parsed.instruction_name, "swap");
+        assert!(parsed.program_call_args.contains_key("amount_in"));
+        assert!(parsed.program_call_args.contains_key("min_amount_out"));
+    }
+
+    #[test]
+    fn test_kind_is_dex() {
+        let visualizer = MeteoraDlmmVisualizer;
+        assert!(matches!(
+            visualizer.kind(),
+            VisualizerKind::Dex(METEORA_DLMM_DISPLAY_NAME)
+        ));
+    }
+
+    #[test]
+    fn test_build_named_accounts_pairs_ordered_accounts() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_sdk::pubkey::Pubkey;
+
+        let idl = get_meteora_dlmm_idl().expect("IDL must load");
+
+        // close_position2: [position, sender, rent_receiver, event_authority, program]
+        let mut data = vec![174, 90, 35, 115, 186, 40, 147, 226];
+        let position = Pubkey::new_unique();
+        let sender = Pubkey::new_unique();
+        let rent_receiver = Pubkey::new_unique();
+        let event_authority = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        data.extend([] as [u8; 0]);
+
+        let instruction = Instruction {
+            program_id: METEORA_DLMM_PROGRAM_ID.parse().unwrap(),
+            accounts: vec![
+                AccountMeta::new(position, false),
+                AccountMeta::new_readonly(sender, true),
+                AccountMeta::new(rent_receiver, false),
+                AccountMeta::new_readonly(event_authority, false),
+                AccountMeta::new_readonly(program, false),
+            ],
+            data,
+        };
+
+        let named = build_named_accounts(idl, &instruction);
+        let lookup: BTreeMap<_, _> = named.into_iter().collect();
+        assert_eq!(lookup.get("position"), Some(&position.to_string()));
+        assert_eq!(lookup.get("sender"), Some(&sender.to_string()));
+        assert_eq!(
+            lookup.get("rent_receiver"),
+            Some(&rent_receiver.to_string())
+        );
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -8,6 +8,7 @@ pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
 pub mod meteora_damm_v2;
+pub mod meteora_dlmm;
 pub mod neutral_trade;
 pub mod onre_app;
 pub mod stakepool;


### PR DESCRIPTION
## Why this PR exists

Solana transactions that call the Meteora DLMM (`lb_clmm`) program currently fall through to the generic unknown-program visualizer, so signers see only a program ID and raw instruction hex. Meteora DLMM is a top-tier Solana DEX and users signing swaps or liquidity actions need to see what they're approving.

## What changed

- New preset `visualsign-solana/src/presets/meteora_dlmm/` containing `config.rs` (program-ID match), `mod.rs` (IDL-driven visualizer), and a bundled `meteora_dlmm.json` IDL.
- Registered `pub mod meteora_dlmm;` in `presets/mod.rs`; `build.rs` auto-discovers the `MeteoraDlmmVisualizer` struct, so no other registration is needed.
- The visualizer bundles the IDL via `include_str!`, decodes it once behind a `OnceLock`, and uses `solana_parser::parse_instruction_with_idl` to produce instruction name, discriminator, args, and IDL-named accounts. Output is rendered through the shared `create_text_field` / `create_raw_data_field` builders into the standard condensed/expanded preview layout. Returns `VisualizerKind::Dex("Meteora DLMM")`.
- Seven unit tests: IDL loads, all discriminators are 8 bytes, short data errors, unknown discriminator errors, a real `swap` instruction decodes with expected args, `kind()` returns `Dex`, and named-account pairing preserves IDL account order.

<img width="732" height="2521" alt="image" src="https://github.com/user-attachments/assets/aacff3fd-97c5-48fd-8718-bc79ad2dc8d8" />


## Why this is safe

- No changes to existing visualizers or shared code — only additive. Unknown-program fallback still exists for anything this preset can't parse, and the `can_handle` gate is scoped to the Meteora DLMM program ID, so other programs are untouched.
- The IDL is bundled, not fetched — no network I/O, no runtime dependency on external state.
- Parsing uses the existing `solana_parser` crate the same way `unknown_program` and `jupiter_swap` do; errors from discriminator mismatches or truncated data return `VisualSignError` rather than panicking, and the workspace clippy denials (`unwrap_used`, `expect_used`, `panic`) are enforced in non-test code.

### Checks run (by agent)
- `cargo fmt -p visualsign-solana`
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings`
- `cargo test -p visualsign-solana` (all 69 tests pass, including the 7 new ones)
- `make -C src test` (full workspace: all tests pass)
- `make -C src lint` (workspace clippy clean)

### Manual steps needed (by human)
None — fully automated by CI.

## How this is maintainable

- Each preset is a self-contained directory under `src/presets/` and is auto-discovered by `build.rs` from the `{PascalName}Visualizer` convention — adding or removing a preset is a one-line change in `presets/mod.rs` plus the directory.
- The visualizer is generic IDL-driven: no hand-written per-instruction decoders. Updating to a newer Meteora IDL is just replacing `meteora_dlmm.json`; the `test_meteora_dlmm_idl_has_discriminators` test catches malformed IDL and `test_swap_instruction_parses` catches a real-world regression on the most-used instruction.
- Pattern matches `jupiter_swap` and `unknown_program` presets already in the tree, so any contributor who has touched those can extend this one. CLAUDE.md documents the preset conventions (field builders, ASCII-only, imports at top of module) that this PR follows.