### PR TITLE
ci(parser_app): wire narrow-build-check; add local-only feature-matrix target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,3 +60,5 @@ jobs:
         run: make -C src lint
       - name: Run tests
         run: make -C src test
+      - name: Check parser_app narrow feature builds
+        run: make -C src narrow-build-check

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,12 +7,12 @@ PARSER_INNER_SOCKET_PATH ?= /tmp/inner_parser.sock
 
 ROOT := $(shell git rev-parse --show-toplevel)
 
-# Chains parser_app can be built with, derived from chain_parsers/visualsign-*.
-# Adding a new chain crate under chain_parsers/visualsign-<name>/ automatically
-# extends narrow-build-check below without further edits. Assumes the
-# 1:1 convention: chain_parsers/visualsign-<name>/ <-> parser_app's
-# `<name>` Cargo feature (see parser_app/Cargo.toml [features]).
-PARSER_APP_CHAINS := $(patsubst visualsign-%,%,$(notdir $(wildcard chain_parsers/visualsign-*)))
+# Chains parser_app can be built with. Single source of truth for both
+# narrow-build-check and feature-matrix-check below; keep in sync with
+# the [features] block in parser_app/Cargo.toml. Listed alphabetically
+# so the depth-2 pair generator in feature-matrix-check produces stable,
+# unique pairs.
+PARSER_APP_CHAINS := ethereum solana sui tron unspecified
 
 .PHONY: all
 all: generated
@@ -56,9 +56,10 @@ narrow-build-check:
 	@# Guards parser_app's per-chain feature gating. If a future change
 	@# re-introduces an unconditional reference to a chain crate from
 	@# parser_app, one of these narrow builds will fail to compile.
-	@# Not wired into CI yet -- invoke manually or via a follow-up
-	@# workflow. Driven by $(PARSER_APP_CHAINS) so new chain crates are
-	@# picked up automatically.
+	@# Wired into main CI; runs on every PR. Driven by
+	@# $(PARSER_APP_CHAINS) above -- when a chain is added to
+	@# parser_app/Cargo.toml, extend that variable and the matrix picks
+	@# the new chain up.
 	@#
 	@# Includes clippy under each narrow feature set so dead-code /
 	@# unused-import lints that only trigger when a chain is OFF are
@@ -68,6 +69,38 @@ narrow-build-check:
 	@set -e; for c in $(PARSER_APP_CHAINS); do \
 		cargo build -p parser_app --no-default-features --features $$c; \
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
+	done
+
+.PHONY: feature-matrix-check
+feature-matrix-check:
+	@# Deep coverage of parser_app's feature gating: every chain alone,
+	@# every chain + diagnostics, every depth-2 pair, and every depth-2
+	@# pair + diagnostics. Hand-rolled (no cargo-hack dependency); matrix
+	@# is generated from $(PARSER_APP_CHAINS) above.
+	@#
+	@# Note: `diagnostics` propagates to the always-on `visualsign` core
+	@# crate, and weakly to `visualsign-solana` via the `?` syntax. The
+	@# non-solana + diagnostics combos still exercise the weak-dep path
+	@# (resolving to a no-op for visualsign-solana).
+	@#
+	@# LOCAL ONLY -- not wired into CI. The full matrix accumulates ~28GB
+	@# in the cargo target dir; ensure ~30GB free in src/target before
+	@# running. Use before releases or when touching feature definitions;
+	@# the per-PR narrow-build-check above covers the common regression
+	@# class on every change.
+	@set -e; for c in $(PARSER_APP_CHAINS); do \
+		cargo build -p parser_app --no-default-features --features $$c; \
+		cargo build -p parser_app --no-default-features --features "$$c diagnostics"; \
+	done
+	@set -e; i=0; for c1 in $(PARSER_APP_CHAINS); do \
+		i=$$((i+1)); j=0; \
+		for c2 in $(PARSER_APP_CHAINS); do \
+			j=$$((j+1)); \
+			if [ $$j -gt $$i ]; then \
+				cargo build -p parser_app --no-default-features --features "$$c1 $$c2"; \
+				cargo build -p parser_app --no-default-features --features "$$c1 $$c2 diagnostics"; \
+			fi; \
+		done; \
 	done
 
 .PHONY: generated

