### PR TITLE
fix(sui): remove reachable todo!() in momentum flash_loan handlers

### DIFF
--- a/src/chain_parsers/visualsign-sui/src/presets/momentum/config.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/momentum/config.rs
@@ -31,11 +31,6 @@ crate::chain_config! {
                     sqrt_price_limit as SqrtPriceLimit: u128 => 4 => get_sqrt_price_limit,
                 ),
                 repay_flash_swap as RepayFlashSwap => RepayFlashSwapIndexes(),
-                flash_loan as FlashLoan => FlashLoanIndexes(
-                    amount_x as AmountX: u64 => 1 => get_amount_x,
-                    amount_y as AmountY: u64 => 2 => get_amount_y,
-                ),
-                repay_flash_loan as RepayFlashLoan => RepayFlashLoanIndexes(),
                 swap_receipt_debts as SwapReceiptDebts => SwapReceiptDebtsIndexes(),
             },
         }

--- a/src/chain_parsers/visualsign-sui/src/presets/momentum/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/momentum/mod.rs
@@ -55,12 +55,6 @@ impl CommandVisualizer for MomentumVisualizer {
                 TradeFunctions::SwapReceiptDebts => {
                     Ok(Self::handle_trade_swap_receipt_debts(context)?)
                 }
-                TradeFunctions::FlashLoan => {
-                    todo!("Have not found tx for testing yet")
-                }
-                TradeFunctions::RepayFlashLoan => {
-                    todo!("Have not found tx for testing yet")
-                }
             },
         }
     }
@@ -704,7 +698,83 @@ mod tests {
 
     use crate::utils::{payload_from_b64, run_aggregated_fixture};
 
+    use sui_json_rpc_types::SuiArgument;
+    use sui_types::base_types::{ObjectID, SuiAddress};
     use visualsign::test_utils::assert_has_field;
+
+    /// The momentum mainnet package id, mirrored from `momentum/config.rs`.
+    /// Hard-coded here so the regression tests do not depend on the macro-private
+    /// `package_id` literal and remain stable if the config is restructured.
+    const MOMENTUM_MAINNET_PACKAGE_ID: &str =
+        "0xcf60a40f45d46fc1e828871a647c1e25a0915dec860d2662eb10fdb382c3c1d1";
+
+    fn make_move_call_context<'a>(
+        sender: &'a SuiAddress,
+        commands: &'a [SuiCommand],
+        inputs: &'a [sui_json_rpc_types::SuiCallArg],
+    ) -> VisualizerContext<'a> {
+        VisualizerContext::new(sender, 0, commands, inputs)
+    }
+
+    fn momentum_trade_move_call(function: &str) -> SuiCommand {
+        let pwc = SuiProgrammableMoveCall {
+            package: ObjectID::from_hex_literal(MOMENTUM_MAINNET_PACKAGE_ID)
+                .expect("valid momentum package id"),
+            module: "trade".to_string(),
+            function: function.to_string(),
+            type_arguments: vec![],
+            arguments: vec![SuiArgument::Input(0)],
+        };
+        SuiCommand::MoveCall(Box::new(pwc))
+    }
+
+    /// PRS-232 regression: the unsupported `flash_loan` arm previously panicked via
+    /// `todo!()`. After the fix, the momentum config no longer claims to handle this
+    /// function so `can_handle` must return `false` and `visualize_tx_commands` must
+    /// return a structured error instead of panicking.
+    #[test]
+    fn test_momentum_flash_loan_does_not_panic() {
+        let sender = SuiAddress::ZERO;
+        let commands = vec![momentum_trade_move_call("flash_loan")];
+        let inputs: Vec<sui_json_rpc_types::SuiCallArg> = vec![];
+
+        let context = make_move_call_context(&sender, &commands, &inputs);
+        let visualizer = MomentumVisualizer;
+
+        assert!(
+            !visualizer.can_handle(&context),
+            "Momentum must not claim to handle flash_loan after PRS-232"
+        );
+
+        let result = visualizer.visualize_tx_commands(&context);
+        assert!(
+            result.is_err(),
+            "flash_loan visualization must return Err, not panic. Got: {result:?}"
+        );
+    }
+
+    /// PRS-232 regression: same property as `flash_loan` for the paired
+    /// `repay_flash_loan` function. Both arms previously routed to `todo!()`.
+    #[test]
+    fn test_momentum_repay_flash_loan_does_not_panic() {
+        let sender = SuiAddress::ZERO;
+        let commands = vec![momentum_trade_move_call("repay_flash_loan")];
+        let inputs: Vec<sui_json_rpc_types::SuiCallArg> = vec![];
+
+        let context = make_move_call_context(&sender, &commands, &inputs);
+        let visualizer = MomentumVisualizer;
+
+        assert!(
+            !visualizer.can_handle(&context),
+            "Momentum must not claim to handle repay_flash_loan after PRS-232"
+        );
+
+        let result = visualizer.visualize_tx_commands(&context);
+        assert!(
+            result.is_err(),
+            "repay_flash_loan visualization must return Err, not panic. Got: {result:?}"
+        );
+    }
 
     #[test]
     fn test_momentum_remove_liquidity() {


### PR DESCRIPTION
## Summary

The momentum preset in `visualsign-sui` advertised support for `flash_loan` and `repay_flash_loan` in its config but the corresponding match arms in `MomentumVisualizer::visualize_tx_commands` were stubs that called `todo!("Have not found tx for testing yet")`. A transaction touching either Move function on the momentum mainnet package would panic the parser thread, a reachable DoS on any server handling untrusted transaction bytes (gRPC parser, REST gateway, local dev container).

Closes PRS-232 — https://linear.app/anchorlabs/issue/PRS-232

## What changed

- `presets/momentum/config.rs` — drop the `flash_loan` and `repay_flash_loan` entries from the `chain_config!` block so `TradeFunctions` no longer enumerates them and `MomentumVisualizer::can_handle` returns false for those Move functions.
- `presets/momentum/mod.rs` — remove the two `todo!()` match arms (variants no longer exist) and add two regression tests (`test_momentum_flash_loan_does_not_panic`, `test_momentum_repay_flash_loan_does_not_panic`) that construct a synthetic `SuiProgrammableMoveCall` against the momentum mainnet package id for each function name, then assert `can_handle == false` and `visualize_tx_commands` returns `Err` rather than panicking.

## Why this shape

Real visualization for `flash_loan` / `repay_flash_loan` would need test vectors we don't have and a settled Move ABI for the momentum DEX flash-loan path. Removing the functions from the supported set is the correct DoS-safe behavior until a fixture lands — the dispatcher falls through to the generic / error path instead of panicking.

## Rollback

Revert this commit. The two Move functions will once again be enumerated as supported and will panic on first call (back to the pre-fix state), no schema or data changes to undo.

## Backwards compatibility

No schema changes. The only behavioral change is that `flash_loan` and `repay_flash_loan` calls under the momentum mainnet package now return a parser error instead of panicking. No deployed VisualSign payloads change.

## Test plan

- [x] `cargo fmt` clean.
- [x] `cargo clippy -p visualsign-sui -- -D warnings` clean.
- [x] `cargo test -p visualsign-sui` — 22 tests pass, including the two new regression tests asserting no-panic behavior for both functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
