### PR TITLE
chore(parser_app): address PR #303 follow-up review comments

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,12 +7,18 @@ PARSER_INNER_SOCKET_PATH ?= /tmp/inner_parser.sock
 
 ROOT := $(shell git rev-parse --show-toplevel)
 
-# Chains parser_app can be built with. Single source of truth for both
-# narrow-build-check and feature-matrix-check below; keep in sync with
-# the [features] block in parser_app/Cargo.toml. Listed alphabetically
-# so the depth-2 pair generator in feature-matrix-check produces stable,
-# unique pairs.
-PARSER_APP_CHAINS := ethereum solana sui tron unspecified
+# Chains parser_app can be built with -- derived from the
+# `chain_parsers/visualsign-<name>/` directory layout that the workspace
+# already uses as its source of truth. `$(sort ...)` deduplicates and
+# alphabetizes so the depth-2 pair generator in feature-matrix-check
+# produces stable, unique pairs across machines (filesystem-listing
+# order isn't guaranteed otherwise).
+#
+# Convention: every `chain_parsers/visualsign-<name>/` directory has a
+# matching `<name>` feature in parser_app/Cargo.toml. A chain crate added
+# without that feature wired in fails loudly at narrow-build-check on
+# the PR that introduces it -- which is the right place to catch it.
+PARSER_APP_CHAINS := $(sort $(patsubst visualsign-%,%,$(notdir $(wildcard chain_parsers/visualsign-*))))
 
 .PHONY: all
 all: generated
@@ -55,45 +61,60 @@ lint:
 narrow-build-check:
 	@# Guards parser_app's per-chain feature gating. If a future change
 	@# re-introduces an unconditional reference to a chain crate from
-	@# parser_app, one of these narrow builds will fail to compile.
+	@# parser_app, one of these narrow checks will fail to compile.
 	@# Wired into main CI; runs on every PR. Driven by
-	@# $(PARSER_APP_CHAINS) above -- when a chain is added to
-	@# parser_app/Cargo.toml, extend that variable and the matrix picks
-	@# the new chain up.
+	@# $(PARSER_APP_CHAINS) above, which auto-extends when a new
+	@# chain_parsers/visualsign-<name>/ directory is added.
 	@#
-	@# Includes clippy under each narrow feature set so dead-code /
+	@# Uses `cargo check` rather than `cargo build`: the failure modes
+	@# we want to catch here are compile-level (unconditional crate
+	@# references that should have been cfg-gated). `check` produces no
+	@# linker output, runs ~2x faster, and matches what clippy needs.
+	@#
+	@# Clippy runs under each narrow feature set so dead-code /
 	@# unused-import lints that only trigger when a chain is OFF are
 	@# enforced (make lint above only covers default features).
-	cargo build -p parser_app --no-default-features
+	@#
+	@# Note: parser_app re-type-checks under each distinct feature set,
+	@# but workspace dependencies are reused from the cache that earlier
+	@# CI steps (make test / make lint) already populated -- so the
+	@# marginal CI cost is dominated by parser_app's own check time.
+	cargo check -p parser_app --no-default-features
 	cargo clippy -p parser_app --no-default-features --all-targets -- -D warnings
 	@set -e; for c in $(PARSER_APP_CHAINS); do \
 		echo "==> features: $$c"; \
-		cargo build -p parser_app --no-default-features --features $$c; \
+		cargo check -p parser_app --no-default-features --features $$c; \
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
 	done
 
 .PHONY: feature-matrix-check
 feature-matrix-check:
-	@# Deep coverage of parser_app's feature gating: every chain alone,
-	@# every chain + diagnostics, every depth-2 pair, and every depth-2
-	@# pair + diagnostics. Hand-rolled (no cargo-hack dependency); matrix
-	@# is generated from $(PARSER_APP_CHAINS) above.
+	@# Deep coverage of parser_app's feature gating: diagnostics alone
+	@# (no chains), every chain alone, every chain + diagnostics, every
+	@# depth-2 pair, and every depth-2 pair + diagnostics. Hand-rolled
+	@# (no cargo-hack dependency); matrix is generated from
+	@# $(PARSER_APP_CHAINS) above.
 	@#
 	@# Note: `diagnostics` propagates to the always-on `visualsign` core
 	@# crate, and weakly to `visualsign-solana` via the `?` syntax. The
 	@# non-solana + diagnostics combos still exercise the weak-dep path
 	@# (resolving to a no-op for visualsign-solana).
 	@#
