### PR TITLE
fix(visualsign-solana): refresh Jupiter v6 IDL from on-chain

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/jupiter_agg_v6.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/jupiter_agg_v6.json
@@ -1,260 +1,14 @@
 {
-  "accounts": [
-    {
-      "discriminator": [
-        156,
-        247,
-        9,
-        188,
-        54,
-        108,
-        85,
-        77
-      ],
-      "name": "TokenLedger"
-    }
-  ],
   "address": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
-  "errors": [
-    {
-      "code": 6000,
-      "msg": "Empty route",
-      "name": "EmptyRoute"
-    },
-    {
-      "code": 6001,
-      "msg": "Slippage tolerance exceeded",
-      "name": "SlippageToleranceExceeded"
-    },
-    {
-      "code": 6002,
-      "msg": "Invalid calculation",
-      "name": "InvalidCalculation"
-    },
-    {
-      "code": 6003,
-      "msg": "Missing platform fee account",
-      "name": "MissingPlatformFeeAccount"
-    },
-    {
-      "code": 6004,
-      "msg": "Invalid slippage",
-      "name": "InvalidSlippage"
-    },
-    {
-      "code": 6005,
-      "msg": "Not enough percent to 100",
-      "name": "NotEnoughPercent"
-    },
-    {
-      "code": 6006,
-      "msg": "Token input index is invalid",
-      "name": "InvalidInputIndex"
-    },
-    {
-      "code": 6007,
-      "msg": "Token output index is invalid",
-      "name": "InvalidOutputIndex"
-    },
-    {
-      "code": 6008,
-      "msg": "Not Enough Account keys",
-      "name": "NotEnoughAccountKeys"
-    },
-    {
-      "code": 6009,
-      "msg": "Non zero minimum out amount not supported",
-      "name": "NonZeroMinimumOutAmountNotSupported"
-    },
-    {
-      "code": 6010,
-      "msg": "Invalid route plan",
-      "name": "InvalidRoutePlan"
-    },
-    {
-      "code": 6011,
-      "msg": "Invalid referral authority",
-      "name": "InvalidReferralAuthority"
-    },
-    {
-      "code": 6012,
-      "msg": "Token account doesn't match the ledger",
-      "name": "LedgerTokenAccountDoesNotMatch"
-    },
-    {
-      "code": 6013,
-      "msg": "Invalid token ledger",
-      "name": "InvalidTokenLedger"
-    },
-    {
-      "code": 6014,
-      "msg": "Token program ID is invalid",
-      "name": "IncorrectTokenProgramID"
-    },
-    {
-      "code": 6015,
-      "msg": "Token program not provided",
-      "name": "TokenProgramNotProvided"
-    },
-    {
-      "code": 6016,
-      "msg": "Swap not supported",
-      "name": "SwapNotSupported"
-    },
-    {
-      "code": 6017,
-      "msg": "Exact out amount doesn't match",
-      "name": "ExactOutAmountNotMatched"
-    },
-    {
-      "code": 6018,
-      "msg": "Source mint and destination mint cannot the same",
-      "name": "SourceAndDestinationMintCannotBeTheSame"
-    },
-    {
-      "code": 6019,
-      "msg": "Invalid mint",
-      "name": "InvalidMint"
-    },
-    {
-      "code": 6020,
-      "msg": "Invalid program authority",
-      "name": "InvalidProgramAuthority"
-    },
-    {
-      "code": 6021,
-      "msg": "Invalid output token account",
-      "name": "InvalidOutputTokenAccount"
-    },
-    {
-      "code": 6022,
-      "msg": "Invalid fee wallet",
-      "name": "InvalidFeeWallet"
-    },
-    {
-      "code": 6023,
-      "msg": "Invalid authority",
-      "name": "InvalidAuthority"
-    },
-    {
-      "code": 6024,
-      "msg": "Insufficient funds",
-      "name": "InsufficientFunds"
-    },
-    {
-      "code": 6025,
-      "msg": "Invalid token account",
-      "name": "InvalidTokenAccount"
-    },
-    {
-      "code": 6026,
-      "msg": "Bonding curve already completed",
-      "name": "BondingCurveAlreadyCompleted"
-    }
-  ],
-  "events": [
-    {
-      "discriminator": [
-        73,
-        79,
-        78,
-        127,
-        184,
-        213,
-        13,
-        220
-      ],
-      "name": "FeeEvent"
-    },
-    {
-      "discriminator": [
-        64,
-        198,
-        205,
-        232,
-        38,
-        8,
-        113,
-        226
-      ],
-      "name": "SwapEvent"
-    },
-    {
-      "discriminator": [
-        152,
-        47,
-        78,
-        235,
-        192,
-        96,
-        110,
-        106
-      ],
-      "name": "SwapsEvent"
-    },
-    {
-      "discriminator": [
-        45,
-        9,
-        244,
-        30,
-        229,
-        52,
-        168,
-        123
-      ],
-      "name": "CandidateSwapResults"
-    },
-    {
-      "discriminator": [
-        248,
-        134,
-        37,
-        55,
-        145,
-        177,
-        114,
-        79
-      ],
-      "name": "CandidateSwapQuoteError"
-    },
-    {
-      "discriminator": [
-        124,
-        66,
-        196,
-        51,
-        218,
-        173,
-        46,
-        93
-      ],
-      "name": "BestSwapOutAmountViolation"
-    }
-  ],
+  "metadata": {
+    "name": "jupiter",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Jupiter aggregator program"
+  },
   "instructions": [
     {
-      "accounts": [
-        {
-          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
-          "name": "wallet",
-          "writable": true
-        },
-        {
-          "name": "program_authority",
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [
-        {
-          "name": "id",
-          "type": "u8"
-        }
-      ],
+      "name": "claim",
       "discriminator": [
         62,
         198,
@@ -265,19 +19,50 @@
         108,
         210
       ],
-      "name": "claim",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
-          "name": "payer",
-          "signer": true,
+          "name": "wallet",
+          "writable": true,
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP"
+        },
+        {
+          "name": "program_authority",
           "writable": true
         },
         {
-          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
-          "name": "wallet"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "claim_token",
+      "discriminator": [
+        116,
+        206,
+        27,
+        191,
+        166,
+        19,
+        0,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "wallet",
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP"
         },
         {
           "name": "program_authority"
@@ -288,7 +73,22 @@
         },
         {
           "name": "destination_token_account",
+          "writable": true,
           "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "wallet"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
             "program": {
               "kind": "const",
               "value": [
@@ -325,23 +125,8 @@
                 248,
                 89
               ]
-            },
-            "seeds": [
-              {
-                "kind": "account",
-                "path": "wallet"
-              },
-              {
-                "kind": "account",
-                "path": "token_program"
-              },
-              {
-                "kind": "account",
-                "path": "mint"
-              }
-            ]
-          },
-          "writable": true
+            }
+          }
         },
         {
           "name": "mint"
@@ -350,12 +135,12 @@
           "name": "token_program"
         },
         {
-          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-          "name": "associated_token_program"
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -364,30 +149,30 @@
           "type": "u8"
         }
       ],
-      "discriminator": [
-        116,
-        206,
-        27,
-        191,
-        166,
-        19,
-        0,
-        73
-      ],
-      "name": "claim_token",
       "returns": "u64"
     },
     {
+      "name": "close_token",
+      "discriminator": [
+        26,
+        74,
+        236,
+        151,
+        104,
+        64,
+        183,
+        249
+      ],
       "accounts": [
         {
-          "address": "9RAufBfjGQjDfrwxeyKmZWPADHSb8HcoqCdrmpqvCr1g",
           "name": "operator",
-          "signer": true
+          "signer": true,
+          "address": "9RAufBfjGQjDfrwxeyKmZWPADHSb8HcoqCdrmpqvCr1g"
         },
         {
-          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP",
           "name": "wallet",
-          "writable": true
+          "writable": true,
+          "address": "7JQeyNK55fkUPUmEotupBFpiBGpgEQYLe8Ht1VdSfxcP"
         },
         {
           "name": "program_authority"
@@ -413,37 +198,10 @@
           "name": "burn_all",
           "type": "bool"
         }
-      ],
-      "discriminator": [
-        26,
-        74,
-        236,
-        151,
-        104,
-        64,
-        183,
-        249
-      ],
-      "name": "close_token"
+      ]
     },
     {
-      "accounts": [
-        {
-          "name": "token_ledger",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "name": "payer",
-          "signer": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [],
+      "name": "create_token_ledger",
       "discriminator": [
         232,
         242,
@@ -454,36 +212,26 @@
         129,
         52
       ],
-      "name": "create_token_ledger"
-    },
-    {
       "accounts": [
         {
-          "name": "token_account",
-          "writable": true
+          "name": "token_ledger",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "user",
-          "signer": true,
-          "writable": true
+          "name": "payer",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "mint"
-        },
-        {
-          "name": "token_program"
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        {
-          "name": "bump",
-          "type": "u8"
-        }
-      ],
+      "args": []
+    },
+    {
+      "name": "create_token_account",
       "discriminator": [
         147,
         241,
@@ -494,9 +242,6 @@
         174,
         118
       ],
-      "name": "create_token_account"
-    },
-    {
       "accounts": [
         {
           "name": "token_account",
@@ -504,19 +249,29 @@
         },
         {
           "name": "user",
-          "signer": true,
-          "writable": true
+          "writable": true,
+          "signer": true
         },
         {
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "mint"
+        },
+        {
           "name": "token_program"
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [],
+      "args": [
+        {
+          "name": "bump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "close_wsol_token_account",
       "discriminator": [
         203,
         129,
@@ -527,81 +282,29 @@
         107,
         86
       ],
-      "name": "close_wsol_token_account"
-    },
-    {
       "accounts": [
         {
-          "name": "token_program"
+          "name": "token_account",
+          "writable": true
         },
         {
-          "name": "user_transfer_authority",
+          "name": "user",
+          "writable": true,
           "signer": true
         },
         {
-          "name": "user_source_token_account",
-          "writable": true
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "user_destination_token_account",
-          "writable": true
-        },
-        {
-          "name": "destination_token_account",
-          "optional": true,
-          "writable": true
-        },
-        {
-          "name": "source_mint"
-        },
-        {
-          "name": "destination_mint"
-        },
-        {
-          "name": "platform_fee_account",
-          "optional": true,
-          "writable": true
-        },
-        {
-          "name": "token_2022_program",
-          "optional": true
-        },
-        {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
-        },
-        {
-          "name": "program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        {
-          "name": "route_plan",
-          "type": {
-            "vec": {
-              "defined": {
-                "name": "RoutePlanStep"
-              }
-            }
-          }
-        },
-        {
-          "name": "out_amount",
-          "type": "u64"
-        },
-        {
-          "name": "quoted_in_amount",
-          "type": "u64"
-        },
-        {
-          "name": "slippage_bps",
-          "type": "u16"
-        },
-        {
-          "name": "platform_fee_bps",
-          "type": "u8"
-        }
-      ],
+      "args": []
+    },
+    {
+      "name": "exact_out_route",
       "discriminator": [
         208,
         51,
@@ -612,10 +315,6 @@
         237,
         92
       ],
-      "name": "exact_out_route",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
           "name": "token_program"
@@ -634,20 +333,27 @@
         },
         {
           "name": "destination_token_account",
-          "optional": true,
-          "writable": true
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "source_mint"
         },
         {
           "name": "destination_mint"
         },
         {
           "name": "platform_fee_account",
-          "optional": true,
-          "writable": true
+          "writable": true,
+          "optional": true
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -665,11 +371,11 @@
           }
         },
         {
-          "name": "in_amount",
+          "name": "out_amount",
           "type": "u64"
         },
         {
-          "name": "quoted_out_amount",
+          "name": "quoted_in_amount",
           "type": "u64"
         },
         {
@@ -681,6 +387,10 @@
           "type": "u8"
         }
       ],
+      "returns": "u64"
+    },
+    {
+      "name": "route",
       "discriminator": [
         229,
         23,
@@ -691,10 +401,6 @@
         173,
         42
       ],
-      "name": "route",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
           "name": "token_program"
@@ -713,23 +419,20 @@
         },
         {
           "name": "destination_token_account",
-          "optional": true,
-          "writable": true
+          "writable": true,
+          "optional": true
         },
         {
           "name": "destination_mint"
         },
         {
           "name": "platform_fee_account",
-          "optional": true,
-          "writable": true
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "token_ledger"
-        },
-        {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -747,6 +450,10 @@
           }
         },
         {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
           "name": "quoted_out_amount",
           "type": "u64"
         },
@@ -759,6 +466,10 @@
           "type": "u8"
         }
       ],
+      "returns": "u64"
+    },
+    {
+      "name": "route_with_token_ledger",
       "discriminator": [
         150,
         86,
@@ -769,20 +480,74 @@
         14,
         104
       ],
-      "name": "route_with_token_ledger",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
-          "name": "token_ledger",
+          "name": "token_program"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
           "writable": true
         },
         {
-          "name": "token_account"
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_ledger"
+        },
+        {
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
+        },
+        {
+          "name": "program"
         }
       ],
