### PR TITLE
chore(skill): clarify helper sourcing in solana-add-idl

### DIFF
--- a/.claude/skills/solana-add-idl/SKILL.md
+++ b/.claude/skills/solana-add-idl/SKILL.md
@@ -96,7 +96,8 @@ Read that file for the exact structure, then generate a generic version with the
 - Keep the `kind()` method returning the user's chosen `VisualizerKind` variant with `display_name` as the `&'static str` argument
 
 **Generic IDL pattern only:**
-- The generic scaffold uses `build_named_accounts`, `build_parsed_fields`, `build_fallback_fields`, `append_raw_data`, `format_arg_value` — all of which work with any IDL
+- The generic scaffold uses the three helpers `dflow_aggregator` defines: `build_named_accounts`, `build_parsed_fields`, and `build_fallback_fields`. All three work with any IDL.
+- Two additional helpers — `append_raw_data` (for byte-blob args) and `format_arg_value` (for custom scalar rendering) — are not present in `dflow_aggregator`. Add them when the target IDL needs them, copying the pattern from another preset such as `kamino_vault` or `jupiter_earn`.
 - The parse function should: check `data.len() < 8`, load IDL, call `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with parsed data + named accounts
 
 **Visualizer body must use the wire-data context API.** At the top of `visualize_tx_commands`:


### PR DESCRIPTION
## Summary

Tiny follow-up to #281 addressing prasanna-anchorage's inline accuracy nit on `.claude/skills/solana-add-idl/SKILL.md`:

> Of the five helpers listed here, `dflow_aggregator` (the template you point at on line 89) actually defines only `build_named_accounts` / `build_parsed_fields` / `build_fallback_fields`. `append_raw_data` and `format_arg_value` live in *other* IDL presets — e.g. `kamino_vault/mod.rs:209,217` or `jupiter_earn/mod.rs:218,229`.

Verified the claim against `main`:
- `chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs` declares `build_named_accounts` (line 118), `build_parsed_fields` (line 151), `build_fallback_fields` (line 197). No `append_raw_data` or `format_arg_value`.
- `append_raw_data` lives in 8 other presets; `format_arg_value` lives in 15.

## Change

One bullet in `SKILL.md` becomes two:

1. The scaffold list trims to the three helpers `dflow_aggregator` actually has.
2. A short note tells first-time users that byte-blob args (`append_raw_data`) and custom scalar rendering (`format_arg_value`) are sourced from `kamino_vault` / `jupiter_earn` when their IDL needs them.

This follows prasanna's option (a) — keep the template promise honest, defer additional helpers to when the IDL warrants them.

## Test plan

- [x] Pre-commit hook (cargo fmt + clippy across workspace splits): clean
- [x] Manual readback of the rewritten section against actual preset code: helper presence verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)