### PR TITLE
fix(tron): handle out-of-range expiration timestamps without panicking

### DIFF
--- a/src/chain_parsers/visualsign-tron/src/lib.rs
+++ b/src/chain_parsers/visualsign-tron/src/lib.rs
@@ -10,6 +10,7 @@ use visualsign::{
 use anychain_tron::protocol::Tron::transaction;
 use anychain_tron::protocol::balance_contract::TransferContract;
 use base64::{Engine as _, engine::general_purpose::STANDARD as b64};
+use chrono::{LocalResult, TimeZone, Utc};
 use protobuf::Message;
 use sha2::{Digest, Sha256};
 
@@ -283,10 +284,50 @@ fn address_to_base58(address_bytes: &[u8]) -> String {
     base58::ToBase58::to_base58(&with_checksum[..])
 }
 
-// Helper function to format Unix timestamp (milliseconds) to human-readable format
+// Helper function to format Unix timestamp (milliseconds) to human-readable format.
+//
+// `chrono::Utc::timestamp_millis_opt` returns `LocalResult::None` for values
+// outside chrono's representable range (e.g. `i64::MAX`, `i64::MIN`). Tron
+// transaction timestamps are attacker-controlled `i64`s read straight from the
+// protobuf-decoded raw transaction, so this must never panic. We fall back to
+// a sentinel string and let the call site keep showing the raw millisecond
+// integer alongside it (see PRS-228).
 fn format_timestamp(timestamp_ms: i64) -> String {
-    use chrono::{TimeZone, Utc};
+    match Utc.timestamp_millis_opt(timestamp_ms) {
+        LocalResult::Single(datetime) => datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+        // `LocalResult::None` is returned for out-of-range values. `Ambiguous`
+        // is not produced for UTC, but handle it defensively for completeness.
+        LocalResult::None | LocalResult::Ambiguous(_, _) => "invalid timestamp".to_string(),
+    }
+}
 
-    let datetime = Utc.timestamp_millis_opt(timestamp_ms).unwrap();
-    datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::format_timestamp;
+
+    #[test]
+    fn format_timestamp_known_value() {
+        // 2021-01-01 00:00:00 UTC = 1609459200000 ms.
+        assert_eq!(
+            format_timestamp(1_609_459_200_000),
+            "2021-01-01 00:00:00 UTC"
+        );
+    }
+
+    #[test]
+    fn format_timestamp_zero_epoch() {
+        assert_eq!(format_timestamp(0), "1970-01-01 00:00:00 UTC");
+    }
+
+    // Regression for PRS-228: attacker-controlled i64 must never panic.
+    #[test]
+    fn format_timestamp_i64_max_does_not_panic() {
+        assert_eq!(format_timestamp(i64::MAX), "invalid timestamp");
+    }
+
+    #[test]
+    fn format_timestamp_i64_min_does_not_panic() {
+        assert_eq!(format_timestamp(i64::MIN), "invalid timestamp");
+    }
 }


### PR DESCRIPTION
## Summary

`format_timestamp` in the Tron parser called `Utc.timestamp_millis_opt(...).unwrap()` on an attacker-controlled `i64` taken straight from the protobuf-decoded raw transaction. Values like `i64::MAX` or `i64::MIN` fall outside chrono's representable range and return `LocalResult::None`, so the `.unwrap()` panicked the parser and gave any unauthenticated caller a trivial DoS against the visual signing service.

This PR replaces the `.unwrap()` with an explicit `match` on `LocalResult` and returns `"invalid timestamp"` for out-of-range / ambiguous values. The call site still surfaces the raw millisecond integer alongside the formatted string, so signers retain the underlying value when chrono can't render it.

## What changed

- `src/chain_parsers/visualsign-tron/src/lib.rs`:
  - `chrono::{LocalResult, TimeZone, Utc}` is now imported at module top instead of inside `format_timestamp`.
  - `format_timestamp` matches on `LocalResult::{Single, None, Ambiguous}`. `Single` formats as before; `None` and `Ambiguous` return `"invalid timestamp"`.
  - Added a `#[cfg(test)]` module with four regression tests: known timestamp, unix epoch, `i64::MAX`, `i64::MIN`. The last two are the PRS-228 regression and previously panicked.

## Linear ticket

Closes PRS-228

Linear: https://linear.app/anchorlabs/issue/PRS-228

## Rollback

Revert this commit. The change is a single file, no schema / config migration, no new dependency (chrono was already a Tron crate dep).

## Backwards compatibility

Yes. For all in-range timestamps the output is byte-identical to before. For previously-panicking inputs the output is now the sentinel `"invalid timestamp"` string instead of a process crash, which is strictly better behaviour. No public API or field schema changed.

## Test plan

Verification is scoped to the affected crate (per the recovery brief):

- [x] `cargo fmt`
- [x] `cargo clippy -p visualsign-tron -- -D warnings` (clean)
- [x] `cargo test -p visualsign-tron` (4/4 tests pass, including the two new `i64::MAX` / `i64::MIN` regression tests)

CI will exercise the rest of the workspace.