-      "args": [],
+      "args": [
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "set_token_ledger",
       "discriminator": [
         228,
         85,
@@ -793,91 +558,19 @@
         77,
         2
       ],
-      "name": "set_token_ledger"
-    },
-    {
       "accounts": [
         {
-          "name": "token_program"
-        },
-        {
-          "name": "program_authority"
-        },
-        {
-          "name": "user_transfer_authority",
-          "signer": true
-        },
-        {
-          "name": "source_token_account",
+          "name": "token_ledger",
           "writable": true
         },
         {
-          "name": "program_source_token_account",
-          "writable": true
-        },
-        {
-          "name": "program_destination_token_account",
-          "writable": true
-        },
-        {
-          "name": "destination_token_account",
-          "writable": true
-        },
-        {
-          "name": "source_mint"
-        },
-        {
-          "name": "destination_mint"
-        },
-        {
-          "name": "platform_fee_account",
-          "optional": true,
-          "writable": true
-        },
-        {
-          "name": "token_2022_program",
-          "optional": true
-        },
-        {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
-        },
-        {
-          "name": "program"
+          "name": "token_account"
         }
       ],
-      "args": [
-        {
-          "name": "id",
-          "type": "u8"
-        },
-        {
-          "name": "route_plan",
-          "type": {
-            "vec": {
-              "defined": {
-                "name": "RoutePlanStep"
-              }
-            }
-          }
-        },
-        {
-          "name": "out_amount",
-          "type": "u64"
-        },
-        {
-          "name": "quoted_in_amount",
-          "type": "u64"
-        },
-        {
-          "name": "slippage_bps",
-          "type": "u16"
-        },
-        {
-          "name": "platform_fee_bps",
-          "type": "u8"
-        }
-      ],
+      "args": []
+    },
+    {
+      "name": "shared_accounts_exact_out_route",
       "discriminator": [
         176,
         209,
@@ -888,10 +581,6 @@
         69,
         62
       ],
-      "name": "shared_accounts_exact_out_route",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
           "name": "token_program"
@@ -927,16 +616,16 @@
         },
         {
           "name": "platform_fee_account",
-          "optional": true,
-          "writable": true
+          "writable": true,
+          "optional": true
         },
         {
           "name": "token_2022_program",
           "optional": true
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -958,11 +647,11 @@
           }
         },
         {
-          "name": "in_amount",
+          "name": "out_amount",
           "type": "u64"
         },
         {
-          "name": "quoted_out_amount",
+          "name": "quoted_in_amount",
           "type": "u64"
         },
         {
@@ -974,6 +663,10 @@
           "type": "u8"
         }
       ],
