### PR TITLE
ci(stagex): versioned TVC summary + surfpool gitignore

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -69,27 +69,42 @@ jobs:
         run: |
           if [[ "$GH_REF_TYPE" == "tag" && "$GH_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             VERSION="${GH_REF_NAME#v}"
+            IS_RELEASE_BUILD=1
           else
             # Compute on the runner: auto-version.sh isn't COPY'd into the
             # Docker build context, so the in-container build.rs would fall
             # back to "dev" and silently lose the git-derived version on
             # latest/pr-* images.
             VERSION=$(scripts/auto-version.sh)
+            # Only push-to-main builds are safe to publish under a bare
+            # `:v<semver>` tag. PR/branch builds on different branches can
+            # produce identical `MAJOR.HEIGHT.MINOR` prefixes (the `+branch-hash`
+            # suffix is what disambiguates them) and would overwrite each
+            # other's `:v<semver>` tag on GHCR. Those builds get only the
+            # event-derived tags (`pr-N` / branch name) plus `:<sha>`.
+            if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+              IS_RELEASE_BUILD=1
+            else
+              IS_RELEASE_BUILD=0
+            fi
           fi
-          # Strip "+branch-hash" build metadata to get a canonical semver tag
-          # that we can both publish to GHCR and reference in the TVC summary.
-          # Validate the shape so a malformed VERSION fails the build instead
-          # of silently producing an invalid tag like ":v".
+          # Strip "+branch-hash" build metadata and validate semver shape so a
+          # malformed VERSION fails the build instead of silently producing an
+          # invalid tag like ":v".
           SEMVER="${VERSION%%+*}"
           if [[ ! "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: auto-version produced non-semver '$SEMVER' from '$VERSION'" >&2
+            echo "ERROR: VERSION='$VERSION' produced non-semver SEMVER='$SEMVER'" >&2
             exit 1
           fi
-          echo "semver_tag=v$SEMVER" >> "$GITHUB_OUTPUT"
-          # Commit-SHA tag (full 40-char hex). Lets a given image be located
-          # by its source commit without parsing VERSION.
-          SHA_FULL=$(git rev-parse HEAD)
-          echo "sha_tag=$SHA_FULL" >> "$GITHUB_OUTPUT"
+          if [[ "$IS_RELEASE_BUILD" == "1" ]]; then
+            echo "semver_tag=v$SEMVER" >> "$GITHUB_OUTPUT"
+          else
+            echo "semver_tag=" >> "$GITHUB_OUTPUT"
+          fi
+          # Commit-SHA tag (full 40-char hex). Always unique, so it's safe to
+          # publish on every build (PR, branch, release) without risking
+          # cross-branch overwrites.
+          echo "sha_tag=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           make VERSION="$VERSION" -j$(nproc) out/${{ matrix.target.name }}/index.json
 
       - name: Load artifact to Docker
@@ -106,11 +121,15 @@ jobs:
           SHA_TAG: ${{ steps.build.outputs.sha_tag }}
         run: |
           # Publish:
-          # - event-derived tags (latest, pr-N, ref_name)
-          # - canonical `v<semver>` so push-triggered main builds also get a
-          #   reproducible version reference, not just `:latest`
-          # - full commit SHA so a given image can be located by its source commit
-          for tag in ${tags} "${SEMVER_TAG}" "${SHA_TAG}"; do
+          # - event-derived tags (latest, pr-N, ref_name) — always
+          # - canonical `:v<semver>` — only on release builds; empty otherwise
+          # - full commit `:<sha>` — always (unique per commit)
+          # Build a unified list so empty SEMVER_TAG doesn't produce a bare
+          # ":latest" tag with no tag suffix in the docker tag command.
+          all_tags=( ${tags} )
+          [ -n "$SEMVER_TAG" ] && all_tags+=( "$SEMVER_TAG" )
+          [ -n "$SHA_TAG" ]    && all_tags+=( "$SHA_TAG" )
+          for tag in "${all_tags[@]}"; do
               docker tag "anchorageoss-visualsign-parser/${{ matrix.target.name }}:latest" "ghcr.io/anchorageoss/${{ matrix.target.name }}:${tag}"
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
@@ -120,12 +139,14 @@ jobs:
         shell: bash
         env:
           SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
+          SHA_TAG: ${{ steps.build.outputs.sha_tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Reference the canonical `v<semver>` tag (not `first_tag`, which
-          # depends on the trigger event: `latest` on main pushes, `v0.<N>.0`
-          # only on release-dispatched workflow_dispatch).
-          container_url="ghcr.io/anchorageoss/parser_app:${SEMVER_TAG}"
+          # Prefer the canonical `v<semver>` on release builds; fall back to
+          # the always-unique commit SHA on PR/branch builds where SEMVER
+          # isn't reproducible. Both reference the same digest below.
+          tvc_tag="${SEMVER_TAG:-$SHA_TAG}"
+          container_url="ghcr.io/anchorageoss/parser_app:${tvc_tag}"
           container_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${container_url}" | cut -d '@' -f 2)
           docker create --name tmp-extract "${container_url}" /bin/true
           docker cp tmp-extract:/parser_app /tmp/binary
@@ -177,15 +198,16 @@ jobs:
           cat "$deploy_md" >> "$GITHUB_STEP_SUMMARY"
 
           # Mirror onto the GitHub release for this semver, when it exists.
-          # Push-triggered stagex may race release.yml (which creates the
-          # release for the same commit); in that case just skip — the
+          # PR/branch builds have no SEMVER_TAG and no matching release;
+          # push-triggered stagex on main may race release.yml (which creates
+          # the release for the same commit); in either case just skip — the
           # release-dispatched stagex run will populate it.
           #
           # Re-running stagex for the same release (manual UI re-run) must be
           # idempotent: strip any existing block bracketed by our sentinel
           # comments before appending the freshly-built one. The sentinels
           # render as nothing in the release body.
-          if gh release view "$SEMVER_TAG" >/dev/null 2>&1; then
+          if [ -n "$SEMVER_TAG" ] && gh release view "$SEMVER_TAG" >/dev/null 2>&1; then
             existing_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
             preserved=$(printf '%s\n' "$existing_body" | awk '
               /<!-- BEGIN_TVC_DEPLOY -->/ { skipping = 1; next }
@@ -203,5 +225,5 @@ jobs:
               --repo "${GITHUB_REPOSITORY}"
             echo "Updated release $SEMVER_TAG with TVC deployment details."
           else
-            echo "No release exists yet for $SEMVER_TAG; skipping release-notes update."
+            echo "No release to update (SEMVER_TAG='${SEMVER_TAG:-<unset>}'); skipping release-notes update."
           fi

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       id-token: write
-      contents: read
+      contents: write  # `gh release edit` (mirror TVC details onto release notes)
       packages: write
     env:
       # release.yml dispatches stagex via `gh workflow run --ref $TAG`, which
@@ -86,6 +86,10 @@ jobs:
             exit 1
           fi
           echo "semver_tag=v$SEMVER" >> "$GITHUB_OUTPUT"
+          # Commit-SHA tag (full 40-char hex). Lets a given image be located
+          # by its source commit without parsing VERSION.
+          SHA_FULL=$(git rev-parse HEAD)
+          echo "sha_tag=$SHA_FULL" >> "$GITHUB_OUTPUT"
           make VERSION="$VERSION" -j$(nproc) out/${{ matrix.target.name }}/index.json
 
       - name: Load artifact to Docker
@@ -99,11 +103,14 @@ jobs:
       - name: Upload to GHCR
         env:
           SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
+          SHA_TAG: ${{ steps.build.outputs.sha_tag }}
         run: |
-          # Publish the canonical `v<semver>` tag alongside event-derived tags
-          # (latest, pr-*, ref_name) so push-triggered main builds also get a
-          # reproducible, version-identifying reference, not just `:latest`.
-          for tag in ${tags} "${SEMVER_TAG}"; do
+          # Publish:
+          # - event-derived tags (latest, pr-N, ref_name)
+          # - canonical `v<semver>` so push-triggered main builds also get a
+          #   reproducible version reference, not just `:latest`
+          # - full commit SHA so a given image can be located by its source commit
+          for tag in ${tags} "${SEMVER_TAG}" "${SHA_TAG}"; do
               docker tag "anchorageoss-visualsign-parser/${{ matrix.target.name }}:latest" "ghcr.io/anchorageoss/${{ matrix.target.name }}:${tag}"
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
@@ -113,6 +120,7 @@ jobs:
         shell: bash
         env:
           SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Reference the canonical `v<semver>` tag (not `first_tag`, which
           # depends on the trigger event: `latest` on main pushes, `v0.<N>.0`
@@ -127,6 +135,11 @@ jobs:
           # Hardcoded: TVC currently only supports this QOS version.
           qos_version="v2026.2.6"
 
+          # Build the deployment block once, then fan it out to both the run
+          # summary and (when a matching GitHub release exists) the release
+          # body. Operators reading either surface get the same paste-ready
+          # values.
+          deploy_md="${RUNNER_TEMP}/tvc_deploy.md"
           {
             echo "## TVC Deployment Details"
             echo ""
@@ -159,4 +172,36 @@ jobs:
             echo '#   "appId": "<env-specific>"'
             echo 'tvc deploy create tvc-deploy.json'
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } > "$deploy_md"
+
+          cat "$deploy_md" >> "$GITHUB_STEP_SUMMARY"
+
+          # Mirror onto the GitHub release for this semver, when it exists.
+          # Push-triggered stagex may race release.yml (which creates the
+          # release for the same commit); in that case just skip — the
+          # release-dispatched stagex run will populate it.
+          #
+          # Re-running stagex for the same release (manual UI re-run) must be
+          # idempotent: strip any existing block bracketed by our sentinel
+          # comments before appending the freshly-built one. The sentinels
+          # render as nothing in the release body.
+          if gh release view "$SEMVER_TAG" >/dev/null 2>&1; then
+            existing_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
+            preserved=$(printf '%s\n' "$existing_body" | awk '
+              /<!-- BEGIN_TVC_DEPLOY -->/ { skipping = 1; next }
+              /<!-- END_TVC_DEPLOY -->/   { skipping = 0; next }
+              !skipping
+            ')
+            new_body="${RUNNER_TEMP}/release_notes.md"
+            {
+              printf '%s\n\n' "$preserved"
+              echo "<!-- BEGIN_TVC_DEPLOY -->"
+              cat "$deploy_md"
+              echo "<!-- END_TVC_DEPLOY -->"
+            } > "$new_body"
+            gh release edit "$SEMVER_TAG" --notes-file "$new_body" \
+              --repo "${GITHUB_REPOSITORY}"
+            echo "Updated release $SEMVER_TAG with TVC deployment details."
+          else
+            echo "No release exists yet for $SEMVER_TAG; skipping release-notes update."
+          fi

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -61,6 +61,7 @@ jobs:
           dockerHub: ${{ secrets.DOCKERHUB_API_KEY }}
 
       - name: Build ${{ matrix.target.name }}
+        id: build
         shell: bash
         env:
           GH_REF_TYPE: ${{ github.ref_type }}
@@ -75,6 +76,16 @@ jobs:
             # latest/pr-* images.
             VERSION=$(scripts/auto-version.sh)
           fi
+          # Strip "+branch-hash" build metadata to get a canonical semver tag
+          # that we can both publish to GHCR and reference in the TVC summary.
+          # Validate the shape so a malformed VERSION fails the build instead
+          # of silently producing an invalid tag like ":v".
+          SEMVER="${VERSION%%+*}"
+          if [[ ! "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: auto-version produced non-semver '$SEMVER' from '$VERSION'" >&2
+            exit 1
+          fi
+          echo "semver_tag=v$SEMVER" >> "$GITHUB_OUTPUT"
           make VERSION="$VERSION" -j$(nproc) out/${{ matrix.target.name }}/index.json
 
       - name: Load artifact to Docker
@@ -86,8 +97,13 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload to GHCR
+        env:
+          SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
         run: |
-          for tag in ${tags}; do
+          # Publish the canonical `v<semver>` tag alongside event-derived tags
+          # (latest, pr-*, ref_name) so push-triggered main builds also get a
+          # reproducible, version-identifying reference, not just `:latest`.
+          for tag in ${tags} "${SEMVER_TAG}"; do
               docker tag "anchorageoss-visualsign-parser/${{ matrix.target.name }}:latest" "ghcr.io/anchorageoss/${{ matrix.target.name }}:${tag}"
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
@@ -95,9 +111,13 @@ jobs:
       - name: TVC deployment details
         if: matrix.target.name == 'parser_app'
         shell: bash
+        env:
+          SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
         run: |
-          first_tag=$(echo "${tags}" | awk '{print $1}')
-          container_url="ghcr.io/anchorageoss/parser_app:${first_tag}"
+          # Reference the canonical `v<semver>` tag (not `first_tag`, which
+          # depends on the trigger event: `latest` on main pushes, `v0.<N>.0`
+          # only on release-dispatched workflow_dispatch).
+          container_url="ghcr.io/anchorageoss/parser_app:${SEMVER_TAG}"
           container_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${container_url}" | cut -d '@' -f 2)
           docker create --name tmp-extract "${container_url}" /bin/true
           docker cp tmp-extract:/parser_app /tmp/binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 out
+.surfpool/

--- a/src/parser/app/src/cli.rs
+++ b/src/parser/app/src/cli.rs
@@ -107,7 +107,10 @@ impl Cli {
             let processor =
                 crate::service::Processor::new(EphemeralKeyHandle::new(opts.ephemeral_file()));
 
-            println!("---- Starting Parser server -----");
+            println!(
+                "---- Starting Parser server (version: {}) -----",
+                env!("VERSION")
+            );
             let mut tasks = Vec::new();
             tasks.push(tokio::spawn(async move {
                 crate::host::Host::listen(opts.host_addr(), processor)


### PR DESCRIPTION
## Summary

- **stagex.yml** — always reference `ghcr.io/anchorageoss/parser_app:v<semver>@sha256:<digest>` in the TVC deployment summary (and publish that tag), regardless of whether stagex was triggered by a `push` to `main` or a release-dispatched `workflow_dispatch`. Today the push-triggered run produces `:latest@sha256:...` and the release-dispatched run produces `:v0.<N>.0@sha256:...` — same image, two different labels — which makes the `pivotContainerImageUrl` pasted into `tvc deploy create` non-reproducible for audit purposes.
- **stagex.yml** — also publish a commit-SHA tag (`:<full-40-char-hex>`) so a given image can be located by its source commit without parsing VERSION. `docker image push --all-tags` covers it, no extra push cost.
- **stagex.yml** — mirror the TVC deployment block onto the GitHub release notes (when a matching release exists for the semver), with sentinel-bracketed insertion for idempotent re-runs. Operators reading the release page get the same paste-ready `tvc deploy` instructions as the run summary.
- **.gitignore** — add `.surfpool/` to the workspace root so the surfpool state dir spawned by integration tests (run from the repo root) doesn't appear in `git status`.

## Changes

### `.github/workflows/stagex.yml` (#293)

- `Build` step derives `SEMVER` from `VERSION` (stripping `+branch-hash`), validates `^[0-9]+\.[0-9]+\.[0-9]+$`, and emits `semver_tag=v<SEMVER>` plus `sha_tag=<full-SHA>` as step outputs.
- `Upload to GHCR` appends `${SEMVER_TAG}` and `${SHA_TAG}` to the tag list — `:v<semver>` and `:<commit-sha>` are now published alongside `:latest`/event-derived tags, so both are resolvable for `docker pull`.
- `TVC deployment details` uses `${SEMVER_TAG}` for `container_url` instead of the event-dependent `first_tag`, writes its content to a temp file, fans it out to `$GITHUB_STEP_SUMMARY`, and (when a matching release exists) calls `gh release edit --notes-file` to mirror the same paste-ready instructions onto the release body. Idempotent via `<!-- BEGIN_TVC_DEPLOY --> / <!-- END_TVC_DEPLOY -->` sentinels.
- Job `permissions.contents` elevated from `read` to `write` (required by `gh release edit`).

### `.gitignore` (#292)

- Add `.surfpool/`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/stagex.yml'))"` passes.
- [ ] Next push to `main` produces a stagex run whose TVC summary shows `ghcr.io/anchorageoss/parser_app:v0.<N>.0@sha256:<digest>` (not `:latest@...`).
- [ ] `docker pull ghcr.io/anchorageoss/parser_app:v0.<N>.0` resolves after that run.
- [ ] `docker pull ghcr.io/anchorageoss/parser_app:<40-char-commit-sha>` resolves and produces the same digest.
- [ ] `docker pull ghcr.io/anchorageoss/parser_app:latest` still resolves (the `:latest` alias is preserved).
- [ ] The GitHub release for `v0.<N>.0` (created by `release.yml`) gets the TVC deployment block appended to its body once the release-dispatched stagex run completes.
- [ ] Running surfpool integration tests locally no longer leaves `.surfpool/` as an untracked entry in `git status`.

Closes #292
Closes #293