-	@# LOCAL ONLY -- not wired into CI. The full matrix accumulates ~28GB
-	@# in the cargo target dir; ensure ~30GB free in src/target before
-	@# running. Use before releases or when touching feature definitions;
-	@# the per-PR narrow-build-check above covers the common regression
-	@# class on every change.
+	@# Uses `cargo check` for the same reason as narrow-build-check
+	@# above -- the goal is compile-level regression detection, not
+	@# producing binaries.
+	@#
+	@# LOCAL ONLY -- not wired into CI. The full matrix grows the cargo
+	@# target dir by a few GB. Run before releases or when touching
+	@# feature definitions; the per-PR narrow-build-check above covers
+	@# the common regression class on every change.
+	echo "==> features: diagnostics"
+	cargo check -p parser_app --no-default-features --features diagnostics
 	@set -e; for c in $(PARSER_APP_CHAINS); do \
 		echo "==> features: $$c"; \
-		cargo build -p parser_app --no-default-features --features $$c; \
+		cargo check -p parser_app --no-default-features --features $$c; \
 		echo "==> features: $$c diagnostics"; \
-		cargo build -p parser_app --no-default-features --features "$$c diagnostics"; \
+		cargo check -p parser_app --no-default-features --features "$$c diagnostics"; \
 	done
 	@set -e; i=0; for c1 in $(PARSER_APP_CHAINS); do \
 		i=$$((i+1)); j=0; \
@@ -101,9 +122,9 @@ feature-matrix-check:
 			j=$$((j+1)); \
 			if [ $$j -gt $$i ]; then \
 				echo "==> features: $$c1 $$c2"; \
-				cargo build -p parser_app --no-default-features --features "$$c1 $$c2"; \
+				cargo check -p parser_app --no-default-features --features "$$c1 $$c2"; \
 				echo "==> features: $$c1 $$c2 diagnostics"; \
-				cargo build -p parser_app --no-default-features --features "$$c1 $$c2 diagnostics"; \
+				cargo check -p parser_app --no-default-features --features "$$c1 $$c2 diagnostics"; \
 			fi; \
 		done; \
 	done


### PR DESCRIPTION
## Summary

Addresses all four follow-up items prasanna-anchorage raised on his approval of #303 (the per-PR narrow-build-check + local feature-matrix-check work). Single PR — all items are small, touch the same Makefile, and don't depend on each other.

## Changes

**1. Restore dynamic chain discovery (`$(sort)` + `$(wildcard)`).**
```
PARSER_APP_CHAINS := $(sort $(patsubst visualsign-%,%,$(notdir $(wildcard chain_parsers/visualsign-*))))
```
The hardcoded list from #303 required editing both the Makefile variable and `parser_app/Cargo.toml`'s `[features]` block whenever a chain was added. The sorted wildcard gives the same stable, deduplicated ordering the depth-2 pair generator needs, and the matrix auto-extends when a new `chain_parsers/visualsign-<name>/` lands.

**2. `cargo build` → `cargo check` in both targets.**
The regression class these targets guard — unconditional chain-crate references that should have been `#[cfg]`-gated — is compile-level. `cargo check` is sufficient and roughly 2× faster than `cargo build`; the clippy invocations already cover lint coverage. As a bonus, `feature-matrix-check` now grows the target dir by ~2GB instead of ~28GB across its 31 invocations.

**3. Add empty + diagnostics combo to `feature-matrix-check`.**
`--no-default-features --features diagnostics` (no chains compiled in) makes the diagnostics axis symmetric with the rest of the matrix.

**4. Tighten comments.**
- `narrow-build-check` comment now reflects the auto-pickup behavior the dynamic variable provides.
- CI cache note rewritten to be accurate: parser_app re-type-checks under each distinct feature set while workspace dependencies are reused from earlier CI steps' cache.

## Test plan

- [x] `make -C src narrow-build-check` — 6 `cargo check` + 6 clippy invocations, exit 0.
- [x] `make -C src feature-matrix-check` — 31 `cargo check` invocations (1 diagnostics-only + 5 singles + 5 singles+diagnostics + 10 pairs + 10 pairs+diagnostics), exit 0. Cargo target dir grew by ~2GB.
- [x] Pre-commit hook (cargo fmt + cargo clippy across all workspace splits): clean.

## References

- PR #303 (merged): https://github.com/anchorageoss/visualsign-parser/pull/303
- prasanna-anchorage's approval comment with the follow-up asks