+      "returns": "u64"
+    },
+    {
+      "name": "shared_accounts_route",
       "discriminator": [
         193,
         32,
@@ -984,10 +677,6 @@
         156,
         129
       ],
-      "name": "shared_accounts_route",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
           "name": "token_program"
@@ -1023,8 +712,104 @@
         },
         {
           "name": "platform_fee_account",
-          "optional": true,
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_2022_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "id",
+          "type": "u8"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStep"
+              }
+            }
+          }
+        },
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u8"
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "shared_accounts_route_with_token_ledger",
+      "discriminator": [
+        230,
+        121,
+        143,
+        80,
+        119,
+        159,
+        106,
+        170
+      ],
+      "accounts": [
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "program_authority"
+        },
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
           "writable": true
+        },
+        {
+          "name": "program_source_token_account",
+          "writable": true
+        },
+        {
+          "name": "program_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "platform_fee_account",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "token_2022_program",
@@ -1034,8 +819,8 @@
           "name": "token_ledger"
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -1069,90 +854,10 @@
           "type": "u8"
         }
       ],
-      "discriminator": [
-        230,
-        121,
-        143,
-        80,
-        119,
-        159,
-        106,
-        170
-      ],
-      "name": "shared_accounts_route_with_token_ledger",
       "returns": "u64"
     },
     {
-      "accounts": [
-        {
-          "name": "user_transfer_authority",
-          "signer": true
-        },
-        {
-          "name": "user_source_token_account",
-          "writable": true
-        },
-        {
-          "name": "user_destination_token_account",
-          "writable": true
-        },
-        {
-          "name": "source_mint"
-        },
-        {
-          "name": "destination_mint"
-        },
-        {
-          "name": "source_token_program"
-        },
-        {
-          "name": "destination_token_program"
-        },
-        {
-          "name": "destination_token_account",
-          "optional": true,
-          "writable": true
-        },
-        {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
-        },
-        {
-          "name": "program"
-        }
-      ],
-      "args": [
-        {
-          "name": "out_amount",
-          "type": "u64"
-        },
-        {
-          "name": "quoted_in_amount",
-          "type": "u64"
-        },
-        {
-          "name": "slippage_bps",
-          "type": "u16"
-        },
-        {
-          "name": "platform_fee_bps",
-          "type": "u16"
-        },
-        {
-          "name": "positive_slippage_bps",
-          "type": "u16"
-        },
-        {
-          "name": "route_plan",
-          "type": {
-            "vec": {
-              "defined": {
-                "name": "RoutePlanStepV2"
-              }
-            }
-          }
-        }
-      ],
+      "name": "exact_out_route_v2",
       "discriminator": [
         157,
         138,
@@ -1163,10 +868,6 @@
         243,
         36
       ],
-      "name": "exact_out_route_v2",
-      "returns": "u64"
-    },
-    {
       "accounts": [
         {
           "name": "user_transfer_authority",
@@ -1194,12 +895,96 @@
         },
         {
           "name": "destination_token_account",
-          "optional": true,
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "quoted_in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "positive_slippage_bps",
+          "type": "u16"
+        },
+        {
+          "name": "route_plan",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "RoutePlanStepV2"
+              }
+            }
+          }
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "route_v2",
+      "discriminator": [
+        187,
+        100,
+        250,
+        204,
+        49,
+        196,
+        175,
+        20
+      ],
+      "accounts": [
+        {
+          "name": "user_transfer_authority",
+          "signer": true
+        },
+        {
+          "name": "user_source_token_account",
           "writable": true
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "user_destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "source_token_program"
+        },
+        {
+          "name": "destination_token_program"
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -1237,20 +1022,20 @@
           }
         }
       ],
