### PR TITLE
fix(solana): use BTreeMap in exponent_finance and kamino_limit configs

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/exponent_finance/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/exponent_finance/config.rs
@@ -1,6 +1,6 @@
 use super::EXPONENT_FINANCE_PROGRAM_ID;
 use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub struct ExponentFinanceConfig;
 
@@ -12,8 +12,8 @@ impl SolanaIntegrationConfig for ExponentFinanceConfig {
     fn data(&self) -> &SolanaIntegrationConfigData {
         static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
         DATA.get_or_init(|| {
-            let mut programs = HashMap::new();
-            let mut instructions = HashMap::new();
+            let mut programs = BTreeMap::new();
+            let mut instructions = BTreeMap::new();
             instructions.insert("*", vec!["*"]);
             programs.insert(EXPONENT_FINANCE_PROGRAM_ID, instructions);
             SolanaIntegrationConfigData { programs }

--- a/src/chain_parsers/visualsign-solana/src/presets/kamino_limit/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/kamino_limit/config.rs
@@ -1,6 +1,6 @@
 use super::KAMINO_LIMIT_PROGRAM_ID;
 use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub struct KaminoLimitConfig;
 
@@ -12,8 +12,8 @@ impl SolanaIntegrationConfig for KaminoLimitConfig {
     fn data(&self) -> &SolanaIntegrationConfigData {
         static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
         DATA.get_or_init(|| {
-            let mut programs = HashMap::new();
-            let mut instructions = HashMap::new();
+            let mut programs = BTreeMap::new();
+            let mut instructions = BTreeMap::new();
             instructions.insert("*", vec!["*"]);
             programs.insert(KAMINO_LIMIT_PROGRAM_ID, instructions);
             SolanaIntegrationConfigData { programs }


### PR DESCRIPTION
## Summary

PR #288 forbade `std::collections::{HashMap, HashSet}` via clippy `disallowed-types` and converted the existing preset configs to `BTreeMap`, but missed the two presets that landed during the same review window:

- `exponent_finance` (PR #275, merged 2026-05-12 22:00 UTC)
- `kamino_limit` (PR #284, merged 2026-05-11 14:50 UTC)

Both still constructed `HashMap` and passed it where `SolanaIntegrationConfigData` now expects `BTreeMap`, so `cargo build -p visualsign-solana` fails on post-#288 main. This is blocking PR #278 (and any other PR rebasing onto main) from going green.

Two trivial 2-line edits: change `HashMap::new()` to `BTreeMap::new()` and update the `use` import in each file. No semantic change — `SolanaIntegrationConfigData` already deterministically orders via `BTreeMap`, so this just aligns construction with the expected type.

## Test plan

- [x] `cargo build -p visualsign-solana` succeeds locally
- [x] `cargo clippy -p visualsign-solana --all-targets -- -D warnings` is clean locally
- [x] `cargo fmt --check` is clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)