### PR TITLE
feat: handle Jupiter v6 route_v2 instructions and refresh IDL

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/txtypes/v0.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/txtypes/v0.rs
@@ -15,7 +15,9 @@ use visualsign::{
 pub fn decode_v0_transfers(
     versioned_tx: &VersionedTransaction,
 ) -> Result<Vec<AnnotatedPayloadField>, VisualSignError> {
+    use crate::presets::jupiter_swap::{JUPITER_IDL_JSON, JUPITER_PROGRAM_ID};
     use solana_parser::solana::parser::parse_transaction;
+    use std::collections::HashMap;
 
     // Serialize the full versioned transaction
     let transaction_bytes = bincode::serialize(versioned_tx).map_err(|e| {
@@ -24,12 +26,21 @@ pub fn decode_v0_transfers(
         ))
     })?;
 
+    // Override the stale Jupiter v6 IDL bundled in solana_parser with our locally
+    // refreshed copy so that newer instructions (e.g. route_v2) don't cause the
+    // whole-tx decode to bail with "no matching instruction discriminator".
+    let mut custom_idls: HashMap<String, (String, bool)> = HashMap::new();
+    custom_idls.insert(
+        JUPITER_PROGRAM_ID.to_string(),
+        (JUPITER_IDL_JSON.to_string(), true),
+    );
+
     let is_full_transaction = true; // true because we're passing full tx and not message
     // Parse using solana-parser which handles V0 transactions and lookup tables
     let parsed_transaction = parse_transaction(
         hex::encode(transaction_bytes),
         is_full_transaction,
-        None,
+        Some(custom_idls),
     )
     .map_err(|e| {
         VisualSignError::ParseError(visualsign::vsptrait::TransactionParseError::DecodeError(

--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/jupiter_agg_v6.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/jupiter_agg_v6.json
@@ -1,0 +1,2932 @@
+{
+  "accounts": [
+    {
+      "discriminator": [
+        156,
+        247,
+        9,
+        188,
+        54,
+        108,
+        85,
+        77
+      ],
+      "name": "TokenLedger"
+    }
+  ],
+  "address": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+  "errors": [
+    {
+      "code": 6000,
+      "msg": "Empty route",
+      "name": "EmptyRoute"
+    },
+    {
+      "code": 6001,
+      "msg": "Slippage tolerance exceeded",
+      "name": "SlippageToleranceExceeded"
+    },
+    {
+      "code": 6002,
+      "msg": "Invalid calculation",
+      "name": "InvalidCalculation"
+    },
+    {
+      "code": 6003,
+      "msg": "Missing platform fee account",
+      "name": "MissingPlatformFeeAccount"
+    },
+    {
+      "code": 6004,
+      "msg": "Invalid slippage",
+      "name": "InvalidSlippage"
+    },
+    {
+      "code": 6005,
+      "msg": "Not enough percent to 100",
+      "name": "NotEnoughPercent"
+    },
+    {
+      "code": 6006,
+      "msg": "Token input index is invalid",
+      "name": "InvalidInputIndex"
+    },
+    {
+      "code": 6007,
+      "msg": "Token output index is invalid",
+      "name": "InvalidOutputIndex"
+    },
+    {
+      "code": 6008,
+      "msg": "Not Enough Account keys",
+      "name": "NotEnoughAccountKeys"
+    },
+    {
+      "code": 6009,
+      "msg": "Non zero minimum out amount not supported",
+      "name": "NonZeroMinimumOutAmountNotSupported"
+    },
+    {
+      "code": 6010,
+      "msg": "Invalid route plan",
+      "name": "InvalidRoutePlan"
+    },
+    {
+      "code": 6011,
+      "msg": "Invalid referral authority",
+      "name": "InvalidReferralAuthority"
+    },
+    {
+      "code": 6012,
+      "msg": "Token account doesn't match the ledger",
+      "name": "LedgerTokenAccountDoesNotMatch"
+    },
+    {
+      "code": 6013,
+      "msg": "Invalid token ledger",
+      "name": "InvalidTokenLedger"
+    },
+    {
+      "code": 6014,
+      "msg": "Token program ID is invalid",
+      "name": "IncorrectTokenProgramID"
+    },
+    {
+      "code": 6015,
+      "msg": "Token program not provided",
+      "name": "TokenProgramNotProvided"
+    },
+    {
+      "code": 6016,
+      "msg": "Swap not supported",
+      "name": "SwapNotSupported"
+    },
+    {
+      "code": 6017,
+      "msg": "Exact out amount doesn't match",
+      "name": "ExactOutAmountNotMatched"
+    },
+    {
+      "code": 6018,
+      "msg": "Source mint and destination mint cannot the same",
+      "name": "SourceAndDestinationMintCannotBeTheSame"
+    },
+    {
+      "code": 6019,
+      "msg": "Invalid mint",
+      "name": "InvalidMint"
+    },
+    {
+      "code": 6020,
+      "msg": "Invalid program authority",
+      "name": "InvalidProgramAuthority"
+    },
+    {
+      "code": 6021,
+      "msg": "Invalid output token account",
+      "name": "InvalidOutputTokenAccount"
+    },
+    {
+      "code": 6022,
+      "msg": "Invalid fee wallet",
+      "name": "InvalidFeeWallet"
+    },
+    {
+      "code": 6023,
+      "msg": "Invalid authority",
+      "name": "InvalidAuthority"
+    },
+    {
+      "code": 6024,
+      "msg": "Insufficient funds",
+      "name": "InsufficientFunds"
+    },
+    {
+      "code": 6025,
+      "msg": "Invalid token account",
+      "name": "InvalidTokenAccount"
+    },
+    {
+      "code": 6026,
+      "msg": "Bonding curve already completed",
+      "name": "BondingCurveAlreadyCompleted"
+    }
+  ],
+  "events": [
+    {
+      "discriminator": [
+        73,
+        79,
+        78,
+        127,
+        184,
+        213,
+        13,
+        220
+      ],
+      "name": "FeeEvent"
+    },
+    {
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
+      ],
+      "name": "SwapEvent"
+    },
+    {
+      "discriminator": [
+        152,
+        47,
+        78,
+        235,
+        192,
+        96,
+        110,
+        106
+      ],
+      "name": "SwapsEvent"
+    },
+    {
+      "discriminator": [
+        45,
+        9,
+        244,
+        30,
+        229,
+        52,
+        168,
+        123
+      ],
+      "name": "CandidateSwapResults"
+    },
+    {
+      "discriminator": [
+        248,
+        134,
+        37,
+        55,
+        145,
+        177,
+        114,
+        79
+      ],
+      "name": "CandidateSwapQuoteError"
+    },
+    {
+      "discriminator": [
+        124,
+        66,
+        196,
+        51,
+        218,
+        173,
+        46,
+        93
+      ],
+      "name": "BestSwapOutAmountViolation"
+    }
+  ],
+  "instructions": [
+    {
+      "accounts": [
+        {
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
+          "name": "wallet",
+          "writable": true
+        },
+        {
+          "name": "program_authority",
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        62,
+        198,
+        214,
+        193,
+        213,
+        159,
+        108,
+        210
+      ],
+      "name": "claim",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
+          "name": "wallet"
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "program_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        116,
+        206,
+        27,
+        191,
+        166,
+        19,
+        0,
+        73
+      ],
+      "name": "claim_token",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "address": "9RAufBfjGQjDfrwxeyKmZWPADHSb8HcoqCdrmpqvCr1g",
+          "name": "operator",
+          "signer": true
+        },
+        {
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
+          "name": "wallet",
+          "writable": true
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "program_token_account",
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "burn_all",
+          "type": "bool"
+        }
+      ],
+      "discriminator": [
+        26,
+        74,
+        236,
+        151,
+        104,
+        64,
+        183,
+        249
+      ],
+      "name": "close_token"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_ledger",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        232,
+        242,
+        197,
+        253,
+        240,
+        143,
+        129,
+        52
+      ],
+      "name": "create_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_account",
+          "writable": true
+        },
+        {
+          "name": "user",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bump",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        147,
+        241,
+        123,
+        100,
+        244,
+        132,
+        174,
+        118
+      ],
+      "name": "create_token_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_account",
+          "writable": true
+        },
+        {
+          "name": "user",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        203,
+        129,
+        103,
+        133,
+        197,
+        125,
+        107,
+        86
+      ],
+      "name": "close_wsol_token_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        208,
+        51,
+        239,
+        151,
+        123,
+        43,
+        237,
+        92
+      ],
+      "name": "exact_out_route",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        229,
+        23,
+        203,
+        151,
+        122,
+        227,
+        173,
+        42
+      ],
+      "name": "route",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_ledger"
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        150,
+        86,
+        71,
+        116,
+        167,
+        93,
+        14,
+        104
+      ],
+      "name": "route_with_token_ledger",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_ledger",
+          "writable": true
+        },
+        {
+          "name": "token_account"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        228,
+        85,
+        185,
+        112,
+        78,
+        79,
+        77,
+        2
+      ],
+      "name": "set_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        176,
+        209,
+        105,
+        168,
+        154,
+        125,
+        69,
+        62
+      ],
+      "name": "shared_accounts_exact_out_route",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        193,
+        32,
+        155,
+        51,
+        65,
+        214,
+        156,
+        129
+      ],
+      "name": "shared_accounts_route",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "name": "token_ledger"
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        230,
+        121,
+        143,
+        80,
+        119,
+        159,
+        106,
+        170
+      ],
+      "name": "shared_accounts_route_with_token_ledger",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "source_token_program"
+        },
+        {
+          "name": "destination_token_program"
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "positive_slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStepV2"
+              }
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        157,
+        138,
+        184,
+        82,
+        21,
+        244,
+        243,
+        36
+      ],
+      "name": "exact_out_route_v2",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "source_token_program"
+        },
+        {
+          "name": "destination_token_program"
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "positive_slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStepV2"
+              }
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        187,
+        100,
+        250,
+        204,
+        49,
+        196,
+        175,
+        20
+      ],
+      "name": "route_v2",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "source_token_program"
+        },
+        {
+          "name": "destination_token_program"
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "positive_slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStepV2"
+              }
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        53,
+        96,
+        229,
+        202,
+        216,
+        187,
+        250,
+        24
+      ],
+      "name": "shared_accounts_exact_out_route_v2",
+      "returns": "u64"
+    },
+    {
+      "accounts": [
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "source_token_program"
+        },
+        {
+          "name": "destination_token_program"
+        },
+        {
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "positive_slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStepV2"
+              }
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        209,
+        152,
+        83,
+        147,
+        124,
+        254,
+        216,
+        233
+      ],
+      "name": "shared_accounts_route_v2",
+      "returns": "u64"
+    }
+  ],
+  "metadata": {
+    "description": "Jupiter aggregator program",
+    "name": "jupiter",
+    "spec": "0.1.0",
+    "version": "0.1.0"
+  },
+  "types": [
+    {
+      "name": "FeeEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "account",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RemainingAccountsInfo",
+      "type": {
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": "u8"
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "AccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookA"
+          },
+          {
+            "name": "TransferHookB"
+          },
+          {
+            "name": "TransferHookReward"
+          },
+          {
+            "name": "TransferHookInput"
+          },
+          {
+            "name": "TransferHookIntermediate"
+          },
+          {
+            "name": "TransferHookOutput"
+          },
+          {
+            "name": "SupplementalTickArrays"
+          },
+          {
+            "name": "SupplementalTickArraysOne"
+          },
+          {
+            "name": "SupplementalTickArraysTwo"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DefiTunaAccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookA"
+          },
+          {
+            "name": "TransferHookB"
+          },
+          {
+            "name": "TransferHookInput"
+          },
+          {
+            "name": "TransferHookIntermediate"
+          },
+          {
+            "name": "TransferHookOutput"
+          },
+          {
+            "name": "SupplementalTickArrays"
+          },
+          {
+            "name": "SupplementalTickArraysOne"
+          },
+          {
+            "name": "SupplementalTickArraysTwo"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoutePlanStep",
+      "type": {
+        "fields": [
+          {
+            "name": "swap",
+            "type": {
+              "defined": {
+                "name": "Swap"
+              }
+            }
+          },
+          {
+            "name": "percent",
+            "type": "u8"
+          },
+          {
+            "name": "input_index",
+            "type": "u8"
+          },
+          {
+            "name": "output_index",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RoutePlanStepV2",
+      "type": {
+        "fields": [
+          {
+            "name": "swap",
+            "type": {
+              "defined": {
+                "name": "Swap"
+              }
+            }
+          },
+          {
+            "name": "bps",
+            "type": "u16"
+          },
+          {
+            "name": "input_index",
+            "type": "u8"
+          },
+          {
+            "name": "output_index",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Side",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Bid"
+          },
+          {
+            "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Saber"
+          },
+          {
+            "name": "SaberAddDecimalsDeposit"
+          },
+          {
+            "name": "SaberAddDecimalsWithdraw"
+          },
+          {
+            "name": "TokenSwap"
+          },
+          {
+            "name": "Sencha"
+          },
+          {
+            "name": "Step"
+          },
+          {
+            "name": "Cropper"
+          },
+          {
+            "name": "Raydium"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "Crema"
+          },
+          {
+            "name": "Lifinity"
+          },
+          {
+            "name": "Mercurial"
+          },
+          {
+            "name": "Cykura"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Serum"
+          },
+          {
+            "name": "MarinadeDeposit"
+          },
+          {
+            "name": "MarinadeUnstake"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Aldrin"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "AldrinV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "Whirlpool"
+          },
+          {
+            "fields": [
+              {
+                "name": "x_to_y",
+                "type": "bool"
+              }
+            ],
+            "name": "Invariant"
+          },
+          {
+            "name": "Meteora"
+          },
+          {
+            "name": "GooseFX"
+          },
+          {
+            "fields": [
+              {
+                "name": "stable",
+                "type": "bool"
+              }
+            ],
+            "name": "DeltaFi"
+          },
+          {
+            "name": "Balansol"
+          },
+          {
+            "fields": [
+              {
+                "name": "x_to_y",
+                "type": "bool"
+              }
+            ],
+            "name": "MarcoPolo"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Dradex"
+          },
+          {
+            "name": "LifinityV2"
+          },
+          {
+            "name": "RaydiumClmm"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Openbook"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Phoenix"
+          },
+          {
+            "fields": [
+              {
+                "name": "from_token_id",
+                "type": "u64"
+              },
+              {
+                "name": "to_token_id",
+                "type": "u64"
+              }
+            ],
+            "name": "Symmetry"
+          },
+          {
+            "name": "TokenSwapV2"
+          },
+          {
+            "name": "HeliumTreasuryManagementRedeemV0"
+          },
+          {
+            "name": "StakeDexStakeWrappedSol"
+          },
+          {
+            "fields": [
+              {
+                "name": "bridge_stake_seed",
+                "type": "u32"
+              }
+            ],
+            "name": "StakeDexSwapViaStake"
+          },
+          {
+            "name": "GooseFXV2"
+          },
+          {
+            "name": "Perps"
+          },
+          {
+            "name": "PerpsAddLiquidity"
+          },
+          {
+            "name": "PerpsRemoveLiquidity"
+          },
+          {
+            "name": "MeteoraDlmm"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "OpenBookV2"
+          },
+          {
+            "name": "RaydiumClmmV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "bridge_stake_seed",
+                "type": "u32"
+              }
+            ],
+            "name": "StakeDexPrefundWithdrawStakeAndDepositStake"
+          },
+          {
+            "fields": [
+              {
+                "name": "pool_index",
+                "type": "u8"
+              },
+              {
+                "name": "quantity_is_input",
+                "type": "bool"
+              },
+              {
+                "name": "quantity_is_collateral",
+                "type": "bool"
+              }
+            ],
+            "name": "Clone"
+          },
+          {
+            "fields": [
+              {
+                "name": "src_lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "dst_lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "src_lst_index",
+                "type": "u32"
+              },
+              {
+                "name": "dst_lst_index",
+                "type": "u32"
+              }
+            ],
+            "name": "SanctumS"
+          },
+          {
+            "fields": [
+              {
+                "name": "lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "lst_index",
+                "type": "u32"
+              }
+            ],
+            "name": "SanctumSAddLiquidity"
+          },
+          {
+            "fields": [
+              {
+                "name": "lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "lst_index",
+                "type": "u32"
+              }
+            ],
+            "name": "SanctumSRemoveLiquidity"
+          },
+          {
+            "name": "RaydiumCP"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              },
+              {
+                "name": "remaining_accounts_info",
+                "type": {
+                  "option": {
+                    "defined": {
+                      "name": "RemainingAccountsInfo"
+                    }
+                  }
+                }
+              }
+            ],
+            "name": "WhirlpoolSwapV2"
+          },
+          {
+            "name": "OneIntro"
+          },
+          {
+            "name": "PumpWrappedBuy"
+          },
+          {
+            "name": "PumpWrappedSell"
+          },
+          {
+            "name": "PerpsV2"
+          },
+          {
+            "name": "PerpsV2AddLiquidity"
+          },
+          {
+            "name": "PerpsV2RemoveLiquidity"
+          },
+          {
+            "name": "MoonshotWrappedBuy"
+          },
+          {
+            "name": "MoonshotWrappedSell"
+          },
+          {
+            "name": "StabbleStableSwap"
+          },
+          {
+            "name": "StabbleWeightedSwap"
+          },
+          {
+            "fields": [
+              {
+                "name": "x_to_y",
+                "type": "bool"
+              }
+            ],
+            "name": "Obric"
+          },
+          {
+            "name": "FoxBuyFromEstimatedCost"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_y",
+                "type": "bool"
+              }
+            ],
+            "name": "FoxClaimPartial"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_quote_to_base",
+                "type": "bool"
+              }
+            ],
+            "name": "SolFi"
+          },
+          {
+            "name": "SolayerDelegateNoInit"
+          },
+          {
+            "name": "SolayerUndelegateNoInit"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "TokenMill"
+          },
+          {
+            "name": "DaosFunBuy"
+          },
+          {
+            "name": "DaosFunSell"
+          },
+          {
+            "name": "ZeroFi"
+          },
+          {
+            "name": "StakeDexWithdrawWrappedSol"
+          },
+          {
+            "name": "VirtualsBuy"
+          },
+          {
+            "name": "VirtualsSell"
+          },
+          {
+            "fields": [
+              {
+                "name": "in_index",
+                "type": "u8"
+              },
+              {
+                "name": "out_index",
+                "type": "u8"
+              }
+            ],
+            "name": "Perena"
+          },
+          {
+            "name": "PumpSwapBuy"
+          },
+          {
+            "name": "PumpSwapSell"
+          },
+          {
+            "name": "Gamma"
+          },
+          {
+            "fields": [
+              {
+                "name": "remaining_accounts_info",
+                "type": {
+                  "defined": {
+                    "name": "RemainingAccountsInfo"
+                  }
+                }
+              }
+            ],
+            "name": "MeteoraDlmmSwapV2"
+          },
+          {
+            "name": "Woofi"
+          },
+          {
+            "name": "MeteoraDammV2"
+          },
+          {
+            "name": "MeteoraDynamicBondingCurveSwap"
+          },
+          {
+            "name": "StabbleStableSwapV2"
+          },
+          {
+            "name": "StabbleWeightedSwapV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "share_fee_rate",
+                "type": "u64"
+              }
+            ],
+            "name": "RaydiumLaunchlabBuy"
+          },
+          {
+            "fields": [
+              {
+                "name": "share_fee_rate",
+                "type": "u64"
+              }
+            ],
+            "name": "RaydiumLaunchlabSell"
+          },
+          {
+            "name": "BoopdotfunWrappedBuy"
+          },
+          {
+            "name": "BoopdotfunWrappedSell"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Plasma"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_bid",
+                "type": "bool"
+              },
+              {
+                "name": "blacklist_bump",
+                "type": "u8"
+              }
+            ],
+            "name": "GoonFi"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              },
+              {
+                "name": "is_base_to_quote",
+                "type": "bool"
+              }
+            ],
+            "name": "HumidiFi"
+          },
+          {
+            "name": "MeteoraDynamicBondingCurveSwapWithRemainingAccounts"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "TesseraV"
+          },
+          {
+            "name": "PumpWrappedBuyV2"
+          },
+          {
+            "name": "PumpWrappedSellV2"
+          },
+          {
+            "name": "PumpSwapBuyV2"
+          },
+          {
+            "name": "PumpSwapSellV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "Heaven"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_quote_to_base",
+                "type": "bool"
+              }
+            ],
+            "name": "SolFiV2"
+          },
+          {
+            "name": "Aquifer"
+          },
+          {
+            "name": "PumpWrappedBuyV3"
+          },
+          {
+            "name": "PumpWrappedSellV3"
+          },
+          {
+            "name": "PumpSwapBuyV3"
+          },
+          {
+            "name": "PumpSwapSellV3"
+          },
+          {
+            "name": "JupiterLendDeposit"
+          },
+          {
+            "name": "JupiterLendRedeem"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              },
+              {
+                "name": "remaining_accounts_info",
+                "type": {
+                  "option": {
+                    "defined": {
+                      "name": "RemainingAccountsInfo"
+                    }
+                  }
+                }
+              }
+            ],
+            "name": "DefiTuna"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "AlphaQ"
+          },
+          {
+            "name": "RaydiumV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_for_y",
+                "type": "bool"
+              }
+            ],
+            "name": "SarosDlmm"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Futarchy"
+          },
+          {
+            "name": "MeteoraDammV2WithRemainingAccounts"
+          },
+          {
+            "name": "Obsidian"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "WhaleStreet"
+          },
+          {
+            "fields": [
+              {
+                "name": "candidate_swaps",
+                "type": {
+                  "vec": {
+                    "defined": {
+                      "name": "CandidateSwap"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "best_position",
+                "type": {
+                  "option": "u8"
+                }
+              }
+            ],
+            "name": "DynamicV1"
+          },
+          {
+            "name": "PumpWrappedBuyV4"
+          },
+          {
+            "name": "PumpWrappedSellV4"
+          },
+          {
+            "name": "CarrotIssue"
+          },
+          {
+            "name": "CarrotRedeem"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Manifest"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "BisonFi"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              },
+              {
+                "name": "is_base_to_quote",
+                "type": "bool"
+              }
+            ],
+            "name": "HumidiFiV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_mint",
+                "type": "bool"
+              }
+            ],
+            "name": "PerenaStar"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              },
+              {
+                "name": "fill_data",
+                "type": "bytes"
+              }
+            ],
+            "name": "JupiterRfqV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_bid",
+                "type": "bool"
+              }
+            ],
+            "name": "GoonFiV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u128"
+              }
+            ],
+            "name": "Scorch"
+          },
+          {
+            "fields": [
+              {
+                "name": "lst_amounts",
+                "type": {
+                  "array": [
+                    "u64",
+                    5
+                  ]
+                }
+              },
+              {
+                "name": "seed",
+                "type": "u64"
+              }
+            ],
+            "name": "VaultLiquidUnstake"
+          },
+          {
+            "name": "XOrca"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "Quantum"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              },
+              {
+                "name": "auth_amount_in",
+                "type": "u64"
+              },
+              {
+                "name": "auth",
+                "type": "u64"
+              }
+            ],
+            "name": "WhaleStreetV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "amount_is_token_a",
+                "type": "bool"
+              }
+            ],
+            "name": "Riptide"
+          },
+          {
+            "name": "RunnerRodeo"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_base_in",
+                "type": "bool"
+              }
+            ],
+            "name": "TaurusFi"
+          },
+          {
+            "name": "Omnipair"
+          },
+          {
+            "name": "MSwap"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_type",
+                "type": {
+                  "defined": {
+                    "name": "HyloSwapType"
+                  }
+                }
+              }
+            ],
+            "name": "Hylo"
+          },
+          {
+            "name": "VoltrDeposit"
+          },
+          {
+            "name": "VoltrWithdraw"
+          },
+          {
+            "fields": [
+              {
+                "name": "src_lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "dst_lst_value_calc_accs",
+                "type": "u8"
+              },
+              {
+                "name": "src_lst_index",
+                "type": "u32"
+              },
+              {
+                "name": "dst_lst_index",
+                "type": "u32"
+              }
+            ],
+            "name": "SanctumSV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_base_in",
+                "type": "bool"
+              }
+            ],
+            "name": "LemmingsFi"
+          },
+          {
+            "name": "ScaleVmmBuy"
+          },
+          {
+            "name": "ScaleVmmSell"
+          },
+          {
+            "name": "ScaleAmmBuy"
+          },
+          {
+            "name": "ScaleAmmSell"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "BisonFiV2"
+          },
+          {
+            "name": "Trends"
+          },
+          {
+            "name": "HumaDeposit"
+          },
+          {
+            "name": "HumaInstantWithdraw"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_base_to_quote",
+                "type": "bool"
+              }
+            ],
+            "name": "Kipseli"
+          },
+          {
+            "fields": [
+              {
+                "name": "candidate_swaps",
+                "type": {
+                  "vec": {
+                    "defined": {
+                      "name": "CandidateSwapWithBps"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "max_split_quote_calls",
+                "type": "u8"
+              },
+              {
+                "name": "max_split_candidates",
+                "type": "u8"
+              }
+            ],
+            "name": "DynamicV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CandidateSwapWithBps",
+      "type": {
+        "fields": [
+          {
+            "name": "candidate_swap",
+            "type": {
+              "defined": {
+                "name": "CandidateSwap"
+              }
+            }
+          },
+          {
+            "name": "bps",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "CandidateSwap",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              },
+              {
+                "name": "is_base_to_quote",
+                "type": "bool"
+              }
+            ],
+            "name": "HumidiFi"
+          },
+          {
+            "fields": [
+              {
+                "name": "side",
+                "type": {
+                  "defined": {
+                    "name": "Side"
+                  }
+                }
+              }
+            ],
+            "name": "TesseraV"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              },
+              {
+                "name": "is_base_to_quote",
+                "type": "bool"
+              }
+            ],
+            "name": "HumidiFiV2"
+          },
+          {
+            "name": "RaydiumV2"
+          },
+          {
+            "name": "RaydiumClmm"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "Whirlpool"
+          },
+          {
+            "name": "ZeroFi"
+          },
+          {
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              }
+            ],
+            "name": "BisonFiV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "is_bid",
+                "type": "bool"
+              }
+            ],
+            "name": "GoonFiV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HyloSwapType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MintStable"
+          },
+          {
+            "name": "RedeemStable"
+          },
+          {
+            "name": "MintLever"
+          },
+          {
+            "name": "RedeemLever"
+          },
+          {
+            "name": "SwapStableToLever"
+          },
+          {
+            "name": "SwapLeverToStable"
+          },
+          {
+            "name": "StabilityPoolDeposit"
+          },
+          {
+            "name": "StabilityPoolWithdraw"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "amm",
+            "type": "pubkey"
+          },
+          {
+            "name": "input_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapEventV2",
+      "type": {
+        "fields": [
+          {
+            "name": "input_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapsEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "swap_events",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "SwapEventV2"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "TokenLedger",
+      "type": {
+        "fields": [
+          {
+            "name": "token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BestSwapOutAmountViolation",
+      "type": {
+        "fields": [
+          {
+            "name": "expected_out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "out_amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "CandidateSwapResult",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "fields": [
+              "u64"
+            ],
+            "name": "OutAmount"
+          },
+          {
+            "fields": [
+              "u64"
+            ],
+            "name": "ProgramError"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CandidateSwapResults",
+      "type": {
+        "fields": [
+          {
+            "name": "results",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CandidateSwapResult"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "CandidateSwapQuoteError",
+      "type": {
+        "fields": [
+          {
+            "name": "candidate_index",
+            "type": "u64"
+          },
+          {
+            "name": "in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "error_code",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
@@ -157,7 +157,9 @@ impl InstructionVisualizer for JupiterSwapVisualizer {
 /// Jupiter v6 IDL refreshed from mainnet.
 /// Kept locally (not sourced from `solana_parser::ProgramType`) so we can pick up
 /// newer instructions like `route_v2` without bumping the upstream rev.
-const JUPITER_IDL_JSON: &str = include_str!("jupiter_agg_v6.json");
+/// Also used to override the stale IDL bundled inside `solana_parser` when that
+/// crate parses a full transaction (see `decode_v0_transfers`).
+pub(crate) const JUPITER_IDL_JSON: &str = include_str!("jupiter_agg_v6.json");
 
 fn get_jupiter_idl() -> Option<Idl> {
     decode_idl_data(JUPITER_IDL_JSON).ok()

--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
@@ -7,7 +7,7 @@ use crate::core::{
 };
 use crate::utils::{SwapTokenInfo, get_token_info};
 use config::JupiterSwapConfig;
-use solana_parser::{Idl, ProgramType, decode_idl_data, parse_instruction_with_idl};
+use solana_parser::{Idl, decode_idl_data, parse_instruction_with_idl};
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{
     create_amount_field, create_number_field, create_raw_data_field, create_text_field,
@@ -39,6 +39,34 @@ pub enum JupiterSwapInstruction {
         out_token: Option<SwapTokenInfo>,
         slippage_bps: u16,
         platform_fee_bps: u8,
+    },
+    RouteV2 {
+        in_token: Option<SwapTokenInfo>,
+        out_token: Option<SwapTokenInfo>,
+        slippage_bps: u16,
+        platform_fee_bps: u16,
+        positive_slippage_bps: u16,
+    },
+    ExactOutRouteV2 {
+        in_token: Option<SwapTokenInfo>,
+        out_token: Option<SwapTokenInfo>,
+        slippage_bps: u16,
+        platform_fee_bps: u16,
+        positive_slippage_bps: u16,
+    },
+    SharedAccountsRouteV2 {
+        in_token: Option<SwapTokenInfo>,
+        out_token: Option<SwapTokenInfo>,
+        slippage_bps: u16,
+        platform_fee_bps: u16,
+        positive_slippage_bps: u16,
+    },
+    SharedAccountsExactOutRouteV2 {
+        in_token: Option<SwapTokenInfo>,
+        out_token: Option<SwapTokenInfo>,
+        slippage_bps: u16,
+        platform_fee_bps: u16,
+        positive_slippage_bps: u16,
     },
     Unknown {
         /// Optional instruction name from IDL if available
@@ -126,10 +154,13 @@ impl InstructionVisualizer for JupiterSwapVisualizer {
     }
 }
 
-/// Get Jupiter v6 IDL from built-in IDLs in solana-parser
+/// Jupiter v6 IDL refreshed from mainnet.
+/// Kept locally (not sourced from `solana_parser::ProgramType`) so we can pick up
+/// newer instructions like `route_v2` without bumping the upstream rev.
+const JUPITER_IDL_JSON: &str = include_str!("jupiter_agg_v6.json");
+
 fn get_jupiter_idl() -> Option<Idl> {
-    ProgramType::from_program_id(JUPITER_PROGRAM_ID)
-        .and_then(|pt| decode_idl_data(pt.idl_json()).ok())
+    decode_idl_data(JUPITER_IDL_JSON).ok()
 }
 
 /// Helper to extract u64 argument from parsed IDL args
@@ -224,10 +255,83 @@ fn parse_jupiter_instruction_with_idl(
                 platform_fee_bps,
             })
         }
+        "route_v2" => parse_route_v2(&parsed.program_call_args, accounts, false, false),
+        "exact_out_route_v2" => parse_route_v2(&parsed.program_call_args, accounts, true, false),
+        "shared_accounts_route_v2" => {
+            parse_route_v2(&parsed.program_call_args, accounts, false, true)
+        }
+        "shared_accounts_exact_out_route_v2" => {
+            parse_route_v2(&parsed.program_call_args, accounts, true, true)
+        }
         _ => Ok(JupiterSwapInstruction::Unknown {
             instruction_name: Some(parsed.instruction_name.clone()),
         }),
     }
+}
+
+/// Parse any of the four v2 route variants. `exact_out` toggles amount field
+/// names and in/out token assignment; `shared` shifts mint account indices.
+fn parse_route_v2(
+    args: &serde_json::Map<String, serde_json::Value>,
+    accounts: &[String],
+    exact_out: bool,
+    shared: bool,
+) -> Result<JupiterSwapInstruction, Box<dyn std::error::Error>> {
+    let slippage_bps = u16::try_from(extract_u64_arg(args, "slippage_bps")?)?;
+    let platform_fee_bps = u16::try_from(extract_u64_arg(args, "platform_fee_bps")?)?;
+    let positive_slippage_bps = u16::try_from(extract_u64_arg(args, "positive_slippage_bps")?)?;
+
+    // Mint indices differ between shared and non-shared v2 variants (see IDL).
+    let (source_mint_idx, destination_mint_idx) = if shared { (6, 7) } else { (3, 4) };
+
+    // exact_out uses out_amount / quoted_in_amount; non-exact_out uses in_amount / quoted_out_amount.
+    let (in_amount, out_amount) = if exact_out {
+        let quoted_in_amount = extract_u64_arg(args, "quoted_in_amount")?;
+        let out_amount = extract_u64_arg(args, "out_amount")?;
+        (quoted_in_amount, out_amount)
+    } else {
+        let in_amount = extract_u64_arg(args, "in_amount")?;
+        let quoted_out_amount = extract_u64_arg(args, "quoted_out_amount")?;
+        (in_amount, quoted_out_amount)
+    };
+
+    let in_token = accounts
+        .get(source_mint_idx)
+        .map(|addr| get_token_info(addr, in_amount));
+    let out_token = accounts
+        .get(destination_mint_idx)
+        .map(|addr| get_token_info(addr, out_amount));
+
+    Ok(match (exact_out, shared) {
+        (false, false) => JupiterSwapInstruction::RouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        },
+        (true, false) => JupiterSwapInstruction::ExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        },
+        (false, true) => JupiterSwapInstruction::SharedAccountsRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        },
+        (true, true) => JupiterSwapInstruction::SharedAccountsExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        },
+    })
 }
 
 fn parse_jupiter_swap_instruction(
@@ -290,6 +394,66 @@ fn format_jupiter_swap_instruction(instruction: &JupiterSwapInstruction) -> Stri
 
             if *platform_fee_bps > 0 {
                 result.push_str(&format!(", platform fee: {platform_fee_bps}bps"));
+            }
+
+            result.push(')');
+            result
+        }
+        JupiterSwapInstruction::RouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::ExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::SharedAccountsRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::SharedAccountsExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        } => {
+            let instruction_type = match instruction {
+                JupiterSwapInstruction::RouteV2 { .. } => "Jupiter Swap V2",
+                JupiterSwapInstruction::ExactOutRouteV2 { .. } => "Jupiter Exact Out Route V2",
+                JupiterSwapInstruction::SharedAccountsRouteV2 { .. } => {
+                    "Jupiter Shared Accounts Route V2"
+                }
+                JupiterSwapInstruction::SharedAccountsExactOutRouteV2 { .. } => {
+                    "Jupiter Shared Accounts Exact Out Route V2"
+                }
+                _ => unreachable!(),
+            };
+
+            let mut result = format!(
+                "{}: From {} {} To {} {} (slippage: {}bps",
+                instruction_type,
+                format_token_amount(in_token),
+                format_token_symbol(in_token),
+                format_token_amount(out_token),
+                format_token_symbol(out_token),
+                slippage_bps
+            );
+
+            if *platform_fee_bps > 0 {
+                result.push_str(&format!(", platform fee: {platform_fee_bps}bps"));
+            }
+            if *positive_slippage_bps > 0 {
+                result.push_str(&format!(", positive slippage: {positive_slippage_bps}bps"));
             }
 
             result.push(')');
@@ -390,6 +554,87 @@ fn create_jupiter_swap_expanded_fields(
                 fields.push(
                     create_number_field("Platform Fee", &platform_fee_bps.to_string(), "bps")
                         .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                );
+            }
+        }
+        JupiterSwapInstruction::RouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::ExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::SharedAccountsRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        }
+        | JupiterSwapInstruction::SharedAccountsExactOutRouteV2 {
+            in_token,
+            out_token,
+            slippage_bps,
+            platform_fee_bps,
+            positive_slippage_bps,
+        } => {
+            if let Some(token) = in_token {
+                fields.extend([
+                    create_text_field("Input Token", &token.symbol)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_amount_field("Input Amount", &token.amount.to_string(), &token.symbol)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_text_field("Input Token Name", &token.name)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_text_field("Input Token Address", &token.address)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                ]);
+            }
+
+            if let Some(token) = out_token {
+                fields.extend([
+                    create_text_field("Output Token", &token.symbol)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_amount_field(
+                        "Quoted Output Amount",
+                        &token.amount.to_string(),
+                        &token.symbol,
+                    )
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_text_field("Output Token Name", &token.name)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                    create_text_field("Output Token Address", &token.address)
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                ]);
+            }
+
+            fields.push(
+                create_number_field("Slippage", &slippage_bps.to_string(), "bps")
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+            );
+
+            if *platform_fee_bps > 0 {
+                fields.push(
+                    create_number_field("Platform Fee", &platform_fee_bps.to_string(), "bps")
+                        .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+                );
+            }
+
+            if *positive_slippage_bps > 0 {
+                fields.push(
+                    create_number_field(
+                        "Positive Slippage",
+                        &positive_slippage_bps.to_string(),
+                        "bps",
+                    )
+                    .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
                 );
             }
         }
@@ -844,5 +1089,192 @@ mod tests {
             }
         });
         assert!(has_slippage, "Should have Slippage field");
+    }
+
+    /// Build a minimal v2 route body (after discriminator + any leading `id` byte).
+    /// Layout: amount_a, amount_b, slippage_bps, platform_fee_bps, positive_slippage_bps,
+    /// then an empty route_plan vec. Semantic meaning of amount_a/amount_b differs
+    /// per variant (in/out vs. out/in) but byte layout is identical.
+    fn build_route_v2_body(
+        amount_a: u64,
+        amount_b: u64,
+        slippage_bps: u16,
+        platform_fee_bps: u16,
+        positive_slippage_bps: u16,
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&amount_a.to_le_bytes());
+        body.extend_from_slice(&amount_b.to_le_bytes());
+        body.extend_from_slice(&slippage_bps.to_le_bytes());
+        body.extend_from_slice(&platform_fee_bps.to_le_bytes());
+        body.extend_from_slice(&positive_slippage_bps.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // empty route_plan
+        body
+    }
+
+    /// 8 accounts — enough for shared v2 variants (source_mint at index 6, destination_mint at 7).
+    fn fixture_accounts_shared_v2() -> Vec<String> {
+        vec![
+            "11111111111111111111111111111111".to_string(),
+            "22222222222222222222222222222222".to_string(),
+            "33333333333333333333333333333333".to_string(),
+            "44444444444444444444444444444444".to_string(),
+            "55555555555555555555555555555555".to_string(),
+            "66666666666666666666666666666666".to_string(),
+            "So11111111111111111111111111111111111111112".to_string(),
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+        ]
+    }
+
+    #[test]
+    fn test_jupiter_route_v2_parsing() {
+        // route_v2 discriminator: [187, 100, 250, 204, 49, 196, 175, 20]
+        let discriminator = hex::decode("bb64facc31c4af14").expect("valid hex");
+        let body = build_route_v2_body(2_000_000, 1_550_653, 50, 0, 25);
+        let data: Vec<u8> = [discriminator, body].concat();
+        let accounts = fixture_accounts();
+
+        let parsed = parse_jupiter_swap_instruction(&data, &accounts).unwrap();
+
+        match &parsed {
+            JupiterSwapInstruction::RouteV2 {
+                in_token,
+                out_token,
+                slippage_bps,
+                platform_fee_bps,
+                positive_slippage_bps,
+            } => {
+                assert_eq!(*slippage_bps, 50);
+                assert_eq!(*platform_fee_bps, 0);
+                assert_eq!(*positive_slippage_bps, 25);
+                // source_mint at accounts[3] -> in_amount
+                assert_eq!(in_token.as_ref().unwrap().amount, 2_000_000);
+                // destination_mint at accounts[4] -> quoted_out_amount
+                assert_eq!(out_token.as_ref().unwrap().amount, 1_550_653);
+            }
+            _ => panic!("Expected RouteV2, got {parsed:?}"),
+        }
+
+        let formatted = format_jupiter_swap_instruction(&parsed);
+        assert!(formatted.contains("Jupiter Swap V2"));
+        assert!(formatted.contains("positive slippage: 25bps"));
+
+        let fields = create_jupiter_swap_expanded_fields(
+            &parsed,
+            "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+            &data,
+        )
+        .unwrap();
+
+        let has_positive_slippage = fields.iter().any(|f| {
+            if let SignablePayloadField::Number { common, .. } = &f.signable_payload_field {
+                common.label == "Positive Slippage"
+            } else {
+                false
+            }
+        });
+        assert!(
+            has_positive_slippage,
+            "Should have Positive Slippage field when positive_slippage_bps > 0"
+        );
+    }
+
+    #[test]
+    fn test_jupiter_exact_out_route_v2_parsing() {
+        // exact_out_route_v2 discriminator: [157, 138, 184, 82, 21, 244, 243, 36]
+        let discriminator = hex::decode("9d8ab85215f4f324").expect("valid hex");
+        // For exact_out: first u64 is out_amount, second is quoted_in_amount.
+        let body = build_route_v2_body(2_000_000, 1_550_653, 50, 0, 0);
+        let data: Vec<u8> = [discriminator, body].concat();
+        let accounts = fixture_accounts();
+
+        let parsed = parse_jupiter_swap_instruction(&data, &accounts).unwrap();
+
+        match &parsed {
+            JupiterSwapInstruction::ExactOutRouteV2 {
+                in_token,
+                out_token,
+                slippage_bps,
+                platform_fee_bps,
+                positive_slippage_bps,
+            } => {
+                assert_eq!(*slippage_bps, 50);
+                assert_eq!(*platform_fee_bps, 0);
+                assert_eq!(*positive_slippage_bps, 0);
+                // in_token gets quoted_in_amount (second u64), out_token gets out_amount (first)
+                assert_eq!(in_token.as_ref().unwrap().amount, 1_550_653);
+                assert_eq!(out_token.as_ref().unwrap().amount, 2_000_000);
+            }
+            _ => panic!("Expected ExactOutRouteV2, got {parsed:?}"),
+        }
+
+        let formatted = format_jupiter_swap_instruction(&parsed);
+        assert!(formatted.contains("Jupiter Exact Out Route V2"));
+        // positive_slippage == 0 should NOT appear in the formatted line
+        assert!(!formatted.contains("positive slippage"));
+    }
+
+    #[test]
+    fn test_jupiter_shared_accounts_route_v2_parsing() {
+        // shared_accounts_route_v2 discriminator: [209, 152, 83, 147, 124, 254, 216, 233]
+        let discriminator = hex::decode("d19853937cfed8e9").expect("valid hex");
+        let id_byte = vec![0x00u8];
+        let body = build_route_v2_body(2_000_000, 1_550_653, 50, 10, 5);
+        let data: Vec<u8> = [discriminator, id_byte, body].concat();
+        let accounts = fixture_accounts_shared_v2();
+
+        let parsed = parse_jupiter_swap_instruction(&data, &accounts).unwrap();
+
+        match &parsed {
+            JupiterSwapInstruction::SharedAccountsRouteV2 {
+                in_token,
+                out_token,
+                slippage_bps,
+                platform_fee_bps,
+                positive_slippage_bps,
+            } => {
+                assert_eq!(*slippage_bps, 50);
+                assert_eq!(*platform_fee_bps, 10);
+                assert_eq!(*positive_slippage_bps, 5);
+                // source_mint at accounts[6], destination_mint at accounts[7]
+                assert_eq!(in_token.as_ref().unwrap().amount, 2_000_000);
+                assert_eq!(out_token.as_ref().unwrap().amount, 1_550_653);
+            }
+            _ => panic!("Expected SharedAccountsRouteV2, got {parsed:?}"),
+        }
+
+        let formatted = format_jupiter_swap_instruction(&parsed);
+        assert!(formatted.contains("Jupiter Shared Accounts Route V2"));
+        assert!(formatted.contains("platform fee: 10bps"));
+        assert!(formatted.contains("positive slippage: 5bps"));
+    }
+
+    #[test]
+    fn test_jupiter_shared_accounts_exact_out_route_v2_parsing() {
+        // shared_accounts_exact_out_route_v2 discriminator: [53, 96, 229, 202, 216, 187, 250, 24]
+        let discriminator = hex::decode("3560e5cad8bbfa18").expect("valid hex");
+        let id_byte = vec![0x00u8];
+        // For exact_out: first u64 is out_amount, second is quoted_in_amount.
+        let body = build_route_v2_body(2_000_000, 1_550_653, 50, 0, 0);
+        let data: Vec<u8> = [discriminator, id_byte, body].concat();
+        let accounts = fixture_accounts_shared_v2();
+
+        let parsed = parse_jupiter_swap_instruction(&data, &accounts).unwrap();
+
+        match &parsed {
+            JupiterSwapInstruction::SharedAccountsExactOutRouteV2 {
+                in_token,
+                out_token,
+                ..
+            } => {
+                // in_token gets quoted_in_amount, out_token gets out_amount
+                assert_eq!(in_token.as_ref().unwrap().amount, 1_550_653);
+                assert_eq!(out_token.as_ref().unwrap().amount, 2_000_000);
+            }
+            _ => panic!("Expected SharedAccountsExactOutRouteV2, got {parsed:?}"),
+        }
+
+        let formatted = format_jupiter_swap_instruction(&parsed);
+        assert!(formatted.contains("Jupiter Shared Accounts Exact Out Route V2"));
     }
 }


### PR DESCRIPTION
## Why this PR exists

Jupiter's `route_v2` family of instructions (`route_v2`, `exact_out_route_v2`, `shared_accounts_route_v2`, `shared_accounts_exact_out_route_v2`) is live on mainnet but absent from the IDL bundled inside `solana_parser`. Transactions using these instructions fail to decode in two places: the `jupiter_swap` visualizer falls through to `Unknown`, and `decode_v0_transfers` aborts the whole-transaction decode with "no matching instruction discriminator". Wallets signing a v2 route see a generic Jupiter blob instead of input/output tokens, slippage, and fees.

## What changed

- Vendored the current Jupiter v6 IDL as `jupiter_swap/jupiter_agg_v6.json`, decoded via `include_str!` instead of `solana_parser::ProgramType::JupiterAggregatorV6`. New instructions can land here without bumping `solana_parser`.
- Added four `JupiterSwapInstruction` variants (`RouteV2`, `ExactOutRouteV2`, `SharedAccountsRouteV2`, `SharedAccountsExactOutRouteV2`) and a single `parse_route_v2` helper. `exact_out` toggles `in_amount`/`quoted_out_amount` vs `out_amount`/`quoted_in_amount`; `shared` shifts the source/destination mint indices from (3, 4) to (6, 7) per the IDL.
- `format_jupiter_swap_instruction` and `create_jupiter_swap_expanded_fields` collapse the four v2 variants into a single or-pattern arm that emits Input/Output Token, Slippage, optional Platform Fee, and optional Positive Slippage fields.
- `decode_v0_transfers` injects the local IDL into `solana_parser::parse_transaction` via the `custom_idls` map, so the whole-transaction decode picks up the same instruction set the visualizer uses.

## Why this is safe

- Display-only path. No changes to signing, custody, or settlement — this only affects how a Jupiter v6 transaction is rendered in the VisualSign payload before the user signs.
- Backward compatible. Existing variants (`Route`, `ExactOutRoute`, `SharedAccountsRoute`, `SharedAccountsExactOutRoute`) are untouched, and the local IDL is a superset of the bundled upstream copy — any instruction that decoded before still decodes.
- Variant-specific byte layout is pinned by the four new unit tests, including the leading `id_byte` for shared variants and the swapped in/out semantics for `exact_out`.
- Workspace clippy denials honored: no `unwrap_used`, `expect_used`, `panic`, or `unsafe_code` in non-test code.
- IDL-drift risk acknowledged: if Jupiter ships a `route_v3`, this preset falls back to `Unknown` rather than misdecode — the same behavior we had with v2 before this PR.

### Checks run (by agent)

- `make -C src build` — green
- `make -C src lint` (clippy `-D warnings`) — clean
- `make -C src test` — full workspace suite green
- `cargo test -p visualsign-solana jupiter` — all 13 jupiter tests pass, including the 4 new v2 tests

### Manual steps needed (by human)

None — fully automated by CI. **Risk: low.**

## How this is maintainable

- Vendoring the IDL means future Jupiter additions are a JSON refresh + handler addition in this repo, not a `solana_parser` rev bump.
- `parse_route_v2` takes two booleans (`exact_out`, `shared`) so all four v2 variants share one decode path; reading any one of the new tests reveals the shape of the rest.
- The four new tests pin exact byte layout per variant; an IDL refresh that breaks decoding trips them immediately.
- The doc comment on `JUPITER_IDL_JSON` documents the dual purpose (visualizer + `decode_v0_transfers` override) so a future contributor does not silently drop the `pub(crate)` constant when refactoring the visualizer.