-      "discriminator": [
-        187,
-        100,
-        250,
-        204,
-        49,
-        196,
-        175,
-        20
-      ],
-      "name": "route_v2",
       "returns": "u64"
     },
     {
+      "name": "shared_accounts_exact_out_route_v2",
+      "discriminator": [
+        53,
+        96,
+        229,
+        202,
+        216,
+        187,
+        250,
+        24
+      ],
       "accounts": [
         {
           "name": "program_authority"
@@ -1288,8 +1073,8 @@
           "name": "destination_token_program"
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -1331,20 +1116,20 @@
           }
         }
       ],
-      "discriminator": [
-        53,
-        96,
-        229,
-        202,
-        216,
-        187,
-        250,
-        24
-      ],
-      "name": "shared_accounts_exact_out_route_v2",
       "returns": "u64"
     },
     {
+      "name": "shared_accounts_route_v2",
+      "discriminator": [
+        209,
+        152,
+        83,
+        147,
+        124,
+        254,
+        216,
+        233
+      ],
       "accounts": [
         {
           "name": "program_authority"
@@ -1382,8 +1167,8 @@
           "name": "destination_token_program"
         },
         {
-          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf",
-          "name": "event_authority"
+          "name": "event_authority",
+          "address": "D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf"
         },
         {
           "name": "program"
@@ -1425,30 +1210,246 @@
           }
         }
       ],
-      "discriminator": [
-        209,
-        152,
-        83,
-        147,
-        124,
-        254,
-        216,
-        233
-      ],
-      "name": "shared_accounts_route_v2",
       "returns": "u64"
     }
   ],
-  "metadata": {
-    "description": "Jupiter aggregator program",
-    "name": "jupiter",
-    "spec": "0.1.0",
-    "version": "0.1.0"
-  },
+  "accounts": [
+    {
+      "name": "TokenLedger",
+      "discriminator": [
+        156,
+        247,
+        9,
+        188,
+        54,
+        108,
+        85,
+        77
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "FeeEvent",
+      "discriminator": [
+        73,
+        79,
+        78,
+        127,
+        184,
+        213,
+        13,
+        220
+      ]
+    },
+    {
+      "name": "SwapEvent",
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
+      ]
+    },
+    {
+      "name": "SwapsEvent",
+      "discriminator": [
+        152,
+        47,
+        78,
+        235,
+        192,
+        96,
+        110,
+        106
+      ]
+    },
+    {
+      "name": "CandidateSwapResults",
+      "discriminator": [
+        45,
+        9,
+        244,
+        30,
+        229,
+        52,
+        168,
+        123
+      ]
+    },
+    {
+      "name": "CandidateSwapQuoteError",
+      "discriminator": [
+        248,
+        134,
+        37,
+        55,
+        145,
+        177,
+        114,
+        79
+      ]
+    },
+    {
+      "name": "BestSwapOutAmountViolation",
+      "discriminator": [
+        124,
+        66,
+        196,
+        51,
+        218,
+        173,
+        46,
+        93
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "EmptyRoute",
+      "msg": "Empty route"
+    },
+    {
+      "code": 6001,
+      "name": "SlippageToleranceExceeded",
+      "msg": "Slippage tolerance exceeded"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidCalculation",
+      "msg": "Invalid calculation"
+    },
+    {
+      "code": 6003,
+      "name": "MissingPlatformFeeAccount",
+      "msg": "Missing platform fee account"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidSlippage",
+      "msg": "Invalid slippage"
+    },
+    {
+      "code": 6005,
+      "name": "NotEnoughPercent",
+      "msg": "Not enough percent to 100"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidInputIndex",
+      "msg": "Token input index is invalid"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidOutputIndex",
+      "msg": "Token output index is invalid"
+    },
+    {
+      "code": 6008,
+      "name": "NotEnoughAccountKeys",
+      "msg": "Not Enough Account keys"
+    },
+    {
+      "code": 6009,
+      "name": "NonZeroMinimumOutAmountNotSupported",
+      "msg": "Non zero minimum out amount not supported"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidRoutePlan",
+      "msg": "Invalid route plan"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidReferralAuthority",
+      "msg": "Invalid referral authority"
+    },
+    {
+      "code": 6012,
+      "name": "LedgerTokenAccountDoesNotMatch",
+      "msg": "Token account doesn't match the ledger"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidTokenLedger",
+      "msg": "Invalid token ledger"
+    },
+    {
+      "code": 6014,
+      "name": "IncorrectTokenProgramID",
+      "msg": "Token program ID is invalid"
+    },
+    {
+      "code": 6015,
+      "name": "TokenProgramNotProvided",
+      "msg": "Token program not provided"
+    },
+    {
+      "code": 6016,
+      "name": "SwapNotSupported",
+      "msg": "Swap not supported"
+    },
+    {
+      "code": 6017,
+      "name": "ExactOutAmountNotMatched",
+      "msg": "Exact out amount doesn't match"
+    },
+    {
+      "code": 6018,
+      "name": "SourceAndDestinationMintCannotBeTheSame",
+      "msg": "Source mint and destination mint cannot the same"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidMint",
+      "msg": "Invalid mint"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidProgramAuthority",
+      "msg": "Invalid program authority"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidOutputTokenAccount",
+      "msg": "Invalid output token account"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidFeeWallet",
+      "msg": "Invalid fee wallet"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 6024,
+      "name": "InsufficientFunds",
+      "msg": "Insufficient funds"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidTokenAccount",
+      "msg": "Invalid token account"
+    },
+    {
+      "code": 6026,
+      "name": "BondingCurveAlreadyCompleted",
+      "msg": "Bonding curve already completed"
+    }
+  ],
   "types": [
     {
       "name": "FeeEvent",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "account",
@@ -1462,13 +1463,13 @@
             "name": "amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "RemainingAccountsInfo",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "slices",
@@ -1480,13 +1481,13 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "RemainingAccountsSlice",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "accounts_type",
@@ -1496,8 +1497,7 @@
             "name": "length",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -1570,6 +1570,7 @@
     {
       "name": "RoutePlanStep",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "swap",
@@ -1591,13 +1592,13 @@
             "name": "output_index",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "RoutePlanStepV2",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "swap",
@@ -1619,8 +1620,7 @@
             "name": "output_index",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -1667,13 +1667,13 @@
             "name": "Raydium"
           },
           {
+            "name": "Crema",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "Crema"
+            ]
           },
           {
             "name": "Lifinity"
@@ -1685,6 +1685,7 @@
             "name": "Cykura"
           },
           {
+            "name": "Serum",
             "fields": [
               {
                 "name": "side",
@@ -1694,8 +1695,7 @@
                   }
                 }
               }
-            ],
-            "name": "Serum"
+            ]
           },
           {
             "name": "MarinadeDeposit"
@@ -1704,6 +1704,7 @@
             "name": "MarinadeUnstake"
           },
           {
+            "name": "Aldrin",
             "fields": [
               {
                 "name": "side",
@@ -1713,10 +1714,10 @@
                   }
                 }
               }
