### PR TITLE
ci(stagex): add TVC deployment summary for parser_app

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -96,9 +96,9 @@ jobs:
             echo ""
             echo '```bash'
             echo "export CONTAINER_URL=\"${pinned_url}\""
-            echo 'docker create --name tmp-extract "$CONTAINER_URL" /bin/true'
-            echo 'docker cp tmp-extract:/parser_app /tmp/binary'
-            echo 'docker rm tmp-extract'
+            echo 'cid=$(docker create "$CONTAINER_URL" /bin/true)'
+            echo 'docker cp "$cid:/parser_app" /tmp/binary'
+            echo 'docker rm "$cid"'
             echo 'sha256sum /tmp/binary'
             echo '```'
             echo ""

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -81,6 +81,7 @@ jobs:
           docker rm tmp-extract
           digest=$(sha256sum /tmp/binary | awk '{print $1}')
           pinned_url="${container_url}@${container_digest}"
+          qos_version=$(grep -m1 -E 'git\+https://github.com/tkhq/qos\.git\?rev=[a-f0-9]{40}' src/Cargo.lock | sed -E 's/.*rev=([a-f0-9]{40}).*/\1/')
 
           {
             echo "## TVC Deployment Details"
@@ -88,6 +89,7 @@ jobs:
             echo "- **Container Image URL**: \`${pinned_url}\`"
             echo "- **Executable path**: \`/parser_app\`"
             echo "- **Expected Executable Digest**: \`sha256:${digest}\`"
+            echo "- **QOS Version**: \`${qos_version}\`"
             echo ""
             echo "### Verify the executable digest"
             echo ""
@@ -101,7 +103,7 @@ jobs:
             echo ""
             echo "### Kick off deployment with \`tvc\`"
             echo ""
-            echo "Generate a config template, paste these values into the matching keys, then create the deployment:"
+            echo "Generate a config template, paste these values into the matching keys, then create the deployment. \`appId\` and any pull-secret fields are environment-specific and must be filled in by the operator."
             echo ""
             echo '```bash'
             echo 'tvc deploy init -o tvc-deploy.json'
@@ -109,7 +111,8 @@ jobs:
             echo "#   \"pivotContainerImageUrl\": \"${pinned_url}\""
             echo '#   "pivotPath": "/parser_app"'
             echo "#   \"expectedPivotDigest\": \"sha256:${digest}\""
-            echo '# (also fill in appId, qosVersion, and any pull-secret fields)'
+            echo "#   \"qosVersion\": \"${qos_version}\""
+            echo '#   "appId": "<env-specific>"'
             echo 'tvc deploy create tvc-deploy.json'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -81,7 +81,8 @@ jobs:
           docker rm tmp-extract
           digest=$(sha256sum /tmp/binary | awk '{print $1}')
           pinned_url="${container_url}@${container_digest}"
-          qos_version=$(grep -m1 -E 'git\+https://github.com/tkhq/qos\.git\?rev=[a-f0-9]{40}' src/Cargo.lock | sed -E 's/.*rev=([a-f0-9]{40}).*/\1/')
+          # Hardcoded: TVC currently only supports this QOS version.
+          qos_version="v2026.2.6"
 
           {
             echo "## TVC Deployment Details"

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -68,3 +68,48 @@ jobs:
               docker tag "anchorageoss-visualsign-parser/${{ matrix.target.name }}:latest" "ghcr.io/anchorageoss/${{ matrix.target.name }}:${tag}"
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
+
+      - name: TVC deployment details
+        if: matrix.target.name == 'parser_app'
+        shell: bash
+        run: |
+          first_tag=$(echo "${tags}" | awk '{print $1}')
+          container_url="ghcr.io/anchorageoss/parser_app:${first_tag}"
+          container_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${container_url}" | cut -d '@' -f 2)
+          docker create --name tmp-extract "${container_url}" /bin/true
+          docker cp tmp-extract:/parser_app /tmp/binary
+          docker rm tmp-extract
+          digest=$(sha256sum /tmp/binary | awk '{print $1}')
+          pinned_url="${container_url}@${container_digest}"
+
+          {
+            echo "## TVC Deployment Details"
+            echo ""
+            echo "- **Container Image URL**: \`${pinned_url}\`"
+            echo "- **Executable path**: \`/parser_app\`"
+            echo "- **Expected Executable Digest**: \`sha256:${digest}\`"
+            echo ""
+            echo "### Verify the executable digest"
+            echo ""
+            echo '```bash'
+            echo "export CONTAINER_URL=\"${pinned_url}\""
+            echo 'docker create --name tmp-extract "$CONTAINER_URL" /bin/true'
+            echo 'docker cp tmp-extract:/parser_app /tmp/binary'
+            echo 'docker rm tmp-extract'
+            echo 'sha256sum /tmp/binary'
+            echo '```'
+            echo ""
+            echo "### Kick off deployment with \`tvc\`"
+            echo ""
+            echo "Generate a config template, paste these values into the matching keys, then create the deployment:"
+            echo ""
+            echo '```bash'
+            echo 'tvc deploy init -o tvc-deploy.json'
+            echo '# Edit tvc-deploy.json to set:'
+            echo "#   \"pivotContainerImageUrl\": \"${pinned_url}\""
+            echo '#   "pivotPath": "/parser_app"'
+            echo "#   \"expectedPivotDigest\": \"sha256:${digest}\""
+            echo '# (also fill in appId, qosVersion, and any pull-secret fields)'
+            echo 'tvc deploy create tvc-deploy.json'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Mirrors [tkhq/tvc-template's stagex.yml](https://github.com/tkhq/tvc-template/blob/cc4a3ae970853768eaa87925953d1b3f110a2d09/.github/workflows/stagex.yml#L65-L86): after pushing `parser_app` to GHCR, extract the binary, hash it, and write deployment metadata to `$GITHUB_STEP_SUMMARY`.
- Surfaces the three values a TVC operator needs (`pivotContainerImageUrl`, `pivotPath`, `expectedPivotDigest`) plus a copy-pasteable `docker create` verification snippet and a `tvc deploy init` / `tvc deploy create` block.
- Gated on `matrix.target.name == 'parser_app'` so `parser_cli` and `parser_gateway` matrix entries are skipped.

## Test plan
- [x] Apply the `stagex` label to this PR so the workflow runs.
- [x] Confirm the **TVC deployment details** step runs only on the `parser_app` matrix entry.
- [x] Open the run summary and verify the rendered "TVC Deployment Details" section contains the three fields, the verification bash block, and the `tvc deploy` block. Summary here https://github.com/anchorageoss/visualsign-parser/actions/runs/25373965675?pr=279
- [ ] Copy the verification snippet, run it locally against the published `pr-NNN` tag, and confirm `sha256sum` matches the **Expected Executable Digest**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)