### PR TITLE
feat: add MetaDAO Conditional Vault Solana preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/config.rs
@@ -1,0 +1,22 @@
+use super::METADAO_CONDITIONAL_VAULT_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct MetadaoConditionalVaultConfig;
+
+impl SolanaIntegrationConfig for MetadaoConditionalVaultConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(METADAO_CONDITIONAL_VAULT_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/metadao_conditional_vault.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/metadao_conditional_vault.json
@@ -1,0 +1,926 @@
+{
+  "accounts": [
+    {
+      "name": "ConditionalVault",
+      "type": {
+        "fields": [
+          {
+            "name": "question",
+            "type": "publicKey"
+          },
+          {
+            "name": "underlyingTokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "underlyingTokenAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "conditionalTokenMints",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "pdaBump",
+            "type": "u8"
+          },
+          {
+            "name": "decimals",
+            "type": "u8"
+          },
+          {
+            "name": "seqNum",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Questions represent statements about future events.",
+        "",
+        "These statements include:",
+        "- \"Will this proposal pass?\"",
+        "- \"Who, if anyone, will be hired?\"",
+        "- \"How effective will the grant committee deem this grant?\"",
+        "",
+        "Questions have 2 or more possible outcomes. For a question like \"will this",
+        "proposal pass,\" the outcomes are \"yes\" and \"no.\" For a question like \"who",
+        "will be hired,\" the outcomes could be \"Alice,\" \"Bob,\" and \"neither.\"",
+        "",
+        "Outcomes resolve to a number between 0 and 1. Binary questions like \"will",
+        "this proposal pass\" have outcomes that resolve to exactly 0 or 1. You can",
+        "also have questions with scalar outcomes. For example, the question \"how",
+        "effective will the grant committee deem this grant\" could have two outcomes:",
+        "\"ineffective\" and \"effective.\" If the grant committee deems the grant 70%",
+        "effective, the \"effective\" outcome would resolve to 0.7 and the \"ineffective\"",
+        "outcome would resolve to 0.3.",
+        "",
+        "Once resolved, the sum of all outcome resolutions is exactly 1."
+      ],
+      "name": "Question",
+      "type": {
+        "fields": [
+          {
+            "name": "questionId",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "oracle",
+            "type": "publicKey"
+          },
+          {
+            "name": "payoutNumerators",
+            "type": {
+              "vec": "u32"
+            }
+          },
+          {
+            "name": "payoutDenominator",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "msg": "An assertion failed",
+      "name": "AssertFailed"
+    },
+    {
+      "code": 6001,
+      "msg": "Insufficient underlying token balance to mint this amount of conditional tokens",
+      "name": "InsufficientUnderlyingTokens"
+    },
+    {
+      "code": 6002,
+      "msg": "Insufficient conditional token balance to merge this `amount`",
+      "name": "InsufficientConditionalTokens"
+    },
+    {
+      "code": 6003,
+      "msg": "This `vault_underlying_token_account` is not this vault's `underlying_token_account`",
+      "name": "InvalidVaultUnderlyingTokenAccount"
+    },
+    {
+      "code": 6004,
+      "msg": "This conditional token mint is not this vault's conditional token mint",
+      "name": "InvalidConditionalTokenMint"
+    },
+    {
+      "code": 6005,
+      "msg": "Question needs to be resolved before users can redeem conditional tokens for underlying tokens",
+      "name": "CantRedeemConditionalTokens"
+    },
+    {
+      "code": 6006,
+      "msg": "Questions need 2 or more conditions",
+      "name": "InsufficientNumConditions"
+    },
+    {
+      "code": 6007,
+      "msg": "Invalid number of payout numerators",
+      "name": "InvalidNumPayoutNumerators"
+    },
+    {
+      "code": 6008,
+      "msg": "Client needs to pass in the list of conditional mints for a vault followed by the user's token accounts for those tokens",
+      "name": "InvalidConditionals"
+    },
+    {
+      "code": 6009,
+      "msg": "Conditional mint not in vault",
+      "name": "ConditionalMintMismatch"
+    },
+    {
+      "code": 6010,
+      "msg": "Unable to deserialize a conditional token mint",
+      "name": "BadConditionalMint"
+    },
+    {
+      "code": 6011,
+      "msg": "Unable to deserialize a conditional token account",
+      "name": "BadConditionalTokenAccount"
+    },
+    {
+      "code": 6012,
+      "msg": "User conditional token account mint does not match conditional mint",
+      "name": "ConditionalTokenMintMismatch"
+    },
+    {
+      "code": 6013,
+      "msg": "Payouts must sum to 1 or more",
+      "name": "PayoutZero"
+    },
+    {
+      "code": 6014,
+      "msg": "Question already resolved",
+      "name": "QuestionAlreadyResolved"
+    },
+    {
+      "code": 6015,
+      "msg": "Conditional token metadata already set",
+      "name": "ConditionalTokenMetadataAlreadySet"
+    },
+    {
+      "code": 6016,
+      "msg": "Conditional token account is not owned by the authority",
+      "name": "UnauthorizedConditionalTokenAccount"
+    },
+    {
+      "code": 6017,
+      "msg": "Payout numerators are too large, causing an overflow",
+      "name": "InvalidPayoutNumerators"
+    },
+    {
+      "code": 6018,
+      "msg": "Questions can only have up to 10 outcomes",
+      "name": "TooManyOutcomes"
+    }
+  ],
+  "events": [
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "vault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "conditionalTokenMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "conditionalTokenMetadata",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "index": false,
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "index": false,
+          "name": "uri",
+          "type": "string"
+        },
+        {
+          "index": false,
+          "name": "seqNum",
+          "type": "u64"
+        }
+      ],
+      "name": "AddMetadataToConditionalTokensEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "vault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "question",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "underlyingTokenMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "vaultUnderlyingTokenAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "conditionalTokenMints",
+          "type": {
+            "vec": "publicKey"
+          }
+        },
+        {
+          "index": false,
+          "name": "pdaBump",
+          "type": "u8"
+        },
+        {
+          "index": false,
+          "name": "seqNum",
+          "type": "u64"
+        }
+      ],
+      "name": "InitializeConditionalVaultEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "questionId",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "index": false,
+          "name": "oracle",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "numOutcomes",
+          "type": "u8"
+        },
+        {
+          "index": false,
+          "name": "question",
+          "type": "publicKey"
+        }
+      ],
+      "name": "InitializeQuestionEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "user",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "vault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postUserUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postVaultUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postUserConditionalTokenBalances",
+          "type": {
+            "vec": "u64"
+          }
+        },
+        {
+          "index": false,
+          "name": "postConditionalTokenSupplies",
+          "type": {
+            "vec": "u64"
+          }
+        },
+        {
+          "index": false,
+          "name": "seqNum",
+          "type": "u64"
+        }
+      ],
+      "name": "MergeTokensEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "user",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "vault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postUserUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postVaultUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postConditionalTokenSupplies",
+          "type": {
+            "vec": "u64"
+          }
+        },
+        {
+          "index": false,
+          "name": "seqNum",
+          "type": "u64"
+        }
+      ],
+      "name": "RedeemTokensEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "question",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "payoutNumerators",
+          "type": {
+            "vec": "u32"
+          }
+        }
+      ],
+      "name": "ResolveQuestionEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "user",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "vault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postUserUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postVaultUnderlyingBalance",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postUserConditionalTokenBalances",
+          "type": {
+            "vec": "u64"
+          }
+        },
+        {
+          "index": false,
+          "name": "postConditionalTokenSupplies",
+          "type": {
+            "vec": "u64"
+          }
+        },
+        {
+          "index": false,
+          "name": "seqNum",
+          "type": "u64"
+        }
+      ],
+      "name": "SplitTokensEvent"
+    }
+  ],
+  "instructions": [
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "InitializeQuestionArgs"
+          }
+        }
+      ],
+      "name": "initializeQuestion"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "oracle"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "ResolveQuestionArgs"
+          }
+        }
+      ],
+      "name": "resolveQuestion"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "underlyingTokenMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "associatedTokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "initializeConditionalVault"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "authority"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "name": "splitTokens"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "authority"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "name": "mergeTokens"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "authority"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "redeemTokens"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "vault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "conditionalTokenMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "conditionalTokenMetadata"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenMetadataProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "rent"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "AddMetadataToConditionalTokensArgs"
+          }
+        }
+      ],
+      "name": "addMetadataToConditionalTokens"
+    }
+  ],
+  "name": "conditional_vault",
+  "types": [
+    {
+      "name": "CommonFields",
+      "type": {
+        "fields": [
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "unixTimestamp",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "AddMetadataToConditionalTokensArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "uri",
+            "type": "string"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InitializeQuestionArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "questionId",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "oracle",
+            "type": "publicKey"
+          },
+          {
+            "name": "numOutcomes",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "ResolveQuestionArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "payoutNumerators",
+            "type": {
+              "vec": "u32"
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ],
+  "version": "0.4.0"
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/mod.rs
@@ -1,0 +1,266 @@
+//! MetaDAO Conditional Vault preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::MetadaoConditionalVaultConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const METADAO_CONDITIONAL_VAULT_PROGRAM_ID: &str =
+    "VLTX1ishMBbcX3rdBWGssxawAo1Q2X2qxYFYqiGodVg";
+
+const DISPLAY_NAME: &str = "MetaDAO Conditional Vault";
+
+const IDL_JSON: &str = include_str!("metadao_conditional_vault.json");
+
+static CONFIG: MetadaoConditionalVaultConfig = MetadaoConditionalVaultConfig;
+
+pub struct MetadaoConditionalVaultVisualizer;
+
+impl InstructionVisualizer for MetadaoConditionalVaultVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        if instruction.data.len() < 8 {
+            return Err(VisualSignError::DecodeError(
+                "Instruction data too short for Anchor discriminator".to_string(),
+            ));
+        }
+
+        let idl = load_idl()?;
+        let parsed = parse_instruction_with_idl(
+            &instruction.data,
+            METADAO_CONDITIONAL_VAULT_PROGRAM_ID,
+            &idl,
+        )
+        .map_err(|e| VisualSignError::DecodeError(format!("IDL parse failed: {e}")))?;
+
+        let named_accounts = build_named_accounts(&idl, &instruction.data, &instruction.accounts);
+
+        build_visualization(context, instruction, &parsed, &named_accounts)
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(DISPLAY_NAME)
+    }
+}
+
+fn load_idl() -> Result<Idl, VisualSignError> {
+    decode_idl_data(IDL_JSON)
+        .map_err(|e| VisualSignError::DecodeError(format!("Failed to decode bundled IDL: {e}")))
+}
+
+fn build_named_accounts(
+    idl: &Idl,
+    instruction_data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named = HashMap::new();
+    if instruction_data.len() < 8 {
+        return named;
+    }
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| &instruction_data[0..8] == disc.as_slice())
+    }) else {
+        return named;
+    };
+    for (index, account_meta) in accounts.iter().enumerate() {
+        if let Some(idl_account) = idl_instruction.accounts.get(index) {
+            named.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+        }
+    }
+    named
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+fn build_visualization(
+    context: &VisualizerContext,
+    instruction: &solana_sdk::instruction::Instruction,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+) -> Result<AnnotatedPayloadField, VisualSignError> {
+    let program_id = instruction.program_id.to_string();
+    let title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);
+
+    let condensed_fields = vec![create_text_field("Instruction", &parsed.instruction_name)?];
+
+    let mut expanded_fields = vec![
+        create_text_field("Program", DISPLAY_NAME)?,
+        create_text_field("Program ID", &program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    let mut account_keys: Vec<&String> = named_accounts.keys().collect();
+    account_keys.sort();
+    for key in account_keys {
+        if let Some(addr) = named_accounts.get(key) {
+            expanded_fields.push(create_text_field(key, addr)?);
+        }
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    expanded_fields.push(create_raw_data_field(
+        &instruction.data,
+        Some(hex::encode(&instruction.data)),
+    )?);
+
+    let condensed = SignablePayloadFieldListLayout {
+        fields: condensed_fields,
+    };
+    let expanded = SignablePayloadFieldListLayout {
+        fields: expanded_fields,
+    };
+
+    let preview_layout = SignablePayloadFieldPreviewLayout {
+        title: Some(SignablePayloadFieldTextV2 {
+            text: title.clone(),
+        }),
+        subtitle: Some(SignablePayloadFieldTextV2 {
+            text: String::new(),
+        }),
+        condensed: Some(condensed),
+        expanded: Some(expanded),
+    };
+
+    let fallback_text = format!(
+        "Program ID: {program_id}\nData: {}",
+        hex::encode(&instruction.data)
+    );
+
+    Ok(AnnotatedPayloadField {
+        static_annotation: None,
+        dynamic_annotation: None,
+        signable_payload_field: SignablePayloadField::PreviewLayout {
+            common: SignablePayloadFieldCommon {
+                label: format!("Instruction {}", context.instruction_index() + 1),
+                fallback_text,
+            },
+            preview_layout,
+        },
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+
+    fn dummy_account_metas(count: usize) -> Vec<AccountMeta> {
+        (0..count)
+            .map(|_| AccountMeta::new_readonly(Pubkey::new_unique(), false))
+            .collect()
+    }
+
+    #[test]
+    fn test_metadao_conditional_vault_idl_loads() {
+        let idl = load_idl().expect("IDL must load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should declare at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_metadao_conditional_vault_idl_has_discriminators() {
+        let idl = load_idl().expect("IDL must load");
+        for instruction in &idl.instructions {
+            let discriminator = instruction
+                .discriminator
+                .as_ref()
+                .expect("decode_idl_data must populate every discriminator");
+            assert_eq!(
+                discriminator.len(),
+                8,
+                "discriminator for `{}` should be 8 bytes, got {}",
+                instruction.name,
+                discriminator.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let bogus = [0xFFu8; 9];
+        let result = parse_instruction_with_idl(&bogus, METADAO_CONDITIONAL_VAULT_PROGRAM_ID, &idl);
+        assert!(
+            result.is_err(),
+            "unknown discriminator should fail to parse"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let short = [0x01u8, 0x02, 0x03];
+        let result = parse_instruction_with_idl(&short, METADAO_CONDITIONAL_VAULT_PROGRAM_ID, &idl);
+        assert!(result.is_err(), "data shorter than 8 bytes should error");
+    }
+
+    #[test]
+    fn test_build_named_accounts_matches_idl_account_names() {
+        let idl = load_idl().expect("IDL must load");
+        let split_tokens = idl
+            .instructions
+            .iter()
+            .find(|i| i.name == "splitTokens")
+            .expect("splitTokens instruction present");
+        let discriminator = split_tokens
+            .discriminator
+            .clone()
+            .expect("discriminator computed");
+        let amount: u64 = 42;
+        let mut data = discriminator;
+        data.extend_from_slice(&amount.to_le_bytes());
+
+        let metas = dummy_account_metas(split_tokens.accounts.len());
+        let named = build_named_accounts(&idl, &data, &metas);
+
+        assert_eq!(
+            named.len(),
+            split_tokens.accounts.len(),
+            "every IDL account should be named"
+        );
+        for idl_account in &split_tokens.accounts {
+            assert!(
+                named.contains_key(&idl_account.name),
+                "missing named account `{}`",
+                idl_account.name
+            );
+        }
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_conditional_vault/mod.rs
@@ -9,7 +9,7 @@ use config::MetadaoConditionalVaultConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -74,8 +74,8 @@ fn build_named_accounts(
     idl: &Idl,
     instruction_data: &[u8],
     accounts: &[solana_sdk::instruction::AccountMeta],
-) -> HashMap<String, String> {
-    let mut named = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named = BTreeMap::new();
     if instruction_data.len() < 8 {
         return named;
     }
@@ -106,7 +106,7 @@ fn build_visualization(
     context: &VisualizerContext,
     instruction: &solana_sdk::instruction::Instruction,
     parsed: &SolanaParsedInstructionData,
-    named_accounts: &HashMap<String, String>,
+    named_accounts: &BTreeMap<String, String>,
 ) -> Result<AnnotatedPayloadField, VisualSignError> {
     let program_id = instruction.program_id.to_string();
     let title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -7,6 +7,7 @@ pub mod jupiter_swap;
 pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
+pub mod metadao_conditional_vault;
 pub mod meteora_damm_v2;
 pub mod meteora_dlmm;
 pub mod neutral_trade;


### PR DESCRIPTION
## Why this PR exists

Solana program `VLTX1ishMBbcX3rdBWGssxawAo1Q2X2qxYFYqiGodVg` (MetaDAO Conditional Vault v0.4) powers MetaDAO's futarchy markets, but had no dedicated visualizer. Transactions calling it fell through to the generic `unknown_program` fallback, so signers saw raw program IDs and hex blobs instead of named instructions and accounts.

## What changed

- New `metadao_conditional_vault` preset registered alphabetically in `presets/mod.rs`.
- Bundles the on-chain Anchor IDL (fetched via `anchor-cli idl fetch`) at `presets/metadao_conditional_vault/metadao_conditional_vault.json` (7 instructions: `initializeQuestion`, `resolveQuestion`, `initializeConditionalVault`, `splitTokens`, `mergeTokens`, `redeemTokens`, `addMetadataToConditionalTokens`).
- `MetadaoConditionalVaultVisualizer` follows the generic IDL-driven pattern: load IDL once via `decode_idl_data`, parse args via `parse_instruction_with_idl`, label accounts by IDL position, fall back to the raw-data field. No bespoke decoders.
- Categorized as `VisualizerKind::Dex("MetaDAO Conditional Vault")`.
- 5 unit tests: IDL load, every-instruction-has-8-byte-discriminator, unknown discriminator → error, short data → error, named-account mapping for `splitTokens`.

<img width="1260" height="2348" alt="image" src="https://github.com/user-attachments/assets/cac34473-402b-4033-8cdc-71d8ee0a5bd8" />


## Why this is safe

- New code only — no public API changes, no behavior change for any other preset or chain. The visualizer is auto-discovered by `build.rs` from the directory name.
- The 8-byte discriminator length check runs before parsing, so malformed instruction data returns an error rather than panicking or reading out-of-bounds.
- Unknown discriminators surface as `DecodeError`; the `unknown_program` fallback still handles transactions if this preset ever fails on a future on-chain instruction.
- Workspace-level clippy denials (`unwrap_used`, `expect_used`, `panic`, `unsafe_code`) are upheld in non-test code; `?` and `.ok_or_else(...)` are used throughout.

### Checks run (by agent)

- `cargo build -p visualsign-solana` — clean
- `cargo fmt -p visualsign-solana` — clean
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets -- -D warnings` (workspace) — clean
- `cargo test -p visualsign-solana` — 5 new tests pass; full crate suite green
- `make -C src test` — full workspace green

### Manual steps needed (by human)

- None — fully automated by CI.

## How this is maintainable

- The preset uses the same generic IDL pattern as other Anchor-driven Solana presets, so a fresh reader sees a familiar shape: load IDL, parse, render.
- `build.rs` auto-discovers `MetadaoConditionalVaultVisualizer` from the directory name; the only manual registration is the one-line `pub mod` entry in `presets/mod.rs`, kept alphabetical.
- The four invariants (IDL loads, discriminators are 8 bytes, short data errors, unknown discriminator errors) are pinned by tests, so regressions in `decode_idl_data` / `parse_instruction_with_idl` will fail this crate's suite.
- Refreshing the IDL for a future program version is a one-liner: `docker run --rm anchor-cli-local idl fetch VLTX1ishMBbcX3rdBWGssxawAo1Q2X2qxYFYqiGodVg --provider.cluster mainnet > metadao_conditional_vault.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)