-            ],
-            "name": "Aldrin"
+            ]
           },
           {
+            "name": "AldrinV2",
             "fields": [
               {
                 "name": "side",
@@ -1726,26 +1727,25 @@
                   }
                 }
               }
-            ],
-            "name": "AldrinV2"
+            ]
           },
           {
+            "name": "Whirlpool",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "Whirlpool"
+            ]
           },
           {
+            "name": "Invariant",
             "fields": [
               {
                 "name": "x_to_y",
                 "type": "bool"
               }
-            ],
-            "name": "Invariant"
+            ]
           },
           {
             "name": "Meteora"
@@ -1754,27 +1754,28 @@
             "name": "GooseFX"
           },
           {
+            "name": "DeltaFi",
             "fields": [
               {
                 "name": "stable",
                 "type": "bool"
               }
-            ],
-            "name": "DeltaFi"
+            ]
           },
           {
             "name": "Balansol"
           },
           {
+            "name": "MarcoPolo",
             "fields": [
               {
                 "name": "x_to_y",
                 "type": "bool"
               }
-            ],
-            "name": "MarcoPolo"
+            ]
           },
           {
+            "name": "Dradex",
             "fields": [
               {
                 "name": "side",
@@ -1784,8 +1785,7 @@
                   }
                 }
               }
-            ],
-            "name": "Dradex"
+            ]
           },
           {
             "name": "LifinityV2"
@@ -1794,6 +1794,7 @@
             "name": "RaydiumClmm"
           },
           {
+            "name": "Openbook",
             "fields": [
               {
                 "name": "side",
@@ -1803,10 +1804,10 @@
                   }
                 }
               }
-            ],
-            "name": "Openbook"
+            ]
           },
           {
+            "name": "Phoenix",
             "fields": [
               {
                 "name": "side",
@@ -1816,10 +1817,10 @@
                   }
                 }
               }
-            ],
-            "name": "Phoenix"
+            ]
           },
           {
+            "name": "Symmetry",
             "fields": [
               {
                 "name": "from_token_id",
@@ -1829,8 +1830,7 @@
                 "name": "to_token_id",
                 "type": "u64"
               }
-            ],
-            "name": "Symmetry"
+            ]
           },
           {
             "name": "TokenSwapV2"
@@ -1842,13 +1842,13 @@
             "name": "StakeDexStakeWrappedSol"
           },
           {
+            "name": "StakeDexSwapViaStake",
             "fields": [
               {
                 "name": "bridge_stake_seed",
                 "type": "u32"
               }
-            ],
-            "name": "StakeDexSwapViaStake"
+            ]
           },
           {
             "name": "GooseFXV2"
@@ -1866,6 +1866,7 @@
             "name": "MeteoraDlmm"
           },
           {
+            "name": "OpenBookV2",
             "fields": [
               {
                 "name": "side",
@@ -1875,22 +1876,22 @@
                   }
                 }
               }
-            ],
-            "name": "OpenBookV2"
+            ]
           },
           {
             "name": "RaydiumClmmV2"
           },
           {
+            "name": "StakeDexPrefundWithdrawStakeAndDepositStake",
             "fields": [
               {
                 "name": "bridge_stake_seed",
                 "type": "u32"
               }
-            ],
-            "name": "StakeDexPrefundWithdrawStakeAndDepositStake"
+            ]
           },
           {
+            "name": "Clone",
             "fields": [
               {
                 "name": "pool_index",
@@ -1904,10 +1905,10 @@
                 "name": "quantity_is_collateral",
                 "type": "bool"
               }
-            ],
-            "name": "Clone"
+            ]
           },
           {
+            "name": "SanctumS",
             "fields": [
               {
                 "name": "src_lst_value_calc_accs",
@@ -1925,10 +1926,10 @@
                 "name": "dst_lst_index",
                 "type": "u32"
               }
-            ],
-            "name": "SanctumS"
+            ]
           },
           {
+            "name": "SanctumSAddLiquidity",
             "fields": [
               {
                 "name": "lst_value_calc_accs",
@@ -1938,10 +1939,10 @@
                 "name": "lst_index",
                 "type": "u32"
               }
-            ],
-            "name": "SanctumSAddLiquidity"
+            ]
           },
           {
+            "name": "SanctumSRemoveLiquidity",
             "fields": [
               {
                 "name": "lst_value_calc_accs",
@@ -1951,13 +1952,13 @@
                 "name": "lst_index",
                 "type": "u32"
               }
-            ],
-            "name": "SanctumSRemoveLiquidity"
+            ]
           },
           {
             "name": "RaydiumCP"
           },
           {
+            "name": "WhirlpoolSwapV2",
             "fields": [
               {
                 "name": "a_to_b",
@@ -1973,8 +1974,7 @@
                   }
                 }
               }
-            ],
-            "name": "WhirlpoolSwapV2"
+            ]
           },
           {
             "name": "OneIntro"
@@ -2007,34 +2007,34 @@
             "name": "StabbleWeightedSwap"
           },
           {
+            "name": "Obric",
             "fields": [
               {
                 "name": "x_to_y",
                 "type": "bool"
               }
-            ],
-            "name": "Obric"
+            ]
           },
           {
             "name": "FoxBuyFromEstimatedCost"
           },
           {
+            "name": "FoxClaimPartial",
             "fields": [
               {
                 "name": "is_y",
                 "type": "bool"
               }
-            ],
-            "name": "FoxClaimPartial"
+            ]
           },
           {
+            "name": "SolFi",
             "fields": [
               {
                 "name": "is_quote_to_base",
                 "type": "bool"
               }
-            ],
-            "name": "SolFi"
+            ]
           },
           {
             "name": "SolayerDelegateNoInit"
@@ -2043,6 +2043,7 @@
             "name": "SolayerUndelegateNoInit"
           },
           {
+            "name": "TokenMill",
             "fields": [
               {
                 "name": "side",
@@ -2052,8 +2053,7 @@
                   }
                 }
               }
