### PR TITLE
feat: add git-based versioning and auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip actual release)'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    # Restrict releases to main: workflow_dispatch is allowed from any ref by
+    # GitHub, so we gate on the actual checked-out ref to prevent feature
+    # branches from minting tags/releases against non-main commits.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        run: |
+          FULL_VERSION=$(scripts/auto-version.sh)
+          SEMVER="${FULL_VERSION%%+*}"
+          if [[ ! "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Invalid semver: $SEMVER (from $FULL_VERSION)"
+            exit 1
+          fi
+          TAG="v${SEMVER}"
+          echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Version: $FULL_VERSION  Tag: $TAG"
+
+      - name: Check if tag/release already exist
+        id: check_tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch --tags origin
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            # Fail fast if the tag already exists at a different commit (e.g.
+            # left over from a force-push or a manually created conflicting
+            # tag). Otherwise we'd publish a release pointing at the wrong
+            # commit and dispatch stagex against it.
+            TAG_COMMIT=$(git rev-parse "$TAG^{commit}")
+            HEAD_COMMIT=$(git rev-parse HEAD)
+            if [ "$TAG_COMMIT" != "$HEAD_COMMIT" ]; then
+              echo "ERROR: Tag $TAG already exists at $TAG_COMMIT, but HEAD is $HEAD_COMMIT" >&2
+              exit 1
+            fi
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+          RELEASE_ERR=$(mktemp)
+          if gh release view "$TAG" >/dev/null 2>"$RELEASE_ERR"; then
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG and its release both exist, skipping."
+          elif grep -qiE 'release not found|not found|HTTP 404' "$RELEASE_ERR"; then
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ERROR: gh release view failed unexpectedly:" >&2
+            cat "$RELEASE_ERR" >&2
+            exit 1
+          fi
+          rm -f "$RELEASE_ERR"
+
+      - name: Create tag
+        if: steps.check_tag.outputs.tag_exists == 'false' && !inputs.dry_run
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG" 2>&1 || {
+            # Push failed; query the remote directly to distinguish "concurrent
+            # run pushed the same tag at HEAD" (continue) from any other failure
+            # (abort). `git fetch --tags` would NOT overwrite our local tag, so
+            # `git rev-parse $TAG` would always match HEAD locally and tell us
+            # nothing about the remote.
+            REMOTE_SHA=$(git ls-remote origin "refs/tags/$TAG" | awk '{print $1}')
+            if [ -z "$REMOTE_SHA" ]; then
+              echo "ERROR: Failed to push tag $TAG and it's not on origin"
+              exit 1
+            fi
+            HEAD_COMMIT=$(git rev-parse HEAD)
+            if [ "$REMOTE_SHA" != "$HEAD_COMMIT" ]; then
+              echo "ERROR: Remote tag $TAG points to $REMOTE_SHA, not HEAD ($HEAD_COMMIT)"
+              exit 1
+            fi
+            echo "Tag already pushed by a concurrent run at the same commit, continuing."
+          }
+
+      - name: Create GitHub release
+        if: steps.check_tag.outputs.release_exists == 'false' && !inputs.dry_run
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$TAG" --generate-notes
+
+      - name: Trigger stagex build
+        # GITHUB_TOKEN tag pushes don't re-trigger other workflows, so we dispatch
+        # stagex explicitly so released images get the semver baked in.
+        # Gate on release_exists == false (not tag_exists) so that a retry after a
+        # partial failure (tag pushed, release creation failed) still dispatches stagex.
+        if: steps.check_tag.outputs.release_exists == 'false' && !inputs.dry_run
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run stagex.yml --ref "$TAG"
+
+      - name: Dry run summary
+        if: inputs.dry_run
+        run: |
+          echo "DRY RUN: would have created tag ${{ steps.version.outputs.tag }} (version: ${{ steps.version.outputs.full_version }})"

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -10,6 +10,7 @@ on:
       - ".github/**"
       - "src/**"
       - "images/**"
+      - "scripts/**"
       - "Makefile"
   pull_request:
     types: [labeled]
@@ -28,10 +29,17 @@ jobs:
       contents: read
       packages: write
     env:
+      # release.yml dispatches stagex via `gh workflow run --ref $TAG`, which
+      # arrives as `workflow_dispatch` (not `push`). Emit `ref_name` for any
+      # `workflow_dispatch` so both tag dispatches (release flow) and branch
+      # dispatches (manual testing on a branch) produce a real tag. Without
+      # this, `docker push --all-tags` runs against an empty tag list and
+      # silently publishes nothing.
       tags: >-
         ${{ github.ref == format('refs/heads/{0}', 'main') && 'latest' || '' }}
         ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
         ${{ github.event_name == 'push' && github.ref_name || '' }}
+        ${{ github.event_name == 'workflow_dispatch' && github.ref_name || '' }}
     strategy:
       matrix:
         target:
@@ -44,6 +52,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Full history so auto-version.sh can compute commit heights and
+          # merge-bases for non-tag builds (latest, pr-*).
+          fetch-depth: 0
       - name: Docker setup
         uses: ./.github/actions/docker-setup
         with:
@@ -51,8 +62,20 @@ jobs:
 
       - name: Build ${{ matrix.target.name }}
         shell: bash
+        env:
+          GH_REF_TYPE: ${{ github.ref_type }}
+          GH_REF_NAME: ${{ github.ref_name }}
         run: |
-          make -j$(nproc) out/${{ matrix.target.name }}/index.json
+          if [[ "$GH_REF_TYPE" == "tag" && "$GH_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION="${GH_REF_NAME#v}"
+          else
+            # Compute on the runner: auto-version.sh isn't COPY'd into the
+            # Docker build context, so the in-container build.rs would fall
+            # back to "dev" and silently lose the git-derived version on
+            # latest/pr-* images.
+            VERSION=$(scripts/auto-version.sh)
+          fi
+          make VERSION="$VERSION" -j$(nproc) out/${{ matrix.target.name }}/index.json
 
       - name: Load artifact to Docker
         run: |

--- a/images/parser_app/Containerfile
+++ b/images/parser_app/Containerfile
@@ -7,6 +7,10 @@ ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locke
 # Directory for Rust artifacts
 ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
 
+# Version injected at build time via --build-arg (set by make VERSION=...)
+ARG VERSION
+ENV VERSION=$VERSION
+
 # Load Rust sources
 ADD src /src
 WORKDIR /src/

--- a/images/parser_cli/Containerfile
+++ b/images/parser_cli/Containerfile
@@ -7,6 +7,10 @@ ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locke
 # Directory for Rust artifacts
 ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
 
+# Version injected at build time via --build-arg (set by make VERSION=...)
+ARG VERSION
+ENV VERSION=$VERSION
+
 # Load Rust sources
 ADD src /src
 WORKDIR /src/

--- a/images/parser_gateway/Containerfile
+++ b/images/parser_gateway/Containerfile
@@ -7,6 +7,10 @@ ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locke
 # Directory for Rust artifacts
 ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
 
+# Version injected at build time via --build-arg (set by make VERSION=...)
+ARG VERSION
+ENV VERSION=$VERSION
+
 # Load Rust sources
 ADD src /src
 WORKDIR /src/

--- a/scripts/auto-version.sh
+++ b/scripts/auto-version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the raw branch name before sanitization so comparisons against
+# "main"/"master" can't be fooled by branches like "main." that collapse
+# to "main-" after character sanitization.
+#
+# Precedence:
+#   1. GITHUB_HEAD_REF -- set on pull_request events
+#   2. GITHUB_REF_NAME -- set on push/workflow_dispatch events
+#   3. git symbolic-ref --short HEAD -- local developer runs
+RAW_BRANCH="${GITHUB_HEAD_REF:-}"
+if [ -z "$RAW_BRANCH" ]; then
+  RAW_BRANCH="${GITHUB_REF_NAME:-}"
+fi
+if [ -z "$RAW_BRANCH" ]; then
+  if git symbolic-ref --short HEAD > /dev/null 2>&1; then
+    RAW_BRANCH="$(git symbolic-ref --short HEAD)"
+  fi
+fi
+
+SHORT_HASH=$(git rev-parse --short=12 HEAD)
+
+# Sanitized branch for semver build metadata (allowed: [0-9A-Za-z-]).
+# Trailing "-" is a separator before SHORT_HASH; omitted when branch is empty.
+if [ -n "$RAW_BRANCH" ]; then
+  # shellcheck disable=SC2001
+  BRANCH_META="$(echo "$RAW_BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g')-"
+else
+  BRANCH_META=
+fi
+
+# Treat the build as a default-branch build only when we know the ref is
+# actually the canonical default branch. `pull_request` events always
+# represent a non-default ref by definition, so even a fork PR opened from
+# a branch literally named `main`/`master` falls through to the merge-base
+# path below.
+if { [ "$RAW_BRANCH" = "main" ] || [ "$RAW_BRANCH" = "master" ]; } \
+   && [ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]; then
+  HEIGHT=$(git rev-list --count HEAD)
+  echo "0.$HEIGHT.0+${BRANCH_META}$SHORT_HASH"
+  exit 0
+fi
+
+REMOTE=$(git remote -v | awk '/[[:space:]]\(fetch\)/ && /anchorageoss\/visualsign-parser/ {print $1; exit}')
+if [ -z "$REMOTE" ]; then
+  REMOTE="origin"
+fi
+
+DEFAULT_BRANCH="main"
+if ! git rev-parse --verify "$REMOTE/$DEFAULT_BRANCH" > /dev/null 2>&1; then
+  DEFAULT_BRANCH="master"
+fi
+
+MERGE_BASE=$(git merge-base "$REMOTE/$DEFAULT_BRANCH" HEAD)
+if [ "$MERGE_BASE" = "$(git rev-parse "$REMOTE/$DEFAULT_BRANCH")" ] && [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  # On CI, the remote-tracking ref may be stale (shallow clone) -- fetch to get the real merge base.
+  # Skipped on local builds; run `git fetch` manually if the version number looks wrong.
+  echo "Fetching $REMOTE..." >&2
+  git fetch "$REMOTE" >&2
+  MERGE_BASE=$(git merge-base "$REMOTE/$DEFAULT_BRANCH" HEAD)
+fi
+MERGE_HEIGHT=$(git rev-list --count "$MERGE_BASE")
+HEIGHT=$(git rev-list --count HEAD)
+MERGE_DIFF=$((HEIGHT - MERGE_HEIGHT))
+echo "0.$MERGE_HEIGHT.$MERGE_DIFF+${BRANCH_META}$SHORT_HASH"

--- a/src/parser/app/build.rs
+++ b/src/parser/app/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
+    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+
+    if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    println!("cargo:rustc-env=VERSION=dev");
+    Ok(())
+}

--- a/src/parser/app/src/cli.rs
+++ b/src/parser/app/src/cli.rs
@@ -100,7 +100,7 @@ impl Cli {
         let opts = ParserOpts::new(&mut args);
 
         if opts.parsed.version() {
-            println!("version: {}", env!("CARGO_PKG_VERSION"));
+            println!("version: {}", env!("VERSION"));
         } else if opts.parsed.help() {
             println!("{}", opts.parsed.info());
         } else {

--- a/src/parser/cli/build.rs
+++ b/src/parser/cli/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
+    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+
+    if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    println!("cargo:rustc-env=VERSION=dev");
+    Ok(())
+}

--- a/src/parser/cli/build.rs
+++ b/src/parser/cli/build.rs
@@ -1,20 +1,39 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let git_dir = workspace_root.join(".git");
+
     println!("cargo:rerun-if-env-changed=VERSION");
-    println!("cargo:rerun-if-changed=../../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
-    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
-    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
-    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
-    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("logs/HEAD").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/main").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/master").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("scripts/auto-version.sh").display()
+    );
 
     if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
         println!("cargo:rustc-env=VERSION={version}");
         return Ok(());
     }
 
-    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+    if let Some(version) = Command::new(workspace_root.join("scripts/auto-version.sh"))
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/src/parser/cli/src/cli.rs
+++ b/src/parser/cli/src/cli.rs
@@ -6,7 +6,7 @@ use visualsign::{SignablePayload, SignablePayloadField};
 
 #[derive(Parser, Debug)]
 #[command(name = "visualsign-parser")]
-#[command(version = "1.0")]
+#[command(version = env!("VERSION"))]
 #[command(about = "Converts raw transactions to visual signing properties")]
 pub(crate) struct Args {
     #[arg(short, long, help = "Chain type")]
@@ -256,10 +256,10 @@ fn parse_and_display(
     Ok(())
 }
 
-/// app cli
+/// CLI entry point.
 pub struct Cli;
 impl Cli {
-    /// start the parser cli
+    /// Parse arguments and run the transaction visualizer.
     pub fn execute() -> Result<(), String> {
         let args = Args::parse();
         let chain = parse_chain(&args.chain);

--- a/src/parser/gateway/build.rs
+++ b/src/parser/gateway/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
+    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+
+    if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    println!("cargo:rustc-env=VERSION=dev");
+    Ok(())
+}

--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -272,7 +272,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    println!("Gateway listening on {addr}");
+    println!("parser_gateway {} listening on {addr}", env!("VERSION"));
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .with_graceful_shutdown(shutdown_signal())

--- a/src/parser/grpc-server/build.rs
+++ b/src/parser/grpc-server/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
+    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
+    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+
+    if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    println!("cargo:rustc-env=VERSION=dev");
+    Ok(())
+}

--- a/src/parser/grpc-server/build.rs
+++ b/src/parser/grpc-server/build.rs
@@ -1,20 +1,39 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let git_dir = workspace_root.join(".git");
+
     println!("cargo:rerun-if-env-changed=VERSION");
-    println!("cargo:rerun-if-changed=../../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../../.git/logs/HEAD");
-    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
-    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/main");
-    println!("cargo:rerun-if-changed=../../../.git/refs/remotes/origin/master");
-    println!("cargo:rerun-if-changed=../../../scripts/auto-version.sh");
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("logs/HEAD").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/main").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/master").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("scripts/auto-version.sh").display()
+    );
 
     if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
         println!("cargo:rustc-env=VERSION={version}");
         return Ok(());
     }
 
-    if let Some(version) = Command::new("../../../scripts/auto-version.sh")
+    if let Some(version) = Command::new(workspace_root.join("scripts/auto-version.sh"))
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/src/parser/grpc-server/src/main.rs
+++ b/src/parser/grpc-server/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .expect("failed to start reflection service");
 
-    println!("gRPC server listening on {addr}");
+    println!("parser_grpc_server {} listening on {addr}", env!("VERSION"));
 
     tonic::transport::Server::builder()
         .add_service(reflection_service)


### PR DESCRIPTION
## Why am I making this PR?

Binaries had a hardcoded version string (`1.0`) with no connection to the actual release state. There was no automated way to tag releases or produce versioned Docker images.

## What am I changing?

Adding `scripts/auto-version.sh` (adapted from `visualsign-turnkeyclient`) that computes `0.COMMIT_HEIGHT.0+branch-hash` from git history. `build.rs` in the three binary crates bakes this into `env!("VERSION")` at compile time, falling through from `VERSION` env var → script → `"dev"`. A new `release.yml` workflow auto-tags every push to main as `v0.N.0` and explicitly dispatches `stagex.yml` on that tag so released Docker images get the semver embedded.

## What is the Linear ticket?

N/A

## What are the rollback steps?

Revert the `release.yml` workflow to stop auto-tagging. The build.rs changes are additive and safe to leave in place — binaries will fall back to `"dev"` if `auto-version.sh` is unavailable.

## Is this change backwards compatible?

Yes. The `VERSION` env var path is additive; nothing relied on the previous hardcoded `"1.0"` string.

## Does this require cross-team/service coordination?

No.

## How do I know it works as designed? Which tests exercise this code?

Verified locally: `parser_cli --version` outputs `0.609.0+worktree-65634345-e10d806da050` (git-derived). `cargo clippy --all-targets -- -D warnings` passes clean.

_Co-authored with Claude._