--- a/src/Makefile
+++ b/src/Makefile
@@ -67,6 +67,7 @@ narrow-build-check:
 	cargo build -p parser_app --no-default-features
 	cargo clippy -p parser_app --no-default-features --all-targets -- -D warnings
 	@set -e; for c in $(PARSER_APP_CHAINS); do \
+		echo "==> features: $$c"; \
 		cargo build -p parser_app --no-default-features --features $$c; \
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
 	done
@@ -89,7 +90,9 @@ feature-matrix-check:
 	@# the per-PR narrow-build-check above covers the common regression
 	@# class on every change.
 	@set -e; for c in $(PARSER_APP_CHAINS); do \
+		echo "==> features: $$c"; \
 		cargo build -p parser_app --no-default-features --features $$c; \
+		echo "==> features: $$c diagnostics"; \
 		cargo build -p parser_app --no-default-features --features "$$c diagnostics"; \
 	done
 	@set -e; i=0; for c1 in $(PARSER_APP_CHAINS); do \
@@ -97,7 +100,9 @@ feature-matrix-check:
 		for c2 in $(PARSER_APP_CHAINS); do \
 			j=$$((j+1)); \
 			if [ $$j -gt $$i ]; then \
+				echo "==> features: $$c1 $$c2"; \
 				cargo build -p parser_app --no-default-features --features "$$c1 $$c2"; \
+				echo "==> features: $$c1 $$c2 diagnostics"; \
 				cargo build -p parser_app --no-default-features --features "$$c1 $$c2 diagnostics"; \
 			fi; \
 		done; \


### PR DESCRIPTION
## Summary

Stacks on top of #302. Adds CI coverage for the feature-gating pattern that PR introduces:

- **CI**: lifts the `narrow-build-check` Makefile target from 3 builds to 6 (empty + each chain individually) and wires it into the main CI workflow so every PR fails fast on unconditional chain-crate references in `parser_app` code. Cheap (~4GB cargo target dir) because subsequent builds reuse the cache from `make test`.
- **Local-only**: adds a `feature-matrix-check` Makefile target (30 builds: singles, singles + diagnostics, depth-2 pairs, depth-2 pairs + diagnostics) for engineers to run before releases or when touching feature definitions. **Not wired into CI** because the matrix accumulates ~28GB in the cargo target dir, which is too heavy to impose on shared CI infrastructure even when gated.

## What changed

- `src/Makefile` — `narrow-build-check` lifted to 6 builds; `feature-matrix-check` added with 30 hand-rolled combinations and a clear LOCAL ONLY comment.
- `.github/workflows/main.yml` — new step running `make narrow-build-check` after the existing `test` step.

## Why this shape

`narrow-build-check` catches the single most likely regression class — a new `use visualsign_<chain>::...` reference in `parser_app` that isn't `#[cfg]`-gated. Cheap enough to run on every PR.

`feature-matrix-check` exists for the rarer case of feature-unification bugs across pairs and the diagnostics axis. Engineers can run it pre-release or when modifying feature definitions, but its disk footprint makes it a poor fit for steady-state CI. If a deeper CI matrix becomes warranted, swapping `feature-matrix-check` for `cargo hack --feature-powerset` or running it on a self-hosted runner with more disk would be the path.

Both targets use `cargo build` (not `cargo check`) and are hand-rolled — no `cargo-hack` dependency.

## Test plan

- [x] `make -C src narrow-build-check` — 6 cargo builds, exit 0.
- [x] `make -C src feature-matrix-check` — 30 cargo builds, exit 0. Target dir grew to ~28GB (hence the local-only positioning).
- [x] Pre-commit hook: cargo fmt + clippy clean.

## Alternatives considered

- **`cargo hack --feature-powerset` in CI**: the standard Rust ecosystem tool. Rejected for this PR to avoid introducing new tooling; can replace `feature-matrix-check` as a one-liner later.
- **Label-gated CI workflow for `feature-matrix-check`**: prototyped, then dropped due to the 28GB disk impact even on `ubuntu-latest-4-cores`. Local-only is cleaner.
- **Every-PR exhaustive matrix**: too heavy on CI runtime; offers diminishing returns over `narrow-build-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)