### PR TITLE
fix(parser_cli): keep text display fixture diagnostics-agnostic

### DIFF
--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -203,16 +203,53 @@ fn test_cli_with_fixtures() {
                 }
             }
             Err(_) => {
-                // Non-JSON output (text/human): plain string comparison
+                // Non-JSON output (text/human): strip diagnostic blocks from the
+                // actual Debug-formatted payload so the display fixture stays
+                // diagnostics-agnostic, matching how the JSON branch filters them above.
+                #[cfg_attr(not(feature = "diagnostics"), allow(unused_mut))]
+                let mut actual_display = actual_output.trim().to_string();
+                #[cfg(feature = "diagnostics")]
+                {
+                    actual_display = strip_debug_diagnostic_blocks(&actual_display);
+                }
                 assert_strings_match(
                     test_name,
                     "display",
                     expected_display.trim(),
-                    actual_output.trim(),
+                    &actual_display,
                 );
             }
         }
     }
+}
+
+/// Remove `Diagnostic { ... },` blocks from a Rust `{:#?}` payload dump.
+/// The blocks live inside the `fields:` array at 8-space indent, so balanced-brace
+/// counting from each `        Diagnostic {` line drops the whole entry.
+#[cfg(feature = "diagnostics")]
+fn strip_debug_diagnostic_blocks(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut depth: i32 = 0;
+    for line in input.lines() {
+        if depth == 0 && line == "        Diagnostic {" {
+            depth = 1;
+            continue;
+        }
+        if depth > 0 {
+            depth += line.matches('{').count() as i32;
+            depth -= line.matches('}').count() as i32;
+            if depth == 0 {
+                continue;
+            }
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    if !input.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 fn assert_strings_match(test_name: &str, fixture_type: &str, expected: &str, actual: &str) {

--- a/src/parser/cli/tests/fixtures/solana-text.display.expected
+++ b/src/parser/cli/tests/fixtures/solana-text.display.expected
@@ -737,32 +737,6 @@ SignablePayload {
                 ),
             },
         },
-        Diagnostic {
-            common: SignablePayloadFieldCommon {
-                fallback_text: "ok: all 6 instructions have valid program_id_index",
-                label: "transaction::oob_program_id",
-            },
-            diagnostic: SignablePayloadFieldDiagnostic {
-                rule: "transaction::oob_program_id",
-                domain: "transaction",
-                level: "ok",
-                message: "all 6 instructions have valid program_id_index",
-                instruction_index: None,
-            },
-        },
-        Diagnostic {
-            common: SignablePayloadFieldCommon {
-                fallback_text: "ok: all 6 instructions have valid account indices",
-                label: "transaction::oob_account_index",
-            },
-            diagnostic: SignablePayloadFieldDiagnostic {
-                rule: "transaction::oob_account_index",
-                domain: "transaction",
-                level: "ok",
-                message: "all 6 instructions have valid account indices",
-                instruction_index: None,
-            },
-        },
     ],
     payload_type: "SolanaTx",
     subtitle: None,


### PR DESCRIPTION
## Summary

- Stagex's `parser_cli` build runs `cargo test --no-default-features --features solana`, which disables the default `diagnostics` feature. The post-#228 `solana-text.display.expected` baked in the new `Diagnostic { ... }` blocks, so when the binary ran without diagnostics emitted, the actual output diverged from the fixture and `test_cli_with_fixtures` failed inside the container (visible on main's most recent `stagex` job for `1e4fe64`).
- Mirror the separation the JSON path already enforces: display fixtures contain only display fields; diagnostics are tested via the diagnostics fixture. The text path now strips `Diagnostic { ... },` blocks from the Debug dump before comparing (gated on the `diagnostics` feature).

## Test plan

- [x] `cd src && cargo test -p parser_cli` (default features: diagnostics on) — 8 tests pass
- [x] `cd src && cargo test -p parser_cli --no-default-features --features solana` (stagex config) — 3 tests pass
- [ ] Confirm green stagex run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)