-            ],
-            "name": "TokenMill"
+            ]
           },
           {
             "name": "DaosFunBuy"
@@ -2074,6 +2074,7 @@
             "name": "VirtualsSell"
           },
           {
+            "name": "Perena",
             "fields": [
               {
                 "name": "in_index",
@@ -2083,8 +2084,7 @@
                 "name": "out_index",
                 "type": "u8"
               }
-            ],
-            "name": "Perena"
+            ]
           },
           {
             "name": "PumpSwapBuy"
@@ -2096,6 +2096,7 @@
             "name": "Gamma"
           },
           {
+            "name": "MeteoraDlmmSwapV2",
             "fields": [
               {
                 "name": "remaining_accounts_info",
@@ -2105,8 +2106,7 @@
                   }
                 }
               }
-            ],
-            "name": "MeteoraDlmmSwapV2"
+            ]
           },
           {
             "name": "Woofi"
@@ -2124,22 +2124,22 @@
             "name": "StabbleWeightedSwapV2"
           },
           {
+            "name": "RaydiumLaunchlabBuy",
             "fields": [
               {
                 "name": "share_fee_rate",
                 "type": "u64"
               }
-            ],
-            "name": "RaydiumLaunchlabBuy"
+            ]
           },
           {
+            "name": "RaydiumLaunchlabSell",
             "fields": [
               {
                 "name": "share_fee_rate",
                 "type": "u64"
               }
-            ],
-            "name": "RaydiumLaunchlabSell"
+            ]
           },
           {
             "name": "BoopdotfunWrappedBuy"
@@ -2148,6 +2148,7 @@
             "name": "BoopdotfunWrappedSell"
           },
           {
+            "name": "Plasma",
             "fields": [
               {
                 "name": "side",
@@ -2157,10 +2158,10 @@
                   }
                 }
               }
-            ],
-            "name": "Plasma"
+            ]
           },
           {
+            "name": "GoonFi",
             "fields": [
               {
                 "name": "is_bid",
@@ -2170,10 +2171,10 @@
                 "name": "blacklist_bump",
                 "type": "u8"
               }
-            ],
-            "name": "GoonFi"
+            ]
           },
           {
+            "name": "HumidiFi",
             "fields": [
               {
                 "name": "swap_id",
@@ -2183,13 +2184,13 @@
                 "name": "is_base_to_quote",
                 "type": "bool"
               }
-            ],
-            "name": "HumidiFi"
+            ]
           },
           {
             "name": "MeteoraDynamicBondingCurveSwapWithRemainingAccounts"
           },
           {
+            "name": "TesseraV",
             "fields": [
               {
                 "name": "side",
@@ -2199,8 +2200,7 @@
                   }
                 }
               }
-            ],
-            "name": "TesseraV"
+            ]
           },
           {
             "name": "PumpWrappedBuyV2"
@@ -2215,22 +2215,22 @@
             "name": "PumpSwapSellV2"
           },
           {
+            "name": "Heaven",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "Heaven"
+            ]
           },
           {
+            "name": "SolFiV2",
             "fields": [
               {
                 "name": "is_quote_to_base",
                 "type": "bool"
               }
-            ],
-            "name": "SolFiV2"
+            ]
           },
           {
             "name": "Aquifer"
@@ -2254,6 +2254,7 @@
             "name": "JupiterLendRedeem"
           },
           {
+            "name": "DefiTuna",
             "fields": [
               {
                 "name": "a_to_b",
@@ -2269,31 +2270,31 @@
                   }
                 }
               }
-            ],
-            "name": "DefiTuna"
+            ]
           },
           {
+            "name": "AlphaQ",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "AlphaQ"
+            ]
           },
           {
             "name": "RaydiumV2"
           },
           {
+            "name": "SarosDlmm",
             "fields": [
               {
                 "name": "swap_for_y",
                 "type": "bool"
               }
-            ],
-            "name": "SarosDlmm"
+            ]
           },
           {
+            "name": "Futarchy",
             "fields": [
               {
                 "name": "side",
@@ -2303,8 +2304,7 @@
                   }
                 }
               }
-            ],
-            "name": "Futarchy"
+            ]
           },
           {
             "name": "MeteoraDammV2WithRemainingAccounts"
@@ -2313,6 +2313,7 @@
             "name": "Obsidian"
           },
           {
+            "name": "WhaleStreet",
             "fields": [
               {
                 "name": "side",
@@ -2322,10 +2323,10 @@
                   }
                 }
               }
-            ],
-            "name": "WhaleStreet"
+            ]
           },
           {
+            "name": "DynamicV1",
             "fields": [
               {
                 "name": "candidate_swaps",
@@ -2343,8 +2344,7 @@
                   "option": "u8"
                 }
               }
-            ],
-            "name": "DynamicV1"
+            ]
           },
           {
             "name": "PumpWrappedBuyV4"
@@ -2359,6 +2359,7 @@
             "name": "CarrotRedeem"
           },
           {
+            "name": "Manifest",
             "fields": [
               {
                 "name": "side",
@@ -2368,19 +2369,19 @@
                   }
                 }
               }
-            ],
-            "name": "Manifest"
+            ]
           },
           {
+            "name": "BisonFi",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "BisonFi"
+            ]
           },
           {
+            "name": "HumidiFiV2",
             "fields": [
               {
                 "name": "swap_id",
@@ -2390,19 +2391,19 @@
                 "name": "is_base_to_quote",
                 "type": "bool"
               }
-            ],
-            "name": "HumidiFiV2"
+            ]
           },
           {
+            "name": "PerenaStar",
             "fields": [
               {
                 "name": "is_mint",
                 "type": "bool"
               }
-            ],
-            "name": "PerenaStar"
+            ]
           },
           {
+            "name": "JupiterRfqV2",
             "fields": [
               {
                 "name": "side",
@@ -2416,28 +2417,28 @@
                 "name": "fill_data",
                 "type": "bytes"
               }
-            ],
-            "name": "JupiterRfqV2"
+            ]
           },
           {
+            "name": "GoonFiV2",
             "fields": [
               {
                 "name": "is_bid",
                 "type": "bool"
               }
-            ],
-            "name": "GoonFiV2"
+            ]
           },
           {
+            "name": "Scorch",
             "fields": [
               {
                 "name": "swap_id",
                 "type": "u128"
               }
-            ],
-            "name": "Scorch"
+            ]
           },
           {
+            "name": "VaultLiquidUnstake",
             "fields": [
               {
                 "name": "lst_amounts",
@@ -2452,13 +2453,13 @@
                 "name": "seed",
                 "type": "u64"
               }
-            ],
-            "name": "VaultLiquidUnstake"
+            ]
           },
           {
             "name": "XOrca"
           },
           {
+            "name": "Quantum",
             "fields": [
               {
                 "name": "side",
@@ -2468,10 +2469,10 @@
                   }
                 }
               }
