### PR TITLE
fix(sui): distinguish Result(N) from Input(N) in PTB arg parsing

### DIFF
--- a/src/chain_parsers/visualsign-sui/src/presets/coin_transfer/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/coin_transfer/mod.rs
@@ -1,6 +1,6 @@
 use crate::core::{CommandVisualizer, SuiIntegrationConfig, VisualizerContext, VisualizerKind};
 use crate::truncate_address;
-use crate::utils::{CoinObject, decode_number, parse_numeric_argument};
+use crate::utils::{CoinObject, decode_number, parse_numeric_argument, parse_result_command_index};
 
 use sui_json_rpc_types::{SuiArgument, SuiCallArg, SuiCommand, SuiObjectArg};
 use sui_types::base_types::SuiAddress;
@@ -135,8 +135,11 @@ fn resolve_amount(
         return Ok(None);
     };
 
+    // `object_argument` is a `Result(N)`. Use the result-specific helper so the
+    // command index is extracted explicitly, never silently coerced via the
+    // input-index path (PRS-227).
     let command = commands
-        .get(parse_numeric_argument(object_argument)? as usize)
+        .get(parse_result_command_index(object_argument)? as usize)
         .ok_or(VisualSignError::MissingData("Command not found".into()))?;
 
     match command {

--- a/src/chain_parsers/visualsign-sui/src/presets/coin_transfer/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/coin_transfer/mod.rs
@@ -137,7 +137,7 @@ fn resolve_amount(
 
     // `object_argument` is a `Result(N)`. Use the result-specific helper so the
     // command index is extracted explicitly, never silently coerced via the
-    // input-index path (PRS-227).
+    // input-index path.
     let command = commands
         .get(parse_result_command_index(object_argument)? as usize)
         .ok_or(VisualSignError::MissingData("Command not found".into()))?;

--- a/src/chain_parsers/visualsign-sui/src/presets/sui_native_staking/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/sui_native_staking/mod.rs
@@ -3,7 +3,9 @@ mod config;
 use config::{Config, NATIVE_STAKING_CONFIG, SuiSystemFunctions};
 
 use crate::core::{CommandVisualizer, SuiIntegrationConfig, VisualizerContext, VisualizerKind};
-use crate::utils::{decode_number, get_index, parse_numeric_argument, truncate_address};
+use crate::utils::{
+    decode_number, get_index, parse_numeric_argument, parse_result_command_index, truncate_address,
+};
 
 use sui_json_rpc_types::{SuiArgument, SuiCallArg, SuiCommand, SuiProgrammableMoveCall};
 use sui_types::base_types::SuiAddress;
@@ -193,8 +195,17 @@ fn get_stake_amount(
     inputs: &[SuiCallArg],
     args: &[SuiArgument],
 ) -> Result<Option<u64>, VisualSignError> {
+    // The stake coin is the result of a prior `SplitCoins` command, so the
+    // argument must be a `SuiArgument::Result(N)` whose `N` indexes the
+    // commands vector. Using `parse_result_command_index` keeps the semantic
+    // distinction explicit and prevents `Input(N)` from being silently
+    // dereferenced against the commands vector (PRS-227).
+    let stake_arg = args
+        .get(1)
+        .copied()
+        .ok_or(VisualSignError::MissingData("Stake argument missing".into()))?;
     let command = commands
-        .get(get_index(args, Some(1))? as usize)
+        .get(parse_result_command_index(stake_arg)? as usize)
         .ok_or(VisualSignError::MissingData("Command not found".into()))?;
 
     match command {

--- a/src/chain_parsers/visualsign-sui/src/presets/sui_native_staking/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/presets/sui_native_staking/mod.rs
@@ -199,7 +199,7 @@ fn get_stake_amount(
     // argument must be a `SuiArgument::Result(N)` whose `N` indexes the
     // commands vector. Using `parse_result_command_index` keeps the semantic
     // distinction explicit and prevents `Input(N)` from being silently
-    // dereferenced against the commands vector (PRS-227).
+    // dereferenced against the commands vector.
     let stake_arg = args
         .get(1)
         .copied()

--- a/src/chain_parsers/visualsign-sui/src/utils/mod.rs
+++ b/src/chain_parsers/visualsign-sui/src/utils/mod.rs
@@ -12,6 +12,7 @@ pub use numeric::decode_number;
 pub use package::SuiPackage;
 pub use tx_args::{
     get_index, get_nested_result_value, get_object_value, get_tx_type_arg, parse_numeric_argument,
+    parse_result_command_index,
 };
 
 #[cfg(test)]

--- a/src/chain_parsers/visualsign-sui/src/utils/tx_args.rs
+++ b/src/chain_parsers/visualsign-sui/src/utils/tx_args.rs
@@ -7,7 +7,7 @@ use visualsign::errors::VisualSignError;
 /// Only `SuiArgument::Input(N)` is accepted, since the returned `u16` is used
 /// downstream to index the PTB inputs vector. `SuiArgument::Result(N)` refers
 /// to the output of a previous command and must not be silently coerced to an
-/// inputs-vector index (see PRS-227).
+/// inputs-vector index.
 pub fn get_index(sui_args: &[SuiArgument], index: Option<usize>) -> Result<u16, VisualSignError> {
     let arg: &SuiArgument = match index {
         Some(i) => sui_args
@@ -49,7 +49,7 @@ pub fn get_nested_result_value(
 /// `SuiArgument::Result(N)` is rejected because `Result(N)` references the
 /// output of a prior command, not a slot in the PTB inputs vector. Conflating
 /// the two lets a crafted PTB display an attacker-chosen inputs entry while
-/// on-chain execution uses the (unrelated) result value (PRS-227).
+/// on-chain execution uses the (unrelated) result value.
 ///
 /// Callers that legitimately want the command index inside `Result(N)` (for
 /// indexing the commands vector, not the inputs vector) must use
@@ -72,7 +72,7 @@ pub fn parse_numeric_argument(arg: SuiArgument) -> Result<u16, VisualSignError> 
 ///
 /// The returned `u16` indexes the PTB commands vector (the producer of the
 /// referenced result), never the inputs vector. Errors for any other variant
-/// so callers cannot accidentally substitute an input index (PRS-227).
+/// so callers cannot accidentally substitute an input index.
 pub fn parse_result_command_index(arg: SuiArgument) -> Result<u16, VisualSignError> {
     match arg {
         SuiArgument::Result(command_index) => Ok(command_index),
@@ -130,8 +130,8 @@ mod tests {
         assert_eq!(parsed, 7);
     }
 
-    /// Regression for PRS-227: `Result(N)` must never be silently coerced to
-    /// an inputs-vector index. `Input(N)` and `Result(N)` are semantically
+    /// Regression: `Result(N)` must never be silently coerced to an
+    /// inputs-vector index. `Input(N)` and `Result(N)` are semantically
     /// distinct and downstream lookups treat the returned index as an inputs
     /// slot.
     #[test]
@@ -171,12 +171,11 @@ mod tests {
         ));
     }
 
-    /// Regression for PRS-227: `get_object_value` must not return the
-    /// inputs-vector entry when the argument is `Result(N)`. Previously the
-    /// `Result(N)` branch was conflated with `Input(N)`, letting an attacker
-    /// craft a PTB where the displayed pool address was `sui_inputs[N]`
-    /// (attacker-chosen) while on-chain execution used the unrelated output
-    /// of a prior command.
+    /// Regression: `get_object_value` must not return the inputs-vector entry
+    /// when the argument is `Result(N)`. Previously the `Result(N)` branch was
+    /// conflated with `Input(N)`, letting an attacker craft a PTB where the
+    /// displayed pool address was `sui_inputs[N]` (attacker-chosen) while
+    /// on-chain execution used the unrelated output of a prior command.
     #[test]
     fn get_object_value_distinguishes_result_from_input() {
         let benign_object = ObjectID::random();

--- a/src/chain_parsers/visualsign-sui/src/utils/tx_args.rs
+++ b/src/chain_parsers/visualsign-sui/src/utils/tx_args.rs
@@ -1,9 +1,13 @@
-use sui_json_rpc_types::SuiArgument::Input;
 use sui_json_rpc_types::{SuiArgument, SuiCallArg};
 use sui_types::base_types::ObjectID;
 use visualsign::errors::VisualSignError;
 
-/// Gets the index from the Sui arguments array (expects a single argument)
+/// Gets the index from the Sui arguments array (expects a single argument).
+///
+/// Only `SuiArgument::Input(N)` is accepted, since the returned `u16` is used
+/// downstream to index the PTB inputs vector. `SuiArgument::Result(N)` refers
+/// to the output of a previous command and must not be silently coerced to an
+/// inputs-vector index (see PRS-227).
 pub fn get_index(sui_args: &[SuiArgument], index: Option<usize>) -> Result<u16, VisualSignError> {
     let arg: &SuiArgument = match index {
         Some(i) => sui_args
@@ -40,12 +44,40 @@ pub fn get_nested_result_value(
     }
 }
 
-/// Parses a numeric argument from a Sui argument (`Input` or `Result`)
+/// Parses a numeric `Input(N)` index from a Sui argument.
+///
+/// `SuiArgument::Result(N)` is rejected because `Result(N)` references the
+/// output of a prior command, not a slot in the PTB inputs vector. Conflating
+/// the two lets a crafted PTB display an attacker-chosen inputs entry while
+/// on-chain execution uses the (unrelated) result value (PRS-227).
+///
+/// Callers that legitimately want the command index inside `Result(N)` (for
+/// indexing the commands vector, not the inputs vector) must use
+/// [`parse_result_command_index`] instead.
 pub fn parse_numeric_argument(arg: SuiArgument) -> Result<u16, VisualSignError> {
     match arg {
-        SuiArgument::Result(index) | Input(index) => Ok(index),
+        SuiArgument::Input(index) => Ok(index),
+        SuiArgument::Result(_) => Err(VisualSignError::DecodeError(
+            "Cannot dereference `SuiArgument::Result(N)` as an input index: it references the \
+             output of a prior command, not the inputs vector"
+                .into(),
+        )),
         _ => Err(VisualSignError::DecodeError(
-            "Parsing numeric argument from Sui argument (expected `Input` or `Result`)".into(),
+            "Parsing numeric argument from Sui argument (expected `Input`)".into(),
+        )),
+    }
+}
+
+/// Parses the command index out of a `SuiArgument::Result(N)`.
+///
+/// The returned `u16` indexes the PTB commands vector (the producer of the
+/// referenced result), never the inputs vector. Errors for any other variant
+/// so callers cannot accidentally substitute an input index (PRS-227).
+pub fn parse_result_command_index(arg: SuiArgument) -> Result<u16, VisualSignError> {
+    match arg {
+        SuiArgument::Result(command_index) => Ok(command_index),
+        _ => Err(VisualSignError::DecodeError(
+            "Expected `SuiArgument::Result(N)` for command-index lookup".into(),
         )),
     }
 }
@@ -74,5 +106,94 @@ pub fn get_object_value(
     match input.object() {
         Some(obj) => Ok(*obj),
         _ => Err(VisualSignError::MissingData("Object not found".into())),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use sui_json_rpc_types::SuiObjectArg;
+    use sui_types::base_types::{ObjectID, SequenceNumber};
+
+    fn shared_object_input(object_id: ObjectID) -> SuiCallArg {
+        SuiCallArg::Object(SuiObjectArg::SharedObject {
+            object_id,
+            initial_shared_version: SequenceNumber::new(),
+            mutable: true,
+        })
+    }
+
+    #[test]
+    fn parse_numeric_argument_accepts_input() {
+        let parsed = parse_numeric_argument(SuiArgument::Input(7)).unwrap();
+        assert_eq!(parsed, 7);
+    }
+
+    /// Regression for PRS-227: `Result(N)` must never be silently coerced to
+    /// an inputs-vector index. `Input(N)` and `Result(N)` are semantically
+    /// distinct and downstream lookups treat the returned index as an inputs
+    /// slot.
+    #[test]
+    fn parse_numeric_argument_rejects_result_distinct_from_input() {
+        // `Input(N)` succeeds and yields `N`.
+        let from_input = parse_numeric_argument(SuiArgument::Input(0)).unwrap();
+        assert_eq!(from_input, 0);
+
+        // `Result(N)` with the same numeric payload must fail loudly rather
+        // than coercing to the same value, so callers cannot accidentally
+        // index the inputs vector with a command-output reference.
+        let from_result = parse_numeric_argument(SuiArgument::Result(0));
+        match from_result {
+            Err(VisualSignError::DecodeError(msg)) => {
+                assert!(
+                    msg.contains("Result"),
+                    "Expected error to mention `Result`, got: {msg}"
+                );
+            }
+            other => panic!("Expected DecodeError for `Result(N)`, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_numeric_argument_rejects_gas_coin() {
+        assert!(matches!(
+            parse_numeric_argument(SuiArgument::GasCoin),
+            Err(VisualSignError::DecodeError(_))
+        ));
+    }
+
+    #[test]
+    fn parse_numeric_argument_rejects_nested_result() {
+        assert!(matches!(
+            parse_numeric_argument(SuiArgument::NestedResult(0, 1)),
+            Err(VisualSignError::DecodeError(_))
+        ));
+    }
+
+    /// Regression for PRS-227: `get_object_value` must not return the
+    /// inputs-vector entry when the argument is `Result(N)`. Previously the
+    /// `Result(N)` branch was conflated with `Input(N)`, letting an attacker
+    /// craft a PTB where the displayed pool address was `sui_inputs[N]`
+    /// (attacker-chosen) while on-chain execution used the unrelated output
+    /// of a prior command.
+    #[test]
+    fn get_object_value_distinguishes_result_from_input() {
+        let benign_object = ObjectID::random();
+        let inputs = vec![shared_object_input(benign_object)];
+
+        // `Input(0)` resolves to `sui_inputs[0]` -- the benign object.
+        let resolved =
+            get_object_value(&[SuiArgument::Input(0)], &inputs, 0).expect("Input(0) must resolve");
+        assert_eq!(resolved, benign_object);
+
+        // `Result(0)` MUST NOT resolve to `sui_inputs[0]`. It refers to the
+        // output of command 0, not an input slot, and the visualizer cannot
+        // dereference it.
+        let result_lookup = get_object_value(&[SuiArgument::Result(0)], &inputs, 0);
+        assert!(
+            matches!(result_lookup, Err(VisualSignError::DecodeError(_))),
+            "Result(0) must error rather than returning the inputs[0] object; got: {result_lookup:?}"
+        );
     }
 }


### PR DESCRIPTION
## Why am I making this PR?

`parse_numeric_argument` in `visualsign-sui/src/utils/tx_args.rs` accepted both `SuiArgument::Input(N)` and `SuiArgument::Result(N)` via the same OR-pattern and returned the raw `N`. Downstream `get_object_value` then indexed the PTB inputs vector with that `N`. Those two argument variants are semantically distinct: `Input(N)` is a slot in the inputs vector (an attacker-controllable benign-looking object the user expects to see), while `Result(N)` is a reference to the output of a prior command (the actually-consumed value at on-chain execution time).

An attacker could craft a Sui PTB whose swap call points at `Result(0)` referencing an earlier MoveCall that produces a malicious pool reference, while `inputs[0]` holds a benign well-known pool. The parser conflated the two, displayed `inputs[0]`'s address as the pool address, and the user signed under false pretenses. Cetus, Momentum, and Suilend presets all flow through `get_object_value` for their displayed `Pool Address` field.

## What am I changing?

Split the helper so `Input(N)` and `Result(N)` cannot be conflated, and force each caller to spell out which one it expects.

- `src/chain_parsers/visualsign-sui/src/utils/tx_args.rs`:
  - `parse_numeric_argument` now accepts only `SuiArgument::Input(N)` and returns an explicit `DecodeError` for `Result(N)` (and every other variant), since the returned `u16` is consumed as an inputs-vector index.
  - `get_index` doc-comment now states explicitly that only `Input(N)` is accepted, mirroring the new contract of `parse_numeric_argument`.
  - New `parse_result_command_index` accepts only `SuiArgument::Result(N)` and returns the commands-vector index, for callers that legitimately need to walk back to the producing command.
  - Added five unit tests: `Input(N)` accepted, `Result(N)` rejected with a distinct error, `GasCoin` and `NestedResult` rejected, plus an end-to-end `get_object_value` regression that proves `Result(0)` no longer dereferences `inputs[0]`.
- `src/chain_parsers/visualsign-sui/src/utils/mod.rs`: re-export the new `parse_result_command_index` helper.
- `src/chain_parsers/visualsign-sui/src/presets/coin_transfer/mod.rs`: `resolve_amount` was using `parse_numeric_argument` on what is actually a `Result(N)` (the output of a prior `SplitCoins` command). Switched to `parse_result_command_index` so the call still works and the intent is explicit.
- `src/chain_parsers/visualsign-sui/src/presets/sui_native_staking/mod.rs`: `get_stake_amount` was using `get_index` for the same `Result(N)` walk-back pattern. Switched to `parse_result_command_index` for the same reason.

The remaining `parse_numeric_argument` and `get_index` call sites all operate on arguments that are genuinely `Input(N)` (a receiver address slot, an `input_coin_args[0]` index, a `get_tx_type_arg` lookup), so they keep their current helper and now reject `Result(N)` loudly rather than coercing.

## What are the rollback steps?

Revert the single commit. No data migration, no on-disk state, no deploy coordination, the change is self-contained in the `visualsign-sui` crate. Reverting reintroduces the conflation, so only do this if a hotfix elsewhere subsumes it.

## Is this change backwards compatible?

Yes for the gRPC / CLI surface. Same input bytes that previously produced a `SignablePayload` still do; the only behavior delta is that a PTB whose `Pool Address`-style field was sourced from a `Result(N)` argument now returns a `DecodeError` instead of silently rendering an attacker-chosen `inputs[N]` address. Pre-fix, that path was a security bug, so failing closed is the correct outcome: the user sees a parse failure instead of a forged address and does not sign.

Internal helper signature change: `parse_numeric_argument` is no longer a superset of inputs and results. Two in-crate callers were updated to use the new `parse_result_command_index`; no out-of-crate consumers since the helper is `pub` within `visualsign-sui::utils` and not re-exported beyond the crate.

## Does this require cross-team/service coordination?

No.

## How do I know it works as designed? Which tests exercise this code?

Verification scoped to `visualsign-sui`:

- `cargo fmt`: clean, no diff.
- `cargo clippy -p visualsign-sui -- -D warnings`: clean.
- `cargo test -p visualsign-sui`: 25 tests pass, 0 failed. New regression tests:
  - `parse_numeric_argument_accepts_input`
  - `parse_numeric_argument_rejects_result_distinct_from_input` (the core invariant)
  - `parse_numeric_argument_rejects_gas_coin`
  - `parse_numeric_argument_rejects_nested_result`
  - `get_object_value_distinguishes_result_from_input` (end-to-end proof that `Result(0)` no longer returns `inputs[0]`)

The existing preset snapshot tests (`test_cetus_amm_swap_a2b_commands`, `test_cetus_amm_swap_b2a_commands`, `test_cetus_amm_aggregated`, `test_momentum_aggregated`, `test_suilend_aggregated`, `test_transfer_commands*`, `test_stake_commands`, `test_withdraw_commands`) all continue to pass, confirming the two `parse_result_command_index` switches in `coin_transfer` and `sui_native_staking` preserve the previously-correct behavior on legitimate `Result(N)` walks.
