### PR TITLE
fix(stagex): emit expectedPivotDigest as pure hex (no `sha256:` prefix)

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -166,7 +166,12 @@ jobs:
             echo ""
             echo "- **Container Image URL**: \`${pinned_url}\`"
             echo "- **Executable path**: \`/parser_app\`"
-            echo "- **Expected Executable Digest**: \`sha256:${digest}\`"
+            # Plain hex, no `sha256:` prefix — that's what QOS' Manifest schema
+            # decodes for the pivot hash, and what `tvc deploy create` then
+            # forwards verbatim into the server-side manifest. A `sha256:`
+            # prefix makes the field 71 chars (odd), tripping hex::decode in
+            # `tvc deploy approve` with `OddLength at line 8 column 85`.
+            echo "- **Expected Executable Digest**: \`${digest}\`"
             echo "- **QOS Version**: \`${qos_version}\`"
             echo ""
             echo "### Verify the executable digest"
@@ -188,7 +193,7 @@ jobs:
             echo '# Edit tvc-deploy.json to set:'
             echo "#   \"pivotContainerImageUrl\": \"${pinned_url}\""
             echo '#   "pivotPath": "/parser_app"'
-            echo "#   \"expectedPivotDigest\": \"sha256:${digest}\""
+            echo "#   \"expectedPivotDigest\": \"${digest}\""
             echo "#   \"qosVersion\": \"${qos_version}\""
             echo '#   "appId": "<env-specific>"'
             echo 'tvc deploy create tvc-deploy.json'


### PR DESCRIPTION
## Summary

- The TVC deployment block in `stagex.yml` emits `expectedPivotDigest` as `sha256:<hex>`, but QOS's `Manifest` schema decodes that field as raw hex. The 7-char prefix makes the value 71 chars total (odd), so `tvc deploy approve` fails parsing the server-stored manifest with `OddLength at line 8 column 85`.
- Drop the `sha256:` prefix in both the human-readable "Expected Executable Digest" line and the paste-ready `tvc deploy init` template so what stagex emits is what tvc actually accepts.

## How this surfaced

While bringing a parser_http_server build up under TVC, every `tvc deploy approve` against the new deploy failed with:

```
Fetching deployment <id>...
Error: failed to parse manifest from deployment

Caused by:
    OddLength at line 8 column 85
```

I patched the local `tvc` source to dump the raw server-side manifest before the parse step:

```rust
let dump_path = std::env::var("TVC_MANIFEST_DUMP").unwrap_or_default();
if !dump_path.is_empty() { std::fs::write(&dump_path, &tvc_manifest.manifest)?; }
let manifest: Manifest = serde_json::from_slice(&tvc_manifest.manifest)
    .context("failed to parse manifest from deployment")?;
```

Line 8 of the dumped manifest:

```
    "hash": "sha256:38831b14113a6ec7cb088a459ce3a4457f5598011f592ffc9947c87e13f89314",
```

Cross-checked against `helloworld`'s working deploy:

```
    "hash": "cbe01169428f144086bfaef348bbf3db70f9217628996cafd2ecb85d5f2b47a1",
```

Pure hex in the working one; `sha256:`-prefixed in ours. Recreating the deploy with the prefix stripped from `expectedPivotDigest` made `tvc deploy approve` parse the manifest cleanly.

## Test plan

- [ ] Run stagex on any branch (e.g. via PR `stagex` label) and confirm the `TVC Deployment Details` block in the workflow summary shows the executable digest as plain hex.
- [ ] Copy the emitted `expectedPivotDigest` into a `tvc deploy create` config; `tvc deploy approve --deploy-id <id> --operator-id <id>` should reach `✓ Manifest loaded` instead of failing with `OddLength`.