### PR TITLE
feat(parser_app): chain-feature flags mirroring parser_cli (#82)

### DIFF
--- a/images/parser_app/Containerfile
+++ b/images/parser_app/Containerfile
@@ -11,6 +11,14 @@ ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
 ARG VERSION
 ENV VERSION=$VERSION
 
+# Chain visualizers compiled into this image. Override per deployment with
+# --build-arg CHAIN_FEATURES="<space-separated subset>". CARGOFLAGS above
+# passes --no-default-features, so chains not listed here are NOT linked into
+# the binary, shrinking both the image and the attestation surface. Default
+# mirrors parser_app/Cargo.toml's `default` feature set.
+ARG CHAIN_FEATURES="ethereum solana sui tron unspecified"
+ENV CHAIN_FEATURES=$CHAIN_FEATURES
+
 # Load Rust sources
 ADD src /src
 WORKDIR /src/
@@ -21,7 +29,7 @@ RUN cargo fetch
 WORKDIR /src/parser/app
 RUN --network=none <<-EOF
     set -eu
-    cargo build ${CARGOFLAGS} --features vsock
+    cargo build ${CARGOFLAGS} --features "vsock ${CHAIN_FEATURES}"
     mkdir -p /rootfs
     mv ${RELEASE_DIR}/parser_app /rootfs/
 EOF

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,19 @@ lint:
 	cargo clippy -p visualsign --features diagnostics --lib -- -D warnings
 	cargo clippy -p visualsign-solana --features diagnostics --lib -- -D warnings
 
+.PHONY: narrow-build-check
+narrow-build-check:
+	@# Guards parser_app's per-chain feature gating. If a future change
+	@# re-introduces an unconditional reference to a chain crate from
+	@# parser_app, one of these narrow builds will fail to compile.
+	@# Not wired into CI yet — invoke manually or via a follow-up workflow.
+	cargo build -p parser_app --no-default-features
+	cargo build -p parser_app --no-default-features --features ethereum
+	cargo build -p parser_app --no-default-features --features solana
+	cargo clippy -p parser_app --no-default-features --all-targets -- -D warnings
+	cargo clippy -p parser_app --no-default-features --features ethereum --all-targets -- -D warnings
+	cargo clippy -p parser_app --no-default-features --features solana --all-targets -- -D warnings
+
 .PHONY: generated
 generated:
 	cargo run --manifest-path ./codegen/Cargo.toml && make fmt

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,13 @@ PARSER_INNER_SOCKET_PATH ?= /tmp/inner_parser.sock
 
 ROOT := $(shell git rev-parse --show-toplevel)
 
+# Chains parser_app can be built with, derived from chain_parsers/visualsign-*.
+# Adding a new chain crate under chain_parsers/visualsign-<name>/ automatically
+# extends narrow-build-check below without further edits. Assumes the
+# 1:1 convention: chain_parsers/visualsign-<name>/ <-> parser_app's
+# `<name>` Cargo feature (see parser_app/Cargo.toml [features]).
+PARSER_APP_CHAINS := $(patsubst visualsign-%,%,$(notdir $(wildcard chain_parsers/visualsign-*)))
+
 .PHONY: all
 all: generated
 	make build
@@ -49,13 +56,19 @@ narrow-build-check:
 	@# Guards parser_app's per-chain feature gating. If a future change
 	@# re-introduces an unconditional reference to a chain crate from
 	@# parser_app, one of these narrow builds will fail to compile.
-	@# Not wired into CI yet — invoke manually or via a follow-up workflow.
+	@# Not wired into CI yet -- invoke manually or via a follow-up
+	@# workflow. Driven by $(PARSER_APP_CHAINS) so new chain crates are
+	@# picked up automatically.
+	@#
+	@# Includes clippy under each narrow feature set so dead-code /
+	@# unused-import lints that only trigger when a chain is OFF are
+	@# enforced (make lint above only covers default features).
 	cargo build -p parser_app --no-default-features
-	cargo build -p parser_app --no-default-features --features ethereum
-	cargo build -p parser_app --no-default-features --features solana
 	cargo clippy -p parser_app --no-default-features --all-targets -- -D warnings
-	cargo clippy -p parser_app --no-default-features --features ethereum --all-targets -- -D warnings
-	cargo clippy -p parser_app --no-default-features --features solana --all-targets -- -D warnings
+	@set -e; for c in $(PARSER_APP_CHAINS); do \
+		cargo build -p parser_app --no-default-features --features $$c; \
+		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
+	done
 
 .PHONY: generated
 generated:

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -12,13 +12,7 @@ qos_hex = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 qos_test_primitives = { workspace = true }
 
-parser_app = { path = "../parser/app", default-features = false, features = [
-  "ethereum",
-  "solana",
-  "sui",
-  "tron",
-  "unspecified",
-] }
+parser_app = { path = "../parser/app" }
 
 generated = { path = "../generated", default-features = false }
 

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -12,7 +12,13 @@ qos_hex = { workspace = true }
 qos_nsm = { workspace = true, features = ["mock"] }
 qos_test_primitives = { workspace = true }
 
-parser_app = { path = "../parser/app", default-features = false }
+parser_app = { path = "../parser/app", default-features = false, features = [
+  "ethereum",
+  "solana",
+  "sui",
+  "tron",
+  "unspecified",
+] }
 
 generated = { path = "../generated", default-features = false }
 

--- a/src/parser/app/Cargo.toml
+++ b/src/parser/app/Cargo.toml
@@ -17,11 +17,11 @@ health_check = { path = "../../health_check" }
 host_primitives = { path = "../../host_primitives" }
 metrics = { path = "../../metrics" }
 visualsign = {workspace = true}
-visualsign-ethereum = { path = "../../chain_parsers/visualsign-ethereum"}
-visualsign-solana = { path = "../../chain_parsers/visualsign-solana"}
-visualsign-sui = { path = "../../chain_parsers/visualsign-sui"}
-visualsign-tron = { path = "../../chain_parsers/visualsign-tron"}
-visualsign-unspecified = { path = "../../chain_parsers/visualsign-unspecified"}
+visualsign-ethereum = { path = "../../chain_parsers/visualsign-ethereum", optional = true }
+visualsign-solana = { path = "../../chain_parsers/visualsign-solana", optional = true }
+visualsign-sui = { path = "../../chain_parsers/visualsign-sui", optional = true }
+visualsign-tron = { path = "../../chain_parsers/visualsign-tron", optional = true }
+visualsign-unspecified = { path = "../../chain_parsers/visualsign-unspecified", optional = true }
 
 serde_json = "1"
 serde = { version = "1", features = ["derive"], default-features = false }
@@ -32,6 +32,17 @@ bs58 = { version = "0.5.1", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
 
 [features]
+# diagnostics is intentionally NOT in `default`: parser_app is the production
+# binary, and `cargo build --workspace --exclude parser_cli` (see Makefile)
+# relies on diagnostics being OFF for parser_app/integration to keep the
+# production payload shape. Opt in explicitly with `--features diagnostics`.
+default = ["ethereum", "solana", "sui", "tron", "unspecified"]
+ethereum = ["dep:visualsign-ethereum"]
+solana = ["dep:visualsign-solana"]
+sui = ["dep:visualsign-sui"]
+tron = ["dep:visualsign-tron"]
+unspecified = ["dep:visualsign-unspecified"]
+diagnostics = ["visualsign/diagnostics", "visualsign-solana?/diagnostics"]
 vsock = ["qos_core/vm"]
 
 [lints]

--- a/src/parser/app/src/registry.rs
+++ b/src/parser/app/src/registry.rs
@@ -1,9 +1,13 @@
 //! Registry module for managing type definitions and lookups
 
 // TODO(pg): this may not be the right place for this
-/// Creates and configures a new transaction converter registry with all supported chains.
+/// Creates and configures a new transaction converter registry.
 ///
-/// Returns a registry with converters for Solana and Unspecified transaction types.
+/// Returns a registry containing a converter for each chain enabled via Cargo
+/// features (see `[features]` in `parser_app/Cargo.toml`). Chains whose
+/// feature is disabled are omitted; requests for those chains hit the
+/// registry-miss path in `convert_transaction` and surface as
+/// `InvalidArgument` at the gRPC layer.
 #[must_use]
 pub fn create_registry() -> visualsign::registry::TransactionConverterRegistry {
     #[allow(unused_mut)] // mut is unused when no chain features are enabled

--- a/src/parser/app/src/registry.rs
+++ b/src/parser/app/src/registry.rs
@@ -6,25 +6,31 @@
 /// Returns a registry with converters for Solana and Unspecified transaction types.
 #[must_use]
 pub fn create_registry() -> visualsign::registry::TransactionConverterRegistry {
+    #[allow(unused_mut)] // mut is unused when no chain features are enabled
     let mut registry = visualsign::registry::TransactionConverterRegistry::new();
     // TODO: Create a ChainRegistry trait that all chains can implement for token metadata,
     // contract types, etc. Currently only Ethereum has a ContractRegistry.
+    #[cfg(feature = "ethereum")]
     registry.register::<visualsign_ethereum::EthereumTransactionWrapper, _>(
         visualsign::registry::Chain::Ethereum,
         visualsign_ethereum::EthereumVisualSignConverter::new(),
     );
+    #[cfg(feature = "solana")]
     registry.register::<visualsign_solana::SolanaTransactionWrapper, _>(
         visualsign::registry::Chain::Solana,
         visualsign_solana::SolanaVisualSignConverter,
     );
+    #[cfg(feature = "sui")]
     registry.register::<visualsign_sui::SuiTransactionWrapper, _>(
         visualsign::registry::Chain::Sui,
         visualsign_sui::SuiVisualSignConverter,
     );
+    #[cfg(feature = "tron")]
     registry.register::<visualsign_tron::TronTransactionWrapper, _>(
         visualsign::registry::Chain::Tron,
         visualsign_tron::TronVisualSignConverter,
     );
+    #[cfg(feature = "unspecified")]
     registry.register::<visualsign_unspecified::UnspecifiedTransactionWrapper, _>(
         visualsign::registry::Chain::Unspecified,
         visualsign_unspecified::UnspecifiedVisualSignConverter,


### PR DESCRIPTION
## Summary

Make per-chain converters in `parser_app` opt-in via Cargo features (`ethereum`, `solana`, `sui`, `tron`, `unspecified`), matching the pattern `parser_cli` already uses. Production deployments can now build a narrower TEE binary containing only the chains they need, shrinking both the image and the attestation surface. `default` keeps all five chains so existing consumers (`grpc-server`, `examples`, the workspace `make` targets) are unchanged.

Closes #82.

## What changed

- `src/parser/app/Cargo.toml` — chain crates moved behind `optional = true`; new `[features]` block with one feature per chain plus a `diagnostics` feature. `default = [ethereum, solana, sui, tron, unspecified]`; `diagnostics` is intentionally **not** in default to preserve the `make build --workspace --exclude parser_cli` invariant that keeps diagnostics OFF for the production payload shape.
- `src/parser/app/src/registry.rs` — each `register::<...>` call is `#[cfg(feature = "<chain>")]`-gated. Doc comment updated to describe the feature-gated set.
- `src/integration/Cargo.toml` — drops `default-features = false` on `parser_app` (a no-op before this PR; under the new gating it would have disabled every chain). Now relies on `parser_app`'s `default`.
- `images/parser_app/Containerfile` — the stagex/TEE build runs `cargo build --no-default-features ...`, which before this PR was a no-op for chains and after would have produced a chains-empty binary. Parameterized via `ARG CHAIN_FEATURES`, defaulting to all five chains so the production image is functionally unchanged; per-environment overrides can pass `--build-arg CHAIN_FEATURES="..."` to ship narrower images.
- `src/Makefile` — new `narrow-build-check` target that builds + clippies `parser_app` under `--no-default-features` and single-chain feature sets. Future PRs that re-introduce an unconditional chain crate reference in `parser_app` will fail this target.

## Alternatives considered

We discussed three shapes for closing #82 before landing on Cargo-features-only:

1. **Runtime allow-list flag** (e.g. `--chains ethereum,solana`) — narrow which compiled-in chains the server actually serves at startup. Adds a third selection layer on top of Cargo features + per-request `parse_request.chain`. Strictly more expressive than this PR (lets ops disable a compiled-in chain in flight without rebuilding), but not necessary to satisfy the issue's "overridden for production env" intent, which `--build-arg CHAIN_FEATURES` already covers. Left as a possible follow-up if a concrete operability need appears.
2. **Per-chain `parser_app` binaries + routing proxy** — split `parser_app` into N narrow binaries (one per chain), with a proxy that reads `parse_request.chain` and forwards to the right backend. Architecturally cleanest mirror of `parser_cli`'s "one chain per process" model, but a multi-week project: signing-key design (each backend has its own ephemeral key, or the proxy joins the TCB), per-binary attestation measurements, service discovery, and N-fold ops surface. Out of scope for #82.
3. **Cargo-features-only (this PR)** — the minimum that closes #82's actual ask. Cleanest interaction with the existing Makefile invariant on diagnostics and with the stagex image pipeline.

## Follow-ups (could be separate PRs)

- Wire `make narrow-build-check` into `.github/workflows/main.yml` so the smoke check runs on every PR. Kept out of this PR to avoid bundling CI changes; ready to land as its own one-line addition.
- If the operability case appears later, add `--chains <csv>` to `parser/app/src/cli.rs` as a startup allow-list on top of compiled-in chains.

## Test plan

- [x] `make -C src test` — full workspace tests, including the diagnostics-OFF/ON split, exit 0.
- [x] `make -C src lint` — clippy `-D warnings` across the four workspace splits, exit 0.
- [x] `make -C src narrow-build-check` — builds and clippies `parser_app` with `--no-default-features`, `--features ethereum`, and `--features solana`, exit 0.
- [x] `cargo build -p parser_app` (default) — succeeds.
- [x] Code review (Senior Code Reviewer subagent) — Critical (Containerfile regression) addressed; Important (narrow-build smoke check) addressed via Makefile target; Minor doc + integration cleanup addressed.
- [x] Security review — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)