### PR TITLE
feat: add Orca Whirlpool Solana preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -11,6 +11,7 @@ pub mod meteora_damm_v2;
 pub mod meteora_dlmm;
 pub mod neutral_trade;
 pub mod onre_app;
+pub mod orca_whirlpool;
 pub mod stakepool;
 pub mod swig_wallet;
 pub mod system;

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/config.rs
@@ -1,0 +1,22 @@
+use super::ORCA_WHIRLPOOL_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct OrcaWhirlpoolConfig;
+
+impl SolanaIntegrationConfig for OrcaWhirlpoolConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(ORCA_WHIRLPOOL_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/mod.rs
@@ -1,0 +1,252 @@
+//! Orca Whirlpool preset — generic IDL-driven visualizer.
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::OrcaWhirlpoolConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const ORCA_WHIRLPOOL_PROGRAM_ID: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc";
+
+const ORCA_WHIRLPOOL_DISPLAY_NAME: &str = "Orca Whirlpool";
+
+const ORCA_WHIRLPOOL_IDL_JSON: &str = include_str!("orca_whirlpool.json");
+
+static ORCA_WHIRLPOOL_CONFIG: OrcaWhirlpoolConfig = OrcaWhirlpoolConfig;
+
+pub struct OrcaWhirlpoolVisualizer;
+
+impl InstructionVisualizer for OrcaWhirlpoolVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        let account_keys: Vec<String> = instruction
+            .accounts
+            .iter()
+            .map(|account| account.pubkey.to_string())
+            .collect();
+
+        let parsed = parse_orca_whirlpool_instruction(&instruction.data, &account_keys)?;
+        let named_accounts = build_named_accounts(&parsed, &account_keys);
+
+        let title_text = format!("{ORCA_WHIRLPOOL_DISPLAY_NAME}: {}", parsed.instruction_name);
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: vec![
+                create_text_field("Instruction", &title_text)
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            ],
+        };
+
+        let expanded = SignablePayloadFieldListLayout {
+            fields: build_expanded_fields(
+                &parsed,
+                &named_accounts,
+                &instruction.program_id.to_string(),
+                &instruction.data,
+            )?,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 {
+                text: title_text.clone(),
+            }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        let fallback_text = format!(
+            "Program ID: {}\nData: {}",
+            instruction.program_id,
+            hex::encode(&instruction.data)
+        );
+
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {}", context.instruction_index() + 1),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&ORCA_WHIRLPOOL_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(ORCA_WHIRLPOOL_DISPLAY_NAME)
+    }
+}
+
+fn load_orca_whirlpool_idl() -> Result<&'static Idl, VisualSignError> {
+    static IDL: std::sync::OnceLock<Result<Idl, String>> = std::sync::OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(ORCA_WHIRLPOOL_IDL_JSON).map_err(|e| e.to_string()))
+        .as_ref()
+        .map_err(|e| VisualSignError::DecodeError(format!("Orca Whirlpool IDL invalid: {e}")))
+}
+
+fn parse_orca_whirlpool_instruction(
+    data: &[u8],
+    _accounts: &[String],
+) -> Result<SolanaParsedInstructionData, VisualSignError> {
+    if data.len() < 8 {
+        return Err(VisualSignError::DecodeError(
+            "Orca Whirlpool instruction data too short (need 8-byte discriminator)".into(),
+        ));
+    }
+
+    let idl = load_orca_whirlpool_idl()?;
+    parse_instruction_with_idl(data, ORCA_WHIRLPOOL_PROGRAM_ID, idl)
+        .map_err(|e| VisualSignError::DecodeError(e.to_string()))
+}
+
+fn build_named_accounts(
+    parsed: &SolanaParsedInstructionData,
+    account_keys: &[String],
+) -> Vec<(String, String)> {
+    let mut named: Vec<(String, String)> = parsed
+        .named_accounts
+        .iter()
+        .map(|(name, pubkey)| (name.clone(), pubkey.clone()))
+        .collect();
+    named.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if named.is_empty() {
+        return account_keys
+            .iter()
+            .enumerate()
+            .map(|(i, pubkey)| (format!("Account {i}"), pubkey.clone()))
+            .collect();
+    }
+
+    named
+}
+
+fn build_expanded_fields(
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &[(String, String)],
+    program_id: &str,
+    data: &[u8],
+) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    let mut fields: Vec<AnnotatedPayloadField> = Vec::new();
+
+    fields.push(
+        create_text_field("Program ID", program_id)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    );
+    fields.push(
+        create_text_field("Instruction Name", &parsed.instruction_name)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    );
+
+    for (name, pubkey) in named_accounts {
+        let label = format!("Account: {name}");
+        fields.push(
+            create_text_field(&label, pubkey)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+    }
+
+    let mut args: Vec<(&String, &serde_json::Value)> = parsed.program_call_args.iter().collect();
+    args.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, value) in args {
+        let label = format!("Arg: {name}");
+        let rendered = format_arg_value(value);
+        fields.push(
+            create_text_field(&label, &rendered)
+                .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+        );
+    }
+
+    fields.push(
+        create_raw_data_field(data, Some(hex::encode(data)))
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    );
+
+    Ok(fields)
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_orca_whirlpool_idl_loads() {
+        let idl = load_orca_whirlpool_idl().expect("IDL should load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should contain at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_orca_whirlpool_idl_has_discriminators() {
+        let idl = load_orca_whirlpool_idl().expect("IDL should load");
+        for ix in &idl.instructions {
+            let disc = ix
+                .discriminator
+                .as_ref()
+                .unwrap_or_else(|| panic!("instruction {} missing discriminator", ix.name));
+            assert_eq!(
+                disc.len(),
+                8,
+                "instruction {} discriminator must be 8 bytes, got {}",
+                ix.name,
+                disc.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage = [0x00u8; 9];
+        let accounts: Vec<String> = vec![];
+        let result = parse_orca_whirlpool_instruction(&garbage, &accounts);
+        assert!(
+            result.is_err(),
+            "Unknown discriminator should return an error"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short = [0x01u8, 0x02, 0x03];
+        let accounts: Vec<String> = vec![];
+        let result = parse_orca_whirlpool_instruction(&short, &accounts);
+        assert!(result.is_err(), "Short data should return an error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/orca_whirlpool.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/orca_whirlpool.json
@@ -1,0 +1,7608 @@
+{
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
+    },
+    "instructions": [
+        {
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
+                1
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower"
+                },
+                {
+                    "name": "tick_array_upper"
+                }
+            ],
+            "args": []
+        }
+    ],
+    "accounts": [
+        {
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
+        },
+        {
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
+        },
+        {
+            "name": "FeeTier",
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
+        },
+        {
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
+        },
+        {
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
+        },
+        {
+            "name": "Position",
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
+        },
+        {
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
+        },
+        {
+            "name": "TickArray",
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
+        },
+        {
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
+        },
+        {
+            "name": "Whirlpool",
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
+        },
+        {
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
+        },
+        {
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
+        },
+        {
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
+        },
+        {
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
+        }
+    ],
+    "errors": [
+        {
+            "code": 6000,
+            "name": "InvalidEnum",
+            "msg": "Enum value could not be converted"
+        },
+        {
+            "code": 6001,
+            "name": "InvalidStartTick",
+            "msg": "Invalid start tick index provided."
+        },
+        {
+            "code": 6002,
+            "name": "TickArrayExistInPool",
+            "msg": "Tick-array already exists in this whirlpool"
+        },
+        {
+            "code": 6003,
+            "name": "TickArrayIndexOutofBounds",
+            "msg": "Attempt to search for a tick-array failed"
+        },
+        {
+            "code": 6004,
+            "name": "InvalidTickSpacing",
+            "msg": "Tick-spacing is not supported"
+        },
+        {
+            "code": 6005,
+            "name": "ClosePositionNotEmpty",
+            "msg": "Position is not empty It cannot be closed"
+        },
+        {
+            "code": 6006,
+            "name": "DivideByZero",
+            "msg": "Unable to divide by zero"
+        },
+        {
+            "code": 6007,
+            "name": "NumberCastError",
+            "msg": "Unable to cast number into BigInt"
+        },
+        {
+            "code": 6008,
+            "name": "NumberDownCastError",
+            "msg": "Unable to down cast number"
+        },
+        {
+            "code": 6009,
+            "name": "TickNotFound",
+            "msg": "Tick not found within tick array"
+        },
+        {
+            "code": 6010,
+            "name": "InvalidTickIndex",
+            "msg": "Provided tick index is either out of bounds or uninitializable"
+        },
+        {
+            "code": 6011,
+            "name": "SqrtPriceOutOfBounds",
+            "msg": "Provided sqrt price out of bounds"
+        },
+        {
+            "code": 6012,
+            "name": "LiquidityZero",
+            "msg": "Liquidity amount must be greater than zero"
+        },
+        {
+            "code": 6013,
+            "name": "LiquidityTooHigh",
+            "msg": "Liquidity amount must be less than i64::MAX"
+        },
+        {
+            "code": 6014,
+            "name": "LiquidityOverflow",
+            "msg": "Liquidity overflow"
+        },
+        {
+            "code": 6015,
+            "name": "LiquidityUnderflow",
+            "msg": "Liquidity underflow"
+        },
+        {
+            "code": 6016,
+            "name": "LiquidityNetError",
+            "msg": "Tick liquidity net underflowed or overflowed"
+        },
+        {
+            "code": 6017,
+            "name": "TokenMaxExceeded",
+            "msg": "Exceeded token max"
+        },
+        {
+            "code": 6018,
+            "name": "TokenMinSubceeded",
+            "msg": "Did not meet token min"
+        },
+        {
+            "code": 6019,
+            "name": "MissingOrInvalidDelegate",
+            "msg": "Position token account has a missing or invalid delegate"
+        },
+        {
+            "code": 6020,
+            "name": "InvalidPositionTokenAmount",
+            "msg": "Position token amount must be 1"
+        },
+        {
+            "code": 6021,
+            "name": "InvalidTimestampConversion",
+            "msg": "Timestamp should be convertible from i64 to u64"
+        },
+        {
+            "code": 6022,
+            "name": "InvalidTimestamp",
+            "msg": "Timestamp should be greater than the last updated timestamp"
+        },
+        {
+            "code": 6023,
+            "name": "InvalidTickArraySequence",
+            "msg": "Invalid tick array sequence provided for instruction."
+        },
+        {
+            "code": 6024,
+            "name": "InvalidTokenMintOrder",
+            "msg": "Token Mint in wrong order"
+        },
+        {
+            "code": 6025,
+            "name": "RewardNotInitialized",
+            "msg": "Reward not initialized"
+        },
+        {
+            "code": 6026,
+            "name": "InvalidRewardIndex",
+            "msg": "Invalid reward index"
+        },
+        {
+            "code": 6027,
+            "name": "RewardVaultAmountInsufficient",
+            "msg": "Reward vault requires amount to support emissions for at least one day"
+        },
+        {
+            "code": 6028,
+            "name": "FeeRateMaxExceeded",
+            "msg": "Exceeded max fee rate"
+        },
+        {
+            "code": 6029,
+            "name": "ProtocolFeeRateMaxExceeded",
+            "msg": "Exceeded max protocol fee rate"
+        },
+        {
+            "code": 6030,
+            "name": "MultiplicationShiftRightOverflow",
+            "msg": "Multiplication with shift right overflow"
+        },
+        {
+            "code": 6031,
+            "name": "MulDivOverflow",
+            "msg": "Muldiv overflow"
+        },
+        {
+            "code": 6032,
+            "name": "MulDivInvalidInput",
+            "msg": "Invalid div_u256 input"
+        },
+        {
+            "code": 6033,
+            "name": "MultiplicationOverflow",
+            "msg": "Multiplication overflow"
+        },
+        {
+            "code": 6034,
+            "name": "InvalidSqrtPriceLimitDirection",
+            "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
+        },
+        {
+            "code": 6035,
+            "name": "ZeroTradableAmount",
+            "msg": "There are no tradable amount to swap."
+        },
+        {
+            "code": 6036,
+            "name": "AmountOutBelowMinimum",
+            "msg": "Amount out below minimum threshold"
+        },
+        {
+            "code": 6037,
+            "name": "AmountInAboveMaximum",
+            "msg": "Amount in above maximum threshold"
+        },
+        {
+            "code": 6038,
+            "name": "TickArraySequenceInvalidIndex",
+            "msg": "Invalid index for tick array sequence"
+        },
+        {
+            "code": 6039,
+            "name": "AmountCalcOverflow",
+            "msg": "Amount calculated overflows"
+        },
+        {
+            "code": 6040,
+            "name": "AmountRemainingOverflow",
+            "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
+        }
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Why this PR exists

Orca Whirlpool transactions show up as opaque `Instruction N` fields with raw program data, so users signing Orca swaps or liquidity actions cannot verify what they are approving. There is no preset for the Orca Whirlpool program (`whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc`).

## What changed

- New preset `visualsign-solana::presets::orca_whirlpool` registered alongside `jupiter_swap`, `stakepool`, etc.
- Vendored the official Orca Whirlpool IDL from `@orca-so/whirlpools-sdk` as `orca_whirlpool.json` (66 instructions, Anchor 0.30+ format — no local/Docker anchor-cli was available and the on-chain IDL account is empty for this program).
- Generic IDL-driven visualizer: `parse_instruction_with_idl` resolves instruction name, named accounts, and args; the expanded field list renders Program ID, Instruction Name, sorted named accounts, sorted args, and the raw data blob. No program-specific decoding — every Whirlpool instruction flows through the same path.
- `OrcaWhirlpoolConfig` registers the program ID with a wildcard instruction matcher so every Whirlpool instruction is claimed by this visualizer.
- `VisualizerKind::Dex("Orca Whirlpool")`.

<img width="732" height="2419" alt="image" src="https://github.com/user-attachments/assets/74beae09-cfbb-450a-bf0d-540812ab8766" />


## Why this is safe

- Strictly additive. No existing preset, type, or registry entry is modified; `presets/mod.rs` gains one `pub mod` line inserted alphabetically, and `build.rs` auto-discovers `OrcaWhirlpoolVisualizer` by directory name.
- Visualization only — no settlement, signing, or state mutation. Worst case for a malformed instruction is that `parse_instruction_with_idl` returns an error and the outer pipeline falls back to the unknown-program visualizer.
- Guarded inputs: data shorter than 8 bytes returns `DecodeError` before touching the IDL; unknown discriminators surface as errors from `solana_parser` rather than panicking.
- No `unwrap`/`expect`/`panic` in non-test code, in line with the workspace lint policy.

### Checks run (by agent)
- `cargo fmt -p visualsign-solana`
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings`
- `cargo test -p visualsign-solana` — all crate tests pass, including four new unit tests (`test_orca_whirlpool_idl_loads`, `test_orca_whirlpool_idl_has_discriminators`, `test_unknown_discriminator_returns_error`, `test_short_data_returns_error`)
- `make test` — full workspace test suite green

### Manual steps needed (by human)
None — fully automated by CI. **Risk: low.**

## How this is maintainable

- The visualizer is a thin wrapper around `solana_parser::parse_instruction_with_idl`, so a fresh reader only needs to understand the IDL parse output (`SolanaParsedInstructionData`) to follow the code.
- IDL is a static `include_str!` baked into the binary; refreshing it means replacing `orca_whirlpool.json` and rerunning tests — `test_orca_whirlpool_idl_has_discriminators` will catch any structural regression on reload.
- The `OnceLock`-cached IDL decode means the first instruction pays the parse cost and the rest are free; if Anchor ships a new spec version, the failure surfaces as a `VisualSignError::DecodeError` on first use rather than a panic.
- Follows the same shape as `jupiter_swap` (the other Dex preset), so anyone adding a new generic Anchor program preset has two adjacent examples to copy from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)