-            ],
-            "name": "Quantum"
+            ]
           },
           {
+            "name": "WhaleStreetV2",
             "fields": [
               {
                 "name": "side",
@@ -2489,29 +2490,28 @@
                 "name": "auth",
                 "type": "u64"
               }
-            ],
-            "name": "WhaleStreetV2"
+            ]
           },
           {
+            "name": "Riptide",
             "fields": [
               {
                 "name": "amount_is_token_a",
                 "type": "bool"
               }
-            ],
-            "name": "Riptide"
+            ]
           },
           {
             "name": "RunnerRodeo"
           },
           {
+            "name": "TaurusFi",
             "fields": [
               {
                 "name": "is_base_in",
                 "type": "bool"
               }
-            ],
-            "name": "TaurusFi"
+            ]
           },
           {
             "name": "Omnipair"
@@ -2520,6 +2520,7 @@
             "name": "MSwap"
           },
           {
+            "name": "Hylo",
             "fields": [
               {
                 "name": "swap_type",
@@ -2529,8 +2530,7 @@
                   }
                 }
               }
-            ],
-            "name": "Hylo"
+            ]
           },
           {
             "name": "VoltrDeposit"
@@ -2539,6 +2539,7 @@
             "name": "VoltrWithdraw"
           },
           {
+            "name": "SanctumSV2",
             "fields": [
               {
                 "name": "src_lst_value_calc_accs",
@@ -2556,17 +2557,16 @@
                 "name": "dst_lst_index",
                 "type": "u32"
               }
-            ],
-            "name": "SanctumSV2"
+            ]
           },
           {
+            "name": "LemmingsFi",
             "fields": [
               {
                 "name": "is_base_in",
                 "type": "bool"
               }
-            ],
-            "name": "LemmingsFi"
+            ]
           },
           {
             "name": "ScaleVmmBuy"
@@ -2581,13 +2581,13 @@
             "name": "ScaleAmmSell"
           },
           {
+            "name": "BisonFiV2",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "BisonFiV2"
+            ]
           },
           {
             "name": "Trends"
@@ -2599,15 +2599,16 @@
             "name": "HumaInstantWithdraw"
           },
           {
+            "name": "Kipseli",
             "fields": [
               {
                 "name": "is_base_to_quote",
                 "type": "bool"
               }
-            ],
-            "name": "Kipseli"
+            ]
           },
           {
+            "name": "DynamicV2",
             "fields": [
               {
                 "name": "candidate_swaps",
@@ -2627,8 +2628,49 @@
                 "name": "max_split_candidates",
                 "type": "u8"
               }
-            ],
-            "name": "DynamicV2"
+            ]
+          },
+          {
+            "name": "PumpSwapBuyV3WithCashbackClaim"
+          },
+          {
+            "name": "PumpSwapSellV3WithCashbackClaim"
+          },
+          {
+            "name": "PumpWrappedBuyV4WithCashbackClaim"
+          },
+          {
+            "name": "PumpWrappedSellV4WithCashbackClaim"
+          },
+          {
+            "name": "GoonFiV3",
+            "fields": [
+              {
+                "name": "is_bid",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "PumpWrappedBuyV5",
+            "fields": [
+              {
+                "name": "claim_cashback",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "PumpWrappedSellV5",
+            "fields": [
+              {
+                "name": "claim_cashback",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ZeroFiSwapV2"
           }
         ]
       }
@@ -2636,6 +2678,7 @@
     {
       "name": "CandidateSwapWithBps",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "candidate_swap",
@@ -2649,8 +2692,7 @@
             "name": "bps",
             "type": "u32"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -2659,6 +2701,7 @@
         "kind": "enum",
         "variants": [
           {
+            "name": "HumidiFi",
             "fields": [
               {
                 "name": "swap_id",
@@ -2668,10 +2711,10 @@
                 "name": "is_base_to_quote",
                 "type": "bool"
               }
-            ],
-            "name": "HumidiFi"
+            ]
           },
           {
+            "name": "TesseraV",
             "fields": [
               {
                 "name": "side",
@@ -2681,10 +2724,10 @@
                   }
                 }
               }
-            ],
-            "name": "TesseraV"
+            ]
           },
           {
+            "name": "HumidiFiV2",
             "fields": [
               {
                 "name": "swap_id",
@@ -2694,8 +2737,7 @@
                 "name": "is_base_to_quote",
                 "type": "bool"
               }
-            ],
-            "name": "HumidiFiV2"
+            ]
           },
           {
             "name": "RaydiumV2"
@@ -2704,34 +2746,65 @@
             "name": "RaydiumClmm"
           },
           {
+            "name": "Whirlpool",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "Whirlpool"
+            ]
           },
           {
             "name": "ZeroFi"
           },
           {
+            "name": "BisonFiV2",
             "fields": [
               {
                 "name": "a_to_b",
                 "type": "bool"
               }
-            ],
-            "name": "BisonFiV2"
+            ]
           },
           {
+            "name": "GoonFiV2",
             "fields": [
               {
                 "name": "is_bid",
                 "type": "bool"
               }
-            ],
-            "name": "GoonFiV2"
+            ]
+          },
+          {
+            "name": "GoonFiV3",
+            "fields": [
+              {
+                "name": "is_bid",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "WhirlpoolV2",
+            "fields": [
+              {
+                "name": "a_to_b",
+                "type": "bool"
+              },
+              {
+                "name": "remaining_accounts_info",
+                "type": {
+                  "option": {
+                    "defined": {
+                      "name": "RemainingAccountsInfo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "ZeroFiSwapV2"
           }
         ]
       }
@@ -2771,6 +2844,7 @@
     {
       "name": "SwapEvent",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "amm",
@@ -2792,13 +2866,13 @@
             "name": "output_amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "SwapEventV2",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "input_mint",
@@ -2816,13 +2890,13 @@
             "name": "output_amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "SwapsEvent",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "swap_events",
@@ -2834,13 +2908,13 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "TokenLedger",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "token_account",
@@ -2850,13 +2924,13 @@
             "name": "amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "BestSwapOutAmountViolation",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "expected_out_amount",
@@ -2866,8 +2940,7 @@
             "name": "out_amount",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
@@ -2876,16 +2949,16 @@
         "kind": "enum",
         "variants": [
           {
+            "name": "OutAmount",
             "fields": [
               "u64"
-            ],
-            "name": "OutAmount"
+            ]
           },
           {
+            "name": "ProgramError",
             "fields": [
               "u64"
-            ],
-            "name": "ProgramError"
+            ]
           }
         ]
       }
@@ -2893,6 +2966,7 @@
     {
       "name": "CandidateSwapResults",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "results",
@@ -2904,13 +2978,13 @@
               }
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
       "name": "CandidateSwapQuoteError",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "candidate_index",
@@ -2924,8 +2998,7 @@
             "name": "error_code",
             "type": "u64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Why this PR exists

A real Solana V0 Jupiter v6 `route_v2` transaction (discriminator `bb64facc31c4af14`) was rendering as `Jupiter: Unknown Instruction`. The discriminator matched in the bundled IDL, but body deserialization aborted on the fourth `RoutePlanStepV2` — the swap was `DynamicV2 { candidate_swaps: vec<CandidateSwapWithBps>, … }`, and the first `CandidateSwap` variant byte was `0x0b` (=11). The bundled `jupiter_agg_v6.json` only defined 9 `CandidateSwap` variants, so `solana_parser`'s enum decoder returned `Err("invalid variant index")`. The error was swallowed by the catch handler in `parse_jupiter_swap_instruction` (`chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs:304-312`), which returned `Unknown { instruction_name: None }`.

The bundled IDL was 8 `Swap` variants and 3 `CandidateSwap` variants behind on-chain.

## What changed

- Replaced `chain_parsers/visualsign-solana/src/presets/jupiter_swap/jupiter_agg_v6.json` with the IDL fetched from the Anchor IDL PDA `C88XWfp26heEmDkmfSzeXP7Fd7GQJ2j9dDTUsyiZbUTa` for program `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4`.
- `Swap` enum: 147 → 155 variants.
- `CandidateSwap` enum: 9 → 12 variants (adds `GoonFiV3` (9), `WhirlpoolV2` (10), `ZeroFiSwapV2` (11) — the unblocking one is index 11).

## Why this is safe

- **Backward compatibility**: only added enum variants and instructions. All v1 (`route`, `exact_out_route`, `shared_accounts_route`) and v2 (`route_v2`, `exact_out_route_v2`, `shared_accounts_route_v2`, `shared_accounts_exact_out_route_v2`) retain identical names, discriminators, and argument names. Confirmed against the field names `parse_jupiter_instruction_with_idl` reads at `mod.rs:217-228` and `mod.rs:239-263`.
- **Approach**: fetched directly from the on-chain Anchor IDL account — same source `anchor idl fetch` reads from. Decompressed via the standard Anchor account layout (`8-byte discriminator | 32-byte authority | 4-byte LE data_len | zlib(IDL JSON)`).
- **Risks mitigated**: adopting an unfamiliar IDL could introduce decode surprises. Pre-merge validation confirmed (a) `route_v2` discriminator `[187, 100, 250, 204, 49, 196, 175, 20]` unchanged, (b) every argument name our code reads is still present, (c) `CandidateSwap` now contains the variant at index 11, (d) all existing Jupiter tests and Solana semantic_pipeline integration tests still pass.

### Checks run (by agent)

- `make -C src lint` — exit 0
- `cargo test -p visualsign-solana` — all tests pass (25 Jupiter unit tests, 8 semantic_pipeline integration tests, real_idl_validation, fuzz_idl_parsing, etc.)
- Validated the fetched IDL satisfies every structural and naming constraint our code depends on (see above).

### Manual steps needed (by human)

None — fully automated by CI.

## How this is maintainable

- The IDL stays a static JSON snapshot in-tree. The comment block at `chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs:114-119` explains why this file is kept local rather than sourced from `solana_parser::ProgramType`.
- Refreshing again in the future: any Python env with `solders`, `requests`, `zlib` runs:

  ```python
  import base64, json, zlib, requests
  from solders.pubkey import Pubkey
  pid = Pubkey.from_string("JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4")
  base, _ = Pubkey.find_program_address([], pid)
  idl_addr = Pubkey.create_with_seed(base, "anchor:idl", pid)
  raw = base64.b64decode(requests.post(
      "https://api.mainnet-beta.solana.com",
      json={"jsonrpc":"2.0","id":1,"method":"getAccountInfo",
            "params":[str(idl_addr), {"encoding":"base64"}]},
      timeout=30,
  ).json()["result"]["value"]["data"][0])
  data_len = int.from_bytes(raw[40:44], "little")
  json.dump(json.loads(zlib.decompress(raw[44:44+data_len])),
            open("jupiter_agg_v6.json", "w"), indent=2)
  ```

- **Known gap**: the existing v2 route tests (`test_jupiter_route_v2_parsing` etc., `mod.rs:1154` onward) build their `route_plan` via `build_route_v2_body` (`mod.rs:1123-1138`), which produces an empty vector. They never enter the `Swap` / `CandidateSwap` decode path, so they cannot catch the same class of staleness next time. Filing a follow-up for a fixture-based test with a non-trivial `route_plan` is a small ticket.

### Follow-ups (separate PRs)

- **Defensive fallback** in `parse_jupiter_swap_instruction` (`mod.rs:296-313`): when `find_instruction_by_discriminator` (already exposed via `solana_parser::lib.rs:7`) matches but `parse_data_into_args` fails, return `Unknown { instruction_name: Some(name) }` instead of `instruction_name: None`. Output degrades to `Jupiter: route_v2` rather than fully Unknown next time the IDL falls behind.
- **Refresh cadence**: a `make refresh-jupiter-idl` target invoking the script above, or a CI job that diffs on-chain against the bundled copy and fails (or opens a PR) on drift.
- **Unrelated**: the `transaction::oob_account_index` diagnostics on instructions 3 and 4 of the triggering transaction — ALT-resolved accounts being checked against only the static account-keys array. Separate issue, separate PR.