### PR TITLE
feat: add MetaDAO Futarchy Solana preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/config.rs
@@ -1,0 +1,22 @@
+use super::METADAO_FUTARCHY_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct MetadaoFutarchyConfig;
+
+impl SolanaIntegrationConfig for MetadaoFutarchyConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(METADAO_FUTARCHY_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/metadao_futarchy.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/metadao_futarchy.json
@@ -1,0 +1,3772 @@
+{
+  "accounts": [
+    {
+      "name": "AmmPosition",
+      "type": {
+        "fields": [
+          {
+            "name": "dao",
+            "type": "publicKey"
+          },
+          {
+            "name": "positionAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Dao",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Embedded FutarchyAmm - 1:1 relationship"
+            ],
+            "name": "amm",
+            "type": {
+              "defined": "FutarchyAmm"
+            }
+          },
+          {
+            "docs": [
+              "`nonce` + `dao_creator` are PDA seeds"
+            ],
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "daoCreator",
+            "type": "publicKey"
+          },
+          {
+            "name": "pdaBump",
+            "type": "u8"
+          },
+          {
+            "name": "squadsMultisig",
+            "type": "publicKey"
+          },
+          {
+            "name": "squadsMultisigVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "proposalCount",
+            "type": "u32"
+          },
+          {
+            "name": "passThresholdBps",
+            "type": "u16"
+          },
+          {
+            "name": "secondsPerProposal",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "For manipulation-resistance the TWAP is a time-weighted average observation,",
+              "where observation tries to approximate price but can only move by",
+              "`twap_max_observation_change_per_update` per update. Because it can only move",
+              "a little bit per update, you need to check that it has a good initial observation.",
+              "Otherwise, an attacker could create a very high initial observation in the pass",
+              "market and a very low one in the fail market to force the proposal to pass.",
+              "",
+              "We recommend setting an initial observation around the spot price of the token,",
+              "and max observation change per update around 2% the spot price of the token.",
+              "For example, if the spot price of META is $400, we'd recommend setting an initial",
+              "observation of 400 (converted into the AMM prices) and a max observation change per",
+              "update of 8 (also converted into the AMM prices). Observations can be updated once",
+              "a minute, so 2% allows the proposal market to reach double the spot price or 0",
+              "in 50 minutes."
+            ],
+            "name": "twapInitialObservation",
+            "type": "u128"
+          },
+          {
+            "name": "twapMaxObservationChangePerUpdate",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "Forces TWAP calculation to start after `twap_start_delay_seconds` seconds"
+            ],
+            "name": "twapStartDelaySeconds",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "As an anti-spam measure and to help liquidity, you need to lock up some liquidity",
+              "in both futarchic markets in order to create a proposal.",
+              "",
+              "For example, for META, we can use a `min_quote_futarchic_liquidity` of",
+              "5000 * 1_000_000 (5000 USDC) and a `min_base_futarchic_liquidity` of",
+              "10 * 1_000_000_000 (10 META)."
+            ],
+            "name": "minQuoteFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "name": "minBaseFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Minimum amount of base tokens that must be staked to launch a proposal"
+            ],
+            "name": "baseToStake",
+            "type": "u64"
+          },
+          {
+            "name": "seqNum",
+            "type": "u64"
+          },
+          {
+            "name": "initialSpendingLimit",
+            "type": {
+              "option": {
+                "defined": "InitialSpendingLimit"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The percentage, in basis points, the pass price needs to be above the",
+              "fail price in order for the proposal to pass for team-sponsored proposals.",
+              "",
+              "Can be negative to allow for team-sponsored proposals to pass by default."
+            ],
+            "name": "teamSponsoredPassThresholdBps",
+            "type": "i16"
+          },
+          {
+            "name": "teamAddress",
+            "type": "publicKey"
+          },
+          {
+            "name": "optimisticProposal",
+            "type": {
+              "option": {
+                "defined": "OptimisticProposal"
+              }
+            }
+          },
+          {
+            "name": "isOptimisticGovernanceEnabled",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "OldDao",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Embedded FutarchyAmm - 1:1 relationship"
+            ],
+            "name": "amm",
+            "type": {
+              "defined": "FutarchyAmm"
+            }
+          },
+          {
+            "docs": [
+              "`nonce` + `dao_creator` are PDA seeds"
+            ],
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "daoCreator",
+            "type": "publicKey"
+          },
+          {
+            "name": "pdaBump",
+            "type": "u8"
+          },
+          {
+            "name": "squadsMultisig",
+            "type": "publicKey"
+          },
+          {
+            "name": "squadsMultisigVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "proposalCount",
+            "type": "u32"
+          },
+          {
+            "name": "passThresholdBps",
+            "type": "u16"
+          },
+          {
+            "name": "secondsPerProposal",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "For manipulation-resistance the TWAP is a time-weighted average observation,",
+              "where observation tries to approximate price but can only move by",
+              "`twap_max_observation_change_per_update` per update. Because it can only move",
+              "a little bit per update, you need to check that it has a good initial observation.",
+              "Otherwise, an attacker could create a very high initial observation in the pass",
+              "market and a very low one in the fail market to force the proposal to pass.",
+              "",
+              "We recommend setting an initial observation around the spot price of the token,",
+              "and max observation change per update around 2% the spot price of the token.",
+              "For example, if the spot price of META is $400, we'd recommend setting an initial",
+              "observation of 400 (converted into the AMM prices) and a max observation change per",
+              "update of 8 (also converted into the AMM prices). Observations can be updated once",
+              "a minute, so 2% allows the proposal market to reach double the spot price or 0",
+              "in 50 minutes."
+            ],
+            "name": "twapInitialObservation",
+            "type": "u128"
+          },
+          {
+            "name": "twapMaxObservationChangePerUpdate",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "Forces TWAP calculation to start after `twap_start_delay_seconds` seconds"
+            ],
+            "name": "twapStartDelaySeconds",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "As an anti-spam measure and to help liquidity, you need to lock up some liquidity",
+              "in both futarchic markets in order to create a proposal.",
+              "",
+              "For example, for META, we can use a `min_quote_futarchic_liquidity` of",
+              "5000 * 1_000_000 (5000 USDC) and a `min_base_futarchic_liquidity` of",
+              "10 * 1_000_000_000 (10 META)."
+            ],
+            "name": "minQuoteFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "name": "minBaseFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Minimum amount of base tokens that must be staked to launch a proposal"
+            ],
+            "name": "baseToStake",
+            "type": "u64"
+          },
+          {
+            "name": "seqNum",
+            "type": "u64"
+          },
+          {
+            "name": "initialSpendingLimit",
+            "type": {
+              "option": {
+                "defined": "InitialSpendingLimit"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The percentage, in basis points, the pass price needs to be above the",
+              "fail price in order for the proposal to pass for team-sponsored proposals.",
+              "",
+              "Can be negative to allow for team-sponsored proposals to pass by default."
+            ],
+            "name": "teamSponsoredPassThresholdBps",
+            "type": "i16"
+          },
+          {
+            "name": "teamAddress",
+            "type": "publicKey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Proposal",
+      "type": {
+        "fields": [
+          {
+            "name": "number",
+            "type": "u32"
+          },
+          {
+            "name": "proposer",
+            "type": "publicKey"
+          },
+          {
+            "name": "timestampEnqueued",
+            "type": "i64"
+          },
+          {
+            "name": "state",
+            "type": {
+              "defined": "ProposalState"
+            }
+          },
+          {
+            "name": "baseVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "dao",
+            "type": "publicKey"
+          },
+          {
+            "name": "pdaBump",
+            "type": "u8"
+          },
+          {
+            "name": "question",
+            "type": "publicKey"
+          },
+          {
+            "name": "durationInSeconds",
+            "type": "u32"
+          },
+          {
+            "name": "squadsProposal",
+            "type": "publicKey"
+          },
+          {
+            "name": "passBaseMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "passQuoteMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "failBaseMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "failQuoteMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "isTeamSponsored",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "StakeAccount",
+      "type": {
+        "fields": [
+          {
+            "name": "proposal",
+            "type": "publicKey"
+          },
+          {
+            "name": "staker",
+            "type": "publicKey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "msg": "Amms must have been created within 5 minutes (counted in slots) of proposal initialization",
+      "name": "AmmTooOld"
+    },
+    {
+      "code": 6001,
+      "msg": "An amm has an `initial_observation` that doesn't match the `dao`'s config",
+      "name": "InvalidInitialObservation"
+    },
+    {
+      "code": 6002,
+      "msg": "An amm has a `max_observation_change_per_update` that doesn't match the `dao`'s config",
+      "name": "InvalidMaxObservationChange"
+    },
+    {
+      "code": 6003,
+      "msg": "An amm has a `start_delay_slots` that doesn't match the `dao`'s config",
+      "name": "InvalidStartDelaySlots"
+    },
+    {
+      "code": 6004,
+      "msg": "One of the vaults has an invalid `settlement_authority`",
+      "name": "InvalidSettlementAuthority"
+    },
+    {
+      "code": 6005,
+      "msg": "Proposal is too young to be executed or rejected",
+      "name": "ProposalTooYoung"
+    },
+    {
+      "code": 6006,
+      "msg": "Markets too young for proposal to be finalized. TWAP might need to be cranked",
+      "name": "MarketsTooYoung"
+    },
+    {
+      "code": 6007,
+      "msg": "This proposal has already been finalized",
+      "name": "ProposalAlreadyFinalized"
+    },
+    {
+      "code": 6008,
+      "msg": "A conditional vault has an invalid nonce. A nonce should encode the proposal number",
+      "name": "InvalidVaultNonce"
+    },
+    {
+      "code": 6009,
+      "msg": "This proposal can't be executed because it isn't in the passed state",
+      "name": "ProposalNotPassed"
+    },
+    {
+      "code": 6010,
+      "msg": "More liquidity needs to be in the AMM to launch this proposal",
+      "name": "InsufficientLiquidity"
+    },
+    {
+      "code": 6011,
+      "msg": "Proposal duration must be longer 1 day and longer than 2 times the TWAP start delay",
+      "name": "ProposalDurationTooShort"
+    },
+    {
+      "code": 6012,
+      "msg": "Pass threshold must be less than 10%",
+      "name": "PassThresholdTooHigh"
+    },
+    {
+      "code": 6013,
+      "msg": "Question must have exactly 2 outcomes for binary futarchy",
+      "name": "QuestionMustBeBinary"
+    },
+    {
+      "code": 6014,
+      "msg": "Squads proposal must be in Active status",
+      "name": "InvalidSquadsProposalStatus"
+    },
+    {
+      "code": 6015,
+      "msg": "Casting overflow. If you're seeing this, please report this",
+      "name": "CastingOverflow"
+    },
+    {
+      "code": 6016,
+      "msg": "Insufficient balance",
+      "name": "InsufficientBalance"
+    },
+    {
+      "code": 6017,
+      "msg": "Cannot remove zero liquidity",
+      "name": "ZeroLiquidityRemove"
+    },
+    {
+      "code": 6018,
+      "msg": "Swap slippage exceeded",
+      "name": "SwapSlippageExceeded"
+    },
+    {
+      "code": 6019,
+      "msg": "Assert failed",
+      "name": "AssertFailed"
+    },
+    {
+      "code": 6020,
+      "msg": "Invalid admin",
+      "name": "InvalidAdmin"
+    },
+    {
+      "code": 6021,
+      "msg": "Proposal is not in draft state",
+      "name": "ProposalNotInDraftState"
+    },
+    {
+      "code": 6022,
+      "msg": "Insufficient token balance",
+      "name": "InsufficientTokenBalance"
+    },
+    {
+      "code": 6023,
+      "msg": "Invalid amount",
+      "name": "InvalidAmount"
+    },
+    {
+      "code": 6024,
+      "msg": "Insufficient stake to launch proposal",
+      "name": "InsufficientStakeToLaunch"
+    },
+    {
+      "code": 6025,
+      "msg": "Staker not found in proposal",
+      "name": "StakerNotFound"
+    },
+    {
+      "code": 6026,
+      "msg": "Pool must be in spot state",
+      "name": "PoolNotInSpotState"
+    },
+    {
+      "code": 6027,
+      "msg": "If you're providing liquidity, you must provide both base and quote token accounts",
+      "name": "InvalidDaoCreateLiquidity"
+    },
+    {
+      "code": 6028,
+      "msg": "Invalid stake account",
+      "name": "InvalidStakeAccount"
+    },
+    {
+      "code": 6029,
+      "msg": "An invariant was violated. You should get in contact with the MetaDAO team if you see this",
+      "name": "InvariantViolated"
+    },
+    {
+      "code": 6030,
+      "msg": "Proposal needs to be active to perform a conditional swap",
+      "name": "ProposalNotActive"
+    },
+    {
+      "code": 6031,
+      "msg": "This Squads transaction should only contain calls to update spending limits",
+      "name": "InvalidTransaction"
+    },
+    {
+      "code": 6032,
+      "msg": "Proposal has already been sponsored",
+      "name": "ProposalAlreadySponsored"
+    },
+    {
+      "code": 6033,
+      "msg": "Team sponsored pass threshold must be between -10% and 10%",
+      "name": "InvalidTeamSponsoredPassThreshold"
+    },
+    {
+      "code": 6034,
+      "msg": "Target K must be greater than the current K",
+      "name": "InvalidTargetK"
+    },
+    {
+      "code": 6035,
+      "msg": "Failed to compile transaction message for Squads vault transaction",
+      "name": "InvalidTransactionMessage"
+    },
+    {
+      "code": 6036,
+      "msg": "Base mint and quote mint must be different",
+      "name": "InvalidMint"
+    },
+    {
+      "code": 6037,
+      "msg": "Proposal is not ready to be unstaked",
+      "name": "ProposalNotReadyToUnstake"
+    },
+    {
+      "code": 6038,
+      "msg": "Optimistic governance is disabled",
+      "name": "OptimisticGovernanceDisabled"
+    },
+    {
+      "code": 6039,
+      "msg": "An active optimistic proposal is already enqueued",
+      "name": "ActiveOptimisticProposalAlreadyEnqueued"
+    },
+    {
+      "code": 6040,
+      "msg": "Optimistic proposal has already passed",
+      "name": "OptimisticProposalAlreadyPassed"
+    },
+    {
+      "code": 6041,
+      "msg": "Invalid spending limit mint. Must be the same as the DAO's quote mint",
+      "name": "InvalidSpendingLimitMint"
+    },
+    {
+      "code": 6042,
+      "msg": "No active optimistic proposal",
+      "name": "NoActiveOptimisticProposal"
+    }
+  ],
+  "events": [
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseTokenAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteTokenAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "ammBaseVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "ammQuoteVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteFeesCollected",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseFeesCollected",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "CollectFeesEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "passThresholdBps",
+          "type": "u16"
+        },
+        {
+          "index": false,
+          "name": "secondsPerProposal",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "twapInitialObservation",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "twapMaxObservationChangePerUpdate",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "twapStartDelaySeconds",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "minQuoteFutarchicLiquidity",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "minBaseFutarchicLiquidity",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseToStake",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "initialSpendingLimit",
+          "type": {
+            "option": {
+              "defined": "InitialSpendingLimit"
+            }
+          }
+        },
+        {
+          "index": false,
+          "name": "squadsMultisig",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisigVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "teamSponsoredPassThresholdBps",
+          "type": "i16"
+        },
+        {
+          "index": false,
+          "name": "teamAddress",
+          "type": "publicKey"
+        }
+      ],
+      "name": "InitializeDaoEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "passThresholdBps",
+          "type": "u16"
+        },
+        {
+          "index": false,
+          "name": "secondsPerProposal",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "twapInitialObservation",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "twapMaxObservationChangePerUpdate",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "twapStartDelaySeconds",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "minQuoteFutarchicLiquidity",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "minBaseFutarchicLiquidity",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseToStake",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "teamSponsoredPassThresholdBps",
+          "type": "i16"
+        },
+        {
+          "index": false,
+          "name": "teamAddress",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "isOptimisticGovernanceEnabled",
+          "type": "bool"
+        }
+      ],
+      "name": "UpdateDaoEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "question",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "proposer",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "number",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "pdaBump",
+          "type": "u8"
+        },
+        {
+          "index": false,
+          "name": "durationInSeconds",
+          "type": "u32"
+        },
+        {
+          "index": false,
+          "name": "squadsProposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisig",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisigVault",
+          "type": "publicKey"
+        }
+      ],
+      "name": "InitializeProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "staker",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "totalStaked",
+          "type": "u64"
+        }
+      ],
+      "name": "StakeToProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "staker",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "totalStaked",
+          "type": "u64"
+        }
+      ],
+      "name": "UnstakeFromProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "timestampEnqueued",
+          "type": "i64"
+        },
+        {
+          "index": false,
+          "name": "totalStaked",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "LaunchProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "passMarketTwap",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "failMarketTwap",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "threshold",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "state",
+          "type": {
+            "defined": "ProposalState"
+          }
+        },
+        {
+          "index": false,
+          "name": "squadsProposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisig",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        },
+        {
+          "index": false,
+          "name": "isTeamSponsored",
+          "type": "bool"
+        }
+      ],
+      "name": "FinalizeProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "user",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "swapType",
+          "type": {
+            "defined": "SwapType"
+          }
+        },
+        {
+          "index": false,
+          "name": "inputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "outputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "minOutputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "SpotSwapEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "trader",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "market",
+          "type": {
+            "defined": "Market"
+          }
+        },
+        {
+          "index": false,
+          "name": "swapType",
+          "type": {
+            "defined": "SwapType"
+          }
+        },
+        {
+          "index": false,
+          "name": "inputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "outputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "minOutputAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "ConditionalSwapEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "liquidityProvider",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "positionAuthority",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "liquidityMinted",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "minLiquidity",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "ProvideLiquidityEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "liquidityProvider",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "liquidityWithdrawn",
+          "type": "u128"
+        },
+        {
+          "index": false,
+          "name": "minBaseAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "minQuoteAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "quoteAmount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "WithdrawLiquidityEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "teamAddress",
+          "type": "publicKey"
+        }
+      ],
+      "name": "SponsorProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "admin",
+          "type": "publicKey"
+        }
+      ],
+      "name": "RemoveProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "proposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "admin",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "postAmmState",
+          "type": {
+            "defined": "FutarchyAmm"
+          }
+        }
+      ],
+      "name": "AdminCancelProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "pool",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseTokenAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteTokenAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "baseMint",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "quoteFeesCollected",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "baseFeesCollected",
+          "type": "u64"
+        }
+      ],
+      "name": "CollectMeteoraDammFeesEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "admin",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "ammPosition",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "oldAuthority",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "newAuthority",
+          "type": "publicKey"
+        }
+      ],
+      "name": "AdminFixPositionAuthorityEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "proposer",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsProposal",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisig",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsMultisigVault",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "index": false,
+          "name": "recipient",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "daoQuoteVaultAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "recipientQuoteAccount",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "enqueuedTimestamp",
+          "type": "i64"
+        }
+      ],
+      "name": "InitiateVaultSpendOptimisticProposalEvent"
+    },
+    {
+      "fields": [
+        {
+          "index": false,
+          "name": "common",
+          "type": {
+            "defined": "CommonFields"
+          }
+        },
+        {
+          "index": false,
+          "name": "dao",
+          "type": "publicKey"
+        },
+        {
+          "index": false,
+          "name": "squadsProposal",
+          "type": "publicKey"
+        }
+      ],
+      "name": "FinalizeOptimisticProposalEvent"
+    }
+  ],
+  "instructions": [
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "daoCreator"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "baseMint"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "quoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProgramConfig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsProgramConfigTreasury"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "spendingLimit"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "futarchyAmmBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "futarchyAmmQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "associatedTokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "InitializeDaoParams"
+          }
+        }
+      ],
+      "name": "initializeDao"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "quoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "baseVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "proposer"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "initializeProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "stakerBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposalBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "stakeAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "staker"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "StakeToProposalParams"
+          }
+        }
+      ],
+      "name": "stakeToProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "stakerBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposalBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "stakeAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "baseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "staker"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "associatedTokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "UnstakeFromProposalParams"
+          }
+        }
+      ],
+      "name": "unstakeFromProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "baseVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "quoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "passBaseMint"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "passQuoteMint"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "failBaseMint"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "failQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "associatedTokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "launchProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigProgram"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultEventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "finalizeProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "squadsMultisigVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "daoParams",
+          "type": {
+            "defined": "UpdateDaoParams"
+          }
+        }
+      ],
+      "name": "updateDao"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        }
+      ],
+      "args": [],
+      "name": "resizeDao"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userQuoteAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "user"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "SpotSwapParams"
+          }
+        }
+      ],
+      "name": "spotSwap"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "trader"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userInputAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "userOutputAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failQuoteMint"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "conditionalVaultProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultEventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "ConditionalSwapParams"
+          }
+        }
+      ],
+      "name": "conditionalSwap"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "liquidityProvider"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "liquidityProviderBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "liquidityProviderQuoteAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "payer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPosition"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "ProvideLiquidityParams"
+          }
+        }
+      ],
+      "name": "provideLiquidity"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "positionAuthority"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "liquidityProviderBaseAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "liquidityProviderQuoteAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPosition"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "WithdrawLiquidityParams"
+          }
+        }
+      ],
+      "name": "withdrawLiquidity"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "collectFees"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultTransaction"
+        }
+      ],
+      "args": [],
+      "name": "executeSpendingLimitChange"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "teamAddress"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "sponsorProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigVaultTransaction"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "squadsMultisigPermissionlessAccount"
+        },
+        {
+          "accounts": [
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "dammV2Program"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "dammV2EventAuthority"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "poolAuthority"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "pool"
+            },
+            {
+              "isMut": true,
+              "isSigner": false,
+              "name": "position"
+            },
+            {
+              "docs": [
+                "Token account of base tokens recipient"
+              ],
+              "isMut": true,
+              "isSigner": false,
+              "name": "tokenAAccount"
+            },
+            {
+              "docs": [
+                "Token account of quote tokens recipient"
+              ],
+              "isMut": true,
+              "isSigner": false,
+              "name": "tokenBAccount"
+            },
+            {
+              "isMut": true,
+              "isSigner": false,
+              "name": "tokenAVault"
+            },
+            {
+              "isMut": true,
+              "isSigner": false,
+              "name": "tokenBVault"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "tokenAMint"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "tokenBMint"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "positionNftAccount"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "owner"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "tokenAProgram"
+            },
+            {
+              "isMut": false,
+              "isSigner": false,
+              "name": "tokenBProgram"
+            }
+          ],
+          "name": "meteoraClaimPositionFeesAccounts"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "systemProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "collectMeteoraDammFees"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsSpendingLimit"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsVaultTransaction"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "daoQuoteVaultAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "proposer"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "recipient"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "recipientQuoteAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": "InitiateVaultSpendOptimisticProposalParams"
+          }
+        }
+      ],
+      "name": "initiateVaultSpendOptimisticProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "finalizeOptimisticProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigProgram"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "AdminApproveMultisigProposalArgs"
+          }
+        }
+      ],
+      "name": "adminApproveMultisigProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigProposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsMultisigVaultTransaction"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigProgram"
+        }
+      ],
+      "args": [],
+      "name": "adminExecuteMultisigProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "question"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "squadsProposal"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisig"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "squadsMultisigProgram"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammPassQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammFailQuoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammBaseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "ammQuoteVault"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultProgram"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "vaultEventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "tokenProgram"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "quoteVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failQuoteMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "passBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "failBaseMint"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVault"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "baseVaultUnderlyingTokenAccount"
+        },
+        {
+          "isMut": false,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "adminCancelProposal"
+    },
+    {
+      "accounts": [
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "proposal"
+        },
+        {
+          "isMut": true,
+          "isSigner": false,
+          "name": "dao"
+        },
+        {
+          "isMut": true,
+          "isSigner": true,
+          "name": "admin"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "eventAuthority"
+        },
+        {
+          "isMut": false,
+          "isSigner": false,
+          "name": "program"
+        }
+      ],
+      "args": [],
+      "name": "adminRemoveProposal"
+    }
+  ],
+  "name": "futarchy",
+  "types": [
+    {
+      "name": "CommonFields",
+      "type": {
+        "fields": [
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "unixTimestamp",
+            "type": "i64"
+          },
+          {
+            "name": "daoSeqNum",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "AdminApproveMultisigProposalArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "transactionIndex",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "ConditionalSwapParams",
+      "type": {
+        "fields": [
+          {
+            "name": "market",
+            "type": {
+              "defined": "Market"
+            }
+          },
+          {
+            "name": "swapType",
+            "type": {
+              "defined": "SwapType"
+            }
+          },
+          {
+            "name": "inputAmount",
+            "type": "u64"
+          },
+          {
+            "name": "minOutputAmount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InitializeDaoParams",
+      "type": {
+        "fields": [
+          {
+            "name": "twapInitialObservation",
+            "type": "u128"
+          },
+          {
+            "name": "twapMaxObservationChangePerUpdate",
+            "type": "u128"
+          },
+          {
+            "name": "twapStartDelaySeconds",
+            "type": "u32"
+          },
+          {
+            "name": "minQuoteFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "name": "minBaseFutarchicLiquidity",
+            "type": "u64"
+          },
+          {
+            "name": "baseToStake",
+            "type": "u64"
+          },
+          {
+            "name": "passThresholdBps",
+            "type": "u16"
+          },
+          {
+            "name": "secondsPerProposal",
+            "type": "u32"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "initialSpendingLimit",
+            "type": {
+              "option": {
+                "defined": "InitialSpendingLimit"
+              }
+            }
+          },
+          {
+            "name": "teamSponsoredPassThresholdBps",
+            "type": "i16"
+          },
+          {
+            "name": "teamAddress",
+            "type": "publicKey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InitiateVaultSpendOptimisticProposalParams",
+      "type": {
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "ProvideLiquidityParams",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "How much quote token you will deposit to the pool"
+            ],
+            "name": "quoteAmount",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "The maximum base token you will deposit to the pool"
+            ],
+            "name": "maxBaseAmount",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "The minimum liquidity you will be assigned"
+            ],
+            "name": "minLiquidity",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "The account that will own the LP position, usually the same as the",
+              "liquidity provider"
+            ],
+            "name": "positionAuthority",
+            "type": "publicKey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SpotSwapParams",
+      "type": {
+        "fields": [
+          {
+            "name": "inputAmount",
+            "type": "u64"
+          },
+          {
+            "name": "swapType",
+            "type": {
+              "defined": "SwapType"
+            }
+          },
+          {
+            "name": "minOutputAmount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "StakeToProposalParams",
+      "type": {
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "UnstakeFromProposalParams",
+      "type": {
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "UpdateDaoParams",
+      "type": {
+        "fields": [
+          {
+            "name": "passThresholdBps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "secondsPerProposal",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "twapInitialObservation",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "twapMaxObservationChangePerUpdate",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "twapStartDelaySeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "minQuoteFutarchicLiquidity",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "minBaseFutarchicLiquidity",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "baseToStake",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "teamSponsoredPassThresholdBps",
+            "type": {
+              "option": "i16"
+            }
+          },
+          {
+            "name": "teamAddress",
+            "type": {
+              "option": "publicKey"
+            }
+          },
+          {
+            "name": "isOptimisticGovernanceEnabled",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "WithdrawLiquidityParams",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "How much liquidity to withdraw"
+            ],
+            "name": "liquidityToWithdraw",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "Minimum base tokens to receive"
+            ],
+            "name": "minBaseAmount",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Minimum quote tokens to receive"
+            ],
+            "name": "minQuoteAmount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "OptimisticProposal",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The squads proposal currently enqueued for execution if not challenged by a new proposal."
+            ],
+            "name": "squadsProposal",
+            "type": "publicKey"
+          },
+          {
+            "docs": [
+              "The timestamp when the active optimistic squads proposal was enqueued."
+            ],
+            "name": "enqueuedTimestamp",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InitialSpendingLimit",
+      "type": {
+        "fields": [
+          {
+            "name": "amountPerMonth",
+            "type": "u64"
+          },
+          {
+            "name": "members",
+            "type": {
+              "vec": "publicKey"
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "FutarchyAmm",
+      "type": {
+        "fields": [
+          {
+            "name": "state",
+            "type": {
+              "defined": "PoolState"
+            }
+          },
+          {
+            "name": "totalLiquidity",
+            "type": "u128"
+          },
+          {
+            "name": "baseMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "ammBaseVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "ammQuoteVault",
+            "type": "publicKey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "TwapOracle",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Running sum of seconds_since_last_update * last_observation.",
+              "",
+              "Assuming latest observations are as big as possible (u64::MAX * 1e12),",
+              "we can store 18 million seconds worth of observations, which turns out to",
+              "be ~213 days.",
+              "",
+              "Assuming that latest observations are 100x smaller than they could theoretically",
+              "be, we can store ~57 years worth of them. Even this is a very",
+              "very conservative assumption - META/USDC prices should be between 1e9 and",
+              "1e15, which would overflow after 1e15 years.",
+              "",
+              "So in the case of an overflow, the aggregator rolls back to 0. It's the",
+              "client's responsibility to sanity check the assets or to handle an",
+              "aggregator at T2 being smaller than an aggregator at T1."
+            ],
+            "name": "aggregator",
+            "type": "u128"
+          },
+          {
+            "name": "lastUpdatedTimestamp",
+            "type": "i64"
+          },
+          {
+            "name": "createdAtTimestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "A price is the number of quote units per base unit multiplied by 1e12.",
+              "You cannot simply divide by 1e12 to get a price you can display in the UI",
+              "because the base and quote decimals may be different. Instead, do:",
+              "ui_price = (price * (10**(base_decimals - quote_decimals))) / 1e12"
+            ],
+            "name": "lastPrice",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "If we did a raw TWAP over prices, someone could push the TWAP heavily with",
+              "a few extremely large outliers. So we use observations, which can only move",
+              "by `max_observation_change_per_update` per update."
+            ],
+            "name": "lastObservation",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "The most that an observation can change per update."
+            ],
+            "name": "maxObservationChangePerUpdate",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "What the initial `latest_observation` is set to."
+            ],
+            "name": "initialObservation",
+            "type": "u128"
+          },
+          {
+            "docs": [
+              "Number of seconds after amm.created_at_slot to start recording TWAP"
+            ],
+            "name": "startDelaySeconds",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Pool",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": {
+              "defined": "TwapOracle"
+            }
+          },
+          {
+            "name": "quoteReserves",
+            "type": "u64"
+          },
+          {
+            "name": "baseReserves",
+            "type": "u64"
+          },
+          {
+            "name": "quoteProtocolFeeBalance",
+            "type": "u64"
+          },
+          {
+            "name": "baseProtocolFeeBalance",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "PoolState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "fields": [
+              {
+                "name": "spot",
+                "type": {
+                  "defined": "Pool"
+                }
+              }
+            ],
+            "name": "Spot"
+          },
+          {
+            "fields": [
+              {
+                "name": "spot",
+                "type": {
+                  "defined": "Pool"
+                }
+              },
+              {
+                "name": "pass",
+                "type": {
+                  "defined": "Pool"
+                }
+              },
+              {
+                "name": "fail",
+                "type": {
+                  "defined": "Pool"
+                }
+              }
+            ],
+            "name": "Futarchy"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Market",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Spot"
+          },
+          {
+            "name": "Pass"
+          },
+          {
+            "name": "Fail"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Buy"
+          },
+          {
+            "name": "Sell"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Token",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Base"
+          },
+          {
+            "name": "Quote"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "fields": [
+              {
+                "name": "amountStaked",
+                "type": "u64"
+              }
+            ],
+            "name": "Draft"
+          },
+          {
+            "name": "Pending"
+          },
+          {
+            "name": "Passed"
+          },
+          {
+            "name": "Failed"
+          },
+          {
+            "name": "Removed"
+          }
+        ]
+      }
+    }
+  ],
+  "version": "0.6.1"
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/mod.rs
@@ -1,0 +1,261 @@
+//! MetaDAO Futarchy preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::MetadaoFutarchyConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::HashMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const METADAO_FUTARCHY_PROGRAM_ID: &str = "FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq";
+
+const DISPLAY_NAME: &str = "MetaDAO Futarchy";
+
+const IDL_JSON: &str = include_str!("metadao_futarchy.json");
+
+static CONFIG: MetadaoFutarchyConfig = MetadaoFutarchyConfig;
+
+pub struct MetadaoFutarchyVisualizer;
+
+impl InstructionVisualizer for MetadaoFutarchyVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        if instruction.data.len() < 8 {
+            return Err(VisualSignError::DecodeError(
+                "Instruction data too short for Anchor discriminator".to_string(),
+            ));
+        }
+
+        let idl = load_idl()?;
+        let parsed =
+            parse_instruction_with_idl(&instruction.data, METADAO_FUTARCHY_PROGRAM_ID, &idl)
+                .map_err(|e| VisualSignError::DecodeError(format!("IDL parse failed: {e}")))?;
+
+        let named_accounts = build_named_accounts(&idl, &instruction.data, &instruction.accounts);
+
+        build_visualization(context, instruction, &parsed, &named_accounts)
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(DISPLAY_NAME)
+    }
+}
+
+fn load_idl() -> Result<Idl, VisualSignError> {
+    decode_idl_data(IDL_JSON)
+        .map_err(|e| VisualSignError::DecodeError(format!("Failed to decode bundled IDL: {e}")))
+}
+
+fn build_named_accounts(
+    idl: &Idl,
+    instruction_data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> HashMap<String, String> {
+    let mut named = HashMap::new();
+    if instruction_data.len() < 8 {
+        return named;
+    }
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| &instruction_data[0..8] == disc.as_slice())
+    }) else {
+        return named;
+    };
+    for (index, account_meta) in accounts.iter().enumerate() {
+        if let Some(idl_account) = idl_instruction.accounts.get(index) {
+            named.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+        }
+    }
+    named
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+fn build_visualization(
+    context: &VisualizerContext,
+    instruction: &solana_sdk::instruction::Instruction,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &HashMap<String, String>,
+) -> Result<AnnotatedPayloadField, VisualSignError> {
+    let program_id = instruction.program_id.to_string();
+    let title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);
+
+    let condensed_fields = vec![create_text_field("Instruction", &parsed.instruction_name)?];
+
+    let mut expanded_fields = vec![
+        create_text_field("Program", DISPLAY_NAME)?,
+        create_text_field("Program ID", &program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    let mut account_keys: Vec<&String> = named_accounts.keys().collect();
+    account_keys.sort();
+    for key in account_keys {
+        if let Some(addr) = named_accounts.get(key) {
+            expanded_fields.push(create_text_field(key, addr)?);
+        }
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    expanded_fields.push(create_raw_data_field(
+        &instruction.data,
+        Some(hex::encode(&instruction.data)),
+    )?);
+
+    let condensed = SignablePayloadFieldListLayout {
+        fields: condensed_fields,
+    };
+    let expanded = SignablePayloadFieldListLayout {
+        fields: expanded_fields,
+    };
+
+    let preview_layout = SignablePayloadFieldPreviewLayout {
+        title: Some(SignablePayloadFieldTextV2 {
+            text: title.clone(),
+        }),
+        subtitle: Some(SignablePayloadFieldTextV2 {
+            text: String::new(),
+        }),
+        condensed: Some(condensed),
+        expanded: Some(expanded),
+    };
+
+    let fallback_text = format!(
+        "Program ID: {program_id}\nData: {}",
+        hex::encode(&instruction.data)
+    );
+
+    Ok(AnnotatedPayloadField {
+        static_annotation: None,
+        dynamic_annotation: None,
+        signable_payload_field: SignablePayloadField::PreviewLayout {
+            common: SignablePayloadFieldCommon {
+                label: format!("Instruction {}", context.instruction_index() + 1),
+                fallback_text,
+            },
+            preview_layout,
+        },
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+
+    fn dummy_account_metas(count: usize) -> Vec<AccountMeta> {
+        (0..count)
+            .map(|_| AccountMeta::new_readonly(Pubkey::new_unique(), false))
+            .collect()
+    }
+
+    #[test]
+    fn test_metadao_futarchy_idl_loads() {
+        let idl = load_idl().expect("IDL must load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should declare at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_metadao_futarchy_idl_has_discriminators() {
+        let idl = load_idl().expect("IDL must load");
+        for instruction in &idl.instructions {
+            let discriminator = instruction
+                .discriminator
+                .as_ref()
+                .expect("decode_idl_data must populate every discriminator");
+            assert_eq!(
+                discriminator.len(),
+                8,
+                "discriminator for `{}` should be 8 bytes, got {}",
+                instruction.name,
+                discriminator.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let bogus = [0xFFu8; 9];
+        let result = parse_instruction_with_idl(&bogus, METADAO_FUTARCHY_PROGRAM_ID, &idl);
+        assert!(
+            result.is_err(),
+            "unknown discriminator should fail to parse"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let short = [0x01u8, 0x02, 0x03];
+        let result = parse_instruction_with_idl(&short, METADAO_FUTARCHY_PROGRAM_ID, &idl);
+        assert!(result.is_err(), "data shorter than 8 bytes should error");
+    }
+
+    #[test]
+    fn test_build_named_accounts_matches_idl_account_names() {
+        let idl = load_idl().expect("IDL must load");
+        let spot_swap = idl
+            .instructions
+            .iter()
+            .find(|i| i.name == "spotSwap")
+            .expect("spotSwap instruction present");
+        let discriminator = spot_swap
+            .discriminator
+            .clone()
+            .expect("discriminator computed");
+        let mut data = discriminator;
+        data.resize(data.len() + 64, 0); // pad with zeros so any args parse harmlessly
+
+        let metas = dummy_account_metas(spot_swap.accounts.len());
+        let named = build_named_accounts(&idl, &data, &metas);
+
+        assert_eq!(
+            named.len(),
+            spot_swap.accounts.len(),
+            "every IDL account should be named"
+        );
+        for idl_account in &spot_swap.accounts {
+            assert!(
+                named.contains_key(&idl_account.name),
+                "missing named account `{}`",
+                idl_account.name
+            );
+        }
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/metadao_futarchy/mod.rs
@@ -9,7 +9,7 @@ use config::MetadaoFutarchyConfig;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_raw_data_field, create_text_field};
 use visualsign::{
@@ -70,8 +70,8 @@ fn build_named_accounts(
     idl: &Idl,
     instruction_data: &[u8],
     accounts: &[solana_sdk::instruction::AccountMeta],
-) -> HashMap<String, String> {
-    let mut named = HashMap::new();
+) -> BTreeMap<String, String> {
+    let mut named = BTreeMap::new();
     if instruction_data.len() < 8 {
         return named;
     }
@@ -102,7 +102,7 @@ fn build_visualization(
     context: &VisualizerContext,
     instruction: &solana_sdk::instruction::Instruction,
     parsed: &SolanaParsedInstructionData,
-    named_accounts: &HashMap<String, String>,
+    named_accounts: &BTreeMap<String, String>,
 ) -> Result<AnnotatedPayloadField, VisualSignError> {
     let program_id = instruction.program_id.to_string();
     let title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);

--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -8,6 +8,7 @@ pub mod kamino_borrow;
 pub mod kamino_farms;
 pub mod kamino_vault;
 pub mod metadao_conditional_vault;
+pub mod metadao_futarchy;
 pub mod meteora_damm_v2;
 pub mod meteora_dlmm;
 pub mod neutral_trade;


### PR DESCRIPTION
## Why this PR exists

Solana program `FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq` (MetaDAO Futarchy) is the core program for MetaDAO's prediction-market DAO governance and conditional AMM, but had no dedicated visualizer. Transactions calling it fell through to the generic `unknown_program` fallback, so signers saw raw program IDs and hex blobs instead of named instructions and accounts.

## What changed

- New `metadao_futarchy` preset registered alphabetically in `presets/mod.rs`.
- Bundles the on-chain Anchor IDL (fetched via `anchor-cli idl fetch`) at `presets/metadao_futarchy/metadao_futarchy.json`. The IDL declares 22 instructions covering DAO lifecycle (`initializeDao`, `updateDao`, `resizeDao`), proposal flow (`initializeProposal`, `stakeToProposal`, `launchProposal`, `finalizeProposal`, `sponsorProposal`), conditional AMM (`spotSwap`, `conditionalSwap`, `provideLiquidity`, `withdrawLiquidity`, `collectFees`, `collectMeteoraDammFees`), spending limits, and admin overrides.
- `MetadaoFutarchyVisualizer` follows the generic IDL-driven pattern: load IDL once via `decode_idl_data`, parse args via `parse_instruction_with_idl`, label accounts by IDL position, fall back to the raw-data field. No bespoke decoders.
- Categorized as `VisualizerKind::Dex("MetaDAO Futarchy")` to match the categorization used for the conditional vault preset and reflect the program's AMM surface.
- 5 unit tests: IDL load, every-instruction-has-8-byte-discriminator, unknown discriminator → error, short data → error, named-account mapping for `spotSwap`.

<img width="1260" height="2360" alt="image" src="https://github.com/user-attachments/assets/01560aca-d281-4384-8d73-1d6a4176716e" />


## Why this is safe

- New code only — no public API changes, no behavior change for any other preset or chain. The visualizer is auto-discovered by `build.rs` from the directory name.
- The 8-byte discriminator length check runs before parsing, so malformed instruction data returns an error rather than panicking or reading out-of-bounds.
- Unknown discriminators surface as `DecodeError`; the `unknown_program` fallback still handles transactions if this preset ever fails on a future on-chain instruction.
- Workspace-level clippy denials (`unwrap_used`, `expect_used`, `panic`, `unsafe_code`) are upheld in non-test code.

### Checks run (by agent)

- `cargo build -p visualsign-solana` — clean
- `cargo fmt -p visualsign-solana` — clean
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean
- `cargo test -p visualsign-solana` — 5 new tests pass; full crate suite green
- `make -C src test` — full workspace green

### Manual steps needed (by human)

- None — fully automated by CI.

## How this is maintainable

- The preset uses the same generic IDL pattern as other Anchor-driven Solana presets (including the recently added `metadao_conditional_vault`), so a fresh reader sees a familiar shape: load IDL, parse, render.
- `build.rs` auto-discovers `MetadaoFutarchyVisualizer` from the directory name; the only manual registration is the one-line `pub mod` entry in `presets/mod.rs`, kept alphabetical.
- The four invariants (IDL loads, discriminators are 8 bytes, short data errors, unknown discriminator errors) are pinned by tests, so regressions in `decode_idl_data` / `parse_instruction_with_idl` will fail this crate's suite.
- Refreshing the IDL for a future program version is a one-liner: `docker run --rm anchor-cli-local idl fetch FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq --provider.cluster mainnet > metadao_futarchy.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)