### PR TITLE
fix(solana): reject V0 transactions referencing unresolved ALT entries

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -355,7 +355,7 @@ fn convert_versioned_to_visual_sign_payload(
 /// program_id or account that lives behind an address lookup table, or that
 /// is out of range entirely.
 ///
-/// Rationale (PRS-226): VisualSign converts raw bytes; it has no RPC and cannot
+/// Rationale: VisualSign converts raw bytes; it has no RPC and cannot
 /// resolve ALT entries. Without resolution, the only safe choice is to refuse
 /// to render -- otherwise the displayed payload would omit instructions or
 /// account references that the validator will still execute, and a malicious
@@ -508,7 +508,7 @@ fn convert_v0_to_visual_sign_payload(
     options: &VisualSignOptions,
     #[cfg(feature = "diagnostics")] lint_config: &visualsign::lint::LintConfig,
 ) -> Result<SignablePayload, VisualSignError> {
-    // SECURITY (PRS-226): the parser does not perform on-chain ALT resolution,
+    // SECURITY: the parser does not perform on-chain ALT resolution,
     // so any instruction or account that references an entry in
     // `address_table_lookups` is unresolvable here. Historically those
     // references were silently dropped from the displayed payload, letting an
@@ -1362,11 +1362,11 @@ mod tests {
         );
     }
 
-    // Regression tests for PRS-226: a V0 transaction that references an
+    // Regression tests: a V0 transaction that references an
     // address lookup table entry (program_id or account index past the static
     // keys, while `address_table_lookups` is non-empty) MUST be rejected, not
     // silently rendered with the ALT-resolved data missing.
-    mod prs_226_alt_rejection {
+    mod v0_alt_rejection {
         use super::*;
         use solana_sdk::instruction::CompiledInstruction;
         use solana_sdk::message::MessageHeader;
@@ -1602,13 +1602,13 @@ mod tests {
             let msg = make_v0(vec![key0], vec![ix], vec![]);
             // We don't assert success vs. failure of conversion here (other
             // unrelated decode paths may still error on malformed input); we
-            // only assert it isn't being caught by the PRS-226 reject branch,
+            // only assert it isn't being caught by the ALT-rejection branch,
             // which would produce the new "Cannot render V0 transaction"
             // message.
             if let Err(VisualSignError::DecodeError(text)) = convert(&msg) {
                 assert!(
                     !text.contains("Cannot render V0 transaction"),
-                    "malformed-without-ALT path must not hit PRS-226 reject branch: {text}"
+                    "malformed-without-ALT path must not hit ALT-rejection branch: {text}"
                 );
             }
         }

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -364,9 +364,13 @@ fn convert_versioned_to_visual_sign_payload(
 ///
 /// The resolved account vector in v0 is `account_keys` followed by, for each
 /// lookup, the addresses pulled at `writable_indexes` then at
-/// `readonly_indexes`. Indices in `[static_len, static_len + loaded_len)` are
-/// ALT-backed; indices `>= static_len + loaded_len` are malformed. The error
-/// reports both classes separately, but rejects on either.
+/// `readonly_indexes`. For instruction `accounts[]`, indices in
+/// `[static_len, static_len + loaded_len)` are ALT-backed and indices
+/// `>= static_len + loaded_len` are malformed. For `program_id_index`, the
+/// V0 spec says program ids must index into the static account_keys table
+/// and cannot be loaded from an ALT, so any `program_id_index >= static_len`
+/// is malformed regardless of `loaded_len`. The error reports the two
+/// classes separately, but rejects on either.
 ///
 /// When `address_table_lookups` is empty, any out-of-bounds index is a
 /// malformed transaction (not an ALT reference) and we keep the existing
@@ -412,12 +416,13 @@ fn reject_v0_if_any_ix_references_alts(
     // exhaustively checked by the compiler. A stray string typo or a future
     // tag rename would otherwise fall through `_ => {}` and silently skip
     // rejection, which would re-introduce the very bug this function exists
-    // to prevent.
+    // to prevent. Program ids do not use this classifier (see below): per
+    // spec, no program_id_index can legitimately resolve via an ALT.
     enum RefKind {
         Alt,
         Malformed,
     }
-    let classify = |idx: usize| -> Option<RefKind> {
+    let classify_account = |idx: usize| -> Option<RefKind> {
         if idx >= loaded_end {
             Some(RefKind::Malformed)
         } else if idx >= static_len {
@@ -428,28 +433,26 @@ fn reject_v0_if_any_ix_references_alts(
     };
 
     for (i, ci) in v0_message.instructions.iter().enumerate() {
-        match classify(ci.program_id_index as usize) {
-            Some(RefKind::Malformed) => {
-                malformed_offenders.push(format!(
-                    "instruction {i}: program_id_index {} is out of range (static={static_len}, loaded={loaded_len})",
-                    ci.program_id_index
-                ));
-                n_mal_refs += 1;
-            }
-            Some(RefKind::Alt) => {
-                alt_offenders.push(format!(
-                    "instruction {i}: program_id_index {} references an ALT entry",
-                    ci.program_id_index
-                ));
-                n_alt_refs += 1;
-            }
-            None => {}
+        // Per the V0 message spec, program ids cannot be loaded via an
+        // ALT: "Program indexes must index into the list of message
+        // account_keys because program ids cannot be dynamically loaded
+        // from a lookup table." Any `program_id_index >= static_len` is
+        // therefore a spec violation, even when the index would fall
+        // within the ALT-loaded range. Classify it as malformed so the
+        // rejection message names the right defect.
+        if (ci.program_id_index as usize) >= static_len {
+            malformed_offenders.push(format!(
+                "instruction {i}: program_id_index {} cannot resolve via ALT \
+                 (program ids must index static account keys; static={static_len}, loaded={loaded_len})",
+                ci.program_id_index
+            ));
+            n_mal_refs += 1;
         }
 
         let mut alt_accounts: Vec<u8> = Vec::new();
         let mut malformed_accounts: Vec<u8> = Vec::new();
         for &idx in &ci.accounts {
-            match classify(idx as usize) {
+            match classify_account(idx as usize) {
                 Some(RefKind::Malformed) => malformed_accounts.push(idx),
                 Some(RefKind::Alt) => alt_accounts.push(idx),
                 None => {}
@@ -1419,10 +1422,14 @@ mod tests {
         }
 
         #[test]
-        fn rejects_v0_when_program_id_lives_behind_an_alt() {
+        fn rejects_v0_when_program_id_index_points_past_static_keys() {
             // 2 static account keys, 1 ALT supplying extra accounts, one
-            // benign instruction in-range, one instruction whose program_id
-            // points past the static keys (= ALT resolved).
+            // benign instruction in-range, one instruction whose
+            // program_id_index points past the static keys. Per the V0
+            // spec, program ids cannot be loaded via an ALT -- they must
+            // index into the static account_keys table -- so this is
+            // classified as `malformed:`, not `ALT-backed:`, even though
+            // the index would otherwise fall within the ALT-loaded range.
             let key0 = Pubkey::new_unique();
             let key1 = Pubkey::new_unique();
             let alt = MessageAddressTableLookup {
@@ -1435,14 +1442,14 @@ mod tests {
                 accounts: vec![0],
                 data: vec![0xAA],
             };
-            let malicious_via_alt = CompiledInstruction {
-                program_id_index: 5, // beyond the 2 static keys -> resolved via ALT
+            let malicious = CompiledInstruction {
+                program_id_index: 5, // past static_len=2; spec says this is malformed
                 accounts: vec![0],
                 data: vec![0xBB],
             };
-            let msg = make_v0(vec![key0, key1], vec![benign, malicious_via_alt], vec![alt]);
+            let msg = make_v0(vec![key0, key1], vec![benign, malicious], vec![alt]);
 
-            let err = convert(&msg).expect_err("must reject ALT-referenced instructions");
+            let err = convert(&msg).expect_err("must reject out-of-static program_id refs");
             let VisualSignError::DecodeError(text) = err else {
                 panic!("expected DecodeError, got {err:?}");
             };
@@ -1457,6 +1464,16 @@ mod tests {
             assert!(
                 text.contains("instruction 1"),
                 "error should name the offending instruction index: {text}"
+            );
+            assert!(
+                text.contains("malformed:"),
+                "program ids cannot be loaded via ALT, so the spec-violation \
+                 classification is malformed, not ALT-backed: {text}"
+            );
+            assert!(
+                !text.contains("ALT-backed:"),
+                "this case has only a spec-violating program_id ref, no \
+                 ALT-backed account refs: {text}"
             );
         }
 

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -408,11 +408,20 @@ fn reject_v0_if_any_ix_references_alts(
     let mut n_alt_refs: usize = 0;
     let mut n_mal_refs: usize = 0;
 
-    let classify = |idx: usize| -> Option<&'static str> {
+    // Use a small enum instead of string tags so the match arms below are
+    // exhaustively checked by the compiler. A stray string typo or a future
+    // tag rename would otherwise fall through `_ => {}` and silently skip
+    // rejection, which would re-introduce the very bug this function exists
+    // to prevent.
+    enum RefKind {
+        Alt,
+        Malformed,
+    }
+    let classify = |idx: usize| -> Option<RefKind> {
         if idx >= loaded_end {
-            Some("malformed")
+            Some(RefKind::Malformed)
         } else if idx >= static_len {
-            Some("alt")
+            Some(RefKind::Alt)
         } else {
             None
         }
@@ -420,30 +429,30 @@ fn reject_v0_if_any_ix_references_alts(
 
     for (i, ci) in v0_message.instructions.iter().enumerate() {
         match classify(ci.program_id_index as usize) {
-            Some("malformed") => {
+            Some(RefKind::Malformed) => {
                 malformed_offenders.push(format!(
                     "instruction {i}: program_id_index {} is out of range (static={static_len}, loaded={loaded_len})",
                     ci.program_id_index
                 ));
                 n_mal_refs += 1;
             }
-            Some("alt") => {
+            Some(RefKind::Alt) => {
                 alt_offenders.push(format!(
                     "instruction {i}: program_id_index {} references an ALT entry",
                     ci.program_id_index
                 ));
                 n_alt_refs += 1;
             }
-            _ => {}
+            None => {}
         }
 
         let mut alt_accounts: Vec<u8> = Vec::new();
         let mut malformed_accounts: Vec<u8> = Vec::new();
         for &idx in &ci.accounts {
             match classify(idx as usize) {
-                Some("malformed") => malformed_accounts.push(idx),
-                Some("alt") => alt_accounts.push(idx),
-                _ => {}
+                Some(RefKind::Malformed) => malformed_accounts.push(idx),
+                Some(RefKind::Alt) => alt_accounts.push(idx),
+                None => {}
             }
         }
         // Sort + dedup so the error message is stable regardless of how the

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -352,7 +352,8 @@ fn convert_versioned_to_visual_sign_payload(
 }
 
 /// Reject a V0 transaction when at least one instruction references a
-/// program_id or account that lives behind an address lookup table.
+/// program_id or account that lives behind an address lookup table, or that
+/// is out of range entirely.
 ///
 /// Rationale (PRS-226): VisualSign converts raw bytes; it has no RPC and cannot
 /// resolve ALT entries. Without resolution, the only safe choice is to refuse
@@ -360,6 +361,12 @@ fn convert_versioned_to_visual_sign_payload(
 /// account references that the validator will still execute, and a malicious
 /// instruction could be hidden behind an ALT entry while the user signs a
 /// benign-looking display.
+///
+/// The resolved account vector in v0 is `account_keys` followed by, for each
+/// lookup, the addresses pulled at `writable_indexes` then at
+/// `readonly_indexes`. Indices in `[static_len, static_len + loaded_len)` are
+/// ALT-backed; indices `>= static_len + loaded_len` are malformed. The error
+/// reports both classes separately, but rejects on either.
 ///
 /// When `address_table_lookups` is empty, any out-of-bounds index is a
 /// malformed transaction (not an ALT reference) and we keep the existing
@@ -374,44 +381,97 @@ fn reject_v0_if_any_ix_references_alts(
     }
 
     let static_len = v0_message.account_keys.len();
-    let mut offenders: Vec<String> = Vec::new();
+    // `loaded_len` is the total number of addresses the message claims to load
+    // via ALTs. In Solana v0, the resolved account vector seen by the runtime
+    // is the concatenation of `account_keys` and, for each lookup, the
+    // addresses pulled at `writable_indexes` followed by those at
+    // `readonly_indexes`. The valid instruction-index range is therefore
+    // `[0, static_len + loaded_len)`. Indices in `[static_len, static_len +
+    // loaded_len)` reference ALT-backed addresses we cannot resolve offline;
+    // indices `>= static_len + loaded_len` are malformed (out-of-range).
+    // Both are unsafe to render, but we report them separately so the error
+    // message is accurate.
+    let loaded_len: usize = v0_message
+        .address_table_lookups
+        .iter()
+        .map(|l| l.writable_indexes.len() + l.readonly_indexes.len())
+        .sum();
+    let loaded_end = static_len.saturating_add(loaded_len);
+
+    let mut alt_offenders: Vec<String> = Vec::new();
+    let mut malformed_offenders: Vec<String> = Vec::new();
+
+    let classify = |idx: usize| -> Option<&'static str> {
+        if idx >= loaded_end {
+            Some("malformed")
+        } else if idx >= static_len {
+            Some("alt")
+        } else {
+            None
+        }
+    };
 
     for (i, ci) in v0_message.instructions.iter().enumerate() {
-        if (ci.program_id_index as usize) >= static_len {
-            offenders.push(format!(
+        match classify(ci.program_id_index as usize) {
+            Some("malformed") => malformed_offenders.push(format!(
+                "instruction {i}: program_id_index {} is out of range (static={static_len}, loaded={loaded_len})",
+                ci.program_id_index
+            )),
+            Some("alt") => alt_offenders.push(format!(
                 "instruction {i}: program_id_index {} references an ALT entry",
                 ci.program_id_index
-            ));
+            )),
+            _ => {}
         }
-        let mut oob_accounts: Vec<u8> = ci
-            .accounts
-            .iter()
-            .copied()
-            .filter(|&idx| (idx as usize) >= static_len)
-            .collect();
+
+        let mut alt_accounts: Vec<u8> = Vec::new();
+        let mut malformed_accounts: Vec<u8> = Vec::new();
+        for &idx in &ci.accounts {
+            match classify(idx as usize) {
+                Some("malformed") => malformed_accounts.push(idx),
+                Some("alt") => alt_accounts.push(idx),
+                _ => {}
+            }
+        }
         // Sort + dedup so the error message is stable regardless of how the
         // raw instruction listed its accounts (and so the same index isn't
         // repeated when it appears twice in `accounts`).
-        oob_accounts.sort_unstable();
-        oob_accounts.dedup();
-        if !oob_accounts.is_empty() {
-            offenders.push(format!(
-                "instruction {i}: account indices {oob_accounts:?} reference ALT entries"
+        alt_accounts.sort_unstable();
+        alt_accounts.dedup();
+        malformed_accounts.sort_unstable();
+        malformed_accounts.dedup();
+        if !alt_accounts.is_empty() {
+            alt_offenders.push(format!(
+                "instruction {i}: account indices {alt_accounts:?} reference ALT entries"
+            ));
+        }
+        if !malformed_accounts.is_empty() {
+            malformed_offenders.push(format!(
+                "instruction {i}: account indices {malformed_accounts:?} are out of range (static={static_len}, loaded={loaded_len})"
             ));
         }
     }
 
-    if offenders.is_empty() {
+    if alt_offenders.is_empty() && malformed_offenders.is_empty() {
         return Ok(());
     }
 
+    let mut details_parts: Vec<String> = Vec::new();
+    if !alt_offenders.is_empty() {
+        details_parts.push(format!("ALT-backed: {}", alt_offenders.join("; ")));
+    }
+    if !malformed_offenders.is_empty() {
+        details_parts.push(format!("malformed: {}", malformed_offenders.join("; ")));
+    }
+
     Err(VisualSignError::DecodeError(format!(
-        "Cannot render V0 transaction: {n_alt} address lookup table(s) present and {n_offenders} unresolved reference(s) into them ({static_len} static account keys). \
+        "Cannot render V0 transaction: {n_alt} address lookup table(s) present, {n_alt_off} unresolved ALT reference(s) and {n_mal_off} out-of-range reference(s) ({static_len} static account keys, {loaded_len} ALT-loaded). \
          Resolving ALT contents requires an on-chain lookup that the parser does not perform. \
          Refusing to display a partial transaction. Details: {details}",
         n_alt = v0_message.address_table_lookups.len(),
-        n_offenders = offenders.len(),
-        details = offenders.join("; ")
+        n_alt_off = alt_offenders.len(),
+        n_mal_off = malformed_offenders.len(),
+        details = details_parts.join(" | ")
     )))
 }
 
@@ -1441,6 +1501,52 @@ mod tests {
             assert!(
                 has_alt_field,
                 "Address Lookup Tables field must be present in payload"
+            );
+        }
+
+        #[test]
+        fn rejects_v0_with_malformed_index_when_alts_are_present() {
+            // ALTs are present but loaded_len=1 (one writable index). Static
+            // keys=2, so the valid resolved range is [0, 3). An instruction
+            // account index of 99 is past `static_len + loaded_len`, i.e.
+            // genuinely out-of-range / malformed, not just ALT-backed. We
+            // still reject (any unresolvable reference is unsafe to render),
+            // and the error message classifies it as malformed rather than
+            // claiming it references an ALT entry.
+            let key0 = Pubkey::new_unique();
+            let key1 = Pubkey::new_unique();
+            let alt = MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![0],
+                readonly_indexes: vec![],
+            };
+            let ix = CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0, 99],
+                data: vec![0xFF],
+            };
+            let msg = make_v0(vec![key0, key1], vec![ix], vec![alt]);
+
+            let err =
+                convert(&msg).expect_err("must reject out-of-range indices even with ALTs present");
+            let VisualSignError::DecodeError(text) = err else {
+                panic!("expected DecodeError, got {err:?}");
+            };
+            assert!(
+                text.contains("Cannot render V0 transaction"),
+                "error should explain why: {text}"
+            );
+            assert!(
+                text.contains("malformed:"),
+                "error should classify the index as malformed, not ALT-backed: {text}"
+            );
+            assert!(
+                text.contains("[99]"),
+                "error should enumerate the offending malformed index: {text}"
+            );
+            assert!(
+                !text.contains("ALT-backed:"),
+                "this case has no ALT-backed references, only malformed ones: {text}"
             );
         }
 

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -363,7 +363,9 @@ fn convert_versioned_to_visual_sign_payload(
 ///
 /// When `address_table_lookups` is empty, any out-of-bounds index is a
 /// malformed transaction (not an ALT reference) and we keep the existing
-/// "render as `unresolved(N)` placeholder + diagnostic" behavior intact.
+/// "render as `unresolved(N)` placeholder" behavior intact. (A lint
+/// diagnostic is also emitted for that case, but only when the
+/// `diagnostics` feature is enabled.)
 fn reject_v0_if_any_ix_references_alts(
     v0_message: &solana_sdk::message::v0::Message,
 ) -> Result<(), VisualSignError> {
@@ -381,12 +383,17 @@ fn reject_v0_if_any_ix_references_alts(
                 ci.program_id_index
             ));
         }
-        let oob_accounts: Vec<u8> = ci
+        let mut oob_accounts: Vec<u8> = ci
             .accounts
             .iter()
             .copied()
             .filter(|&idx| (idx as usize) >= static_len)
             .collect();
+        // Sort + dedup so the error message is stable regardless of how the
+        // raw instruction listed its accounts (and so the same index isn't
+        // repeated when it appears twice in `accounts`).
+        oob_accounts.sort_unstable();
+        oob_accounts.dedup();
         if !oob_accounts.is_empty() {
             offenders.push(format!(
                 "instruction {i}: account indices {oob_accounts:?} reference ALT entries"
@@ -1396,8 +1403,8 @@ mod tests {
                 "error should mention account indices: {text}"
             );
             assert!(
-                text.contains('7') && text.contains('9'),
-                "error should enumerate the offending indices: {text}"
+                text.contains("[7, 9]"),
+                "error should enumerate the offending indices as `[7, 9]`: {text}"
             );
         }
 

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -400,6 +400,13 @@ fn reject_v0_if_any_ix_references_alts(
 
     let mut alt_offenders: Vec<String> = Vec::new();
     let mut malformed_offenders: Vec<String> = Vec::new();
+    // Track the actual number of offending index references (post-dedup),
+    // not the number of formatted offender entries. A single entry like
+    // `instruction 0: account indices [2, 3] reference ALT entries`
+    // represents two index references, so counting entries would understate
+    // the offence count and mismatch the wording "N reference(s)".
+    let mut n_alt_refs: usize = 0;
+    let mut n_mal_refs: usize = 0;
 
     let classify = |idx: usize| -> Option<&'static str> {
         if idx >= loaded_end {
@@ -413,14 +420,20 @@ fn reject_v0_if_any_ix_references_alts(
 
     for (i, ci) in v0_message.instructions.iter().enumerate() {
         match classify(ci.program_id_index as usize) {
-            Some("malformed") => malformed_offenders.push(format!(
-                "instruction {i}: program_id_index {} is out of range (static={static_len}, loaded={loaded_len})",
-                ci.program_id_index
-            )),
-            Some("alt") => alt_offenders.push(format!(
-                "instruction {i}: program_id_index {} references an ALT entry",
-                ci.program_id_index
-            )),
+            Some("malformed") => {
+                malformed_offenders.push(format!(
+                    "instruction {i}: program_id_index {} is out of range (static={static_len}, loaded={loaded_len})",
+                    ci.program_id_index
+                ));
+                n_mal_refs += 1;
+            }
+            Some("alt") => {
+                alt_offenders.push(format!(
+                    "instruction {i}: program_id_index {} references an ALT entry",
+                    ci.program_id_index
+                ));
+                n_alt_refs += 1;
+            }
             _ => {}
         }
 
@@ -441,11 +454,13 @@ fn reject_v0_if_any_ix_references_alts(
         malformed_accounts.sort_unstable();
         malformed_accounts.dedup();
         if !alt_accounts.is_empty() {
+            n_alt_refs += alt_accounts.len();
             alt_offenders.push(format!(
                 "instruction {i}: account indices {alt_accounts:?} reference ALT entries"
             ));
         }
         if !malformed_accounts.is_empty() {
+            n_mal_refs += malformed_accounts.len();
             malformed_offenders.push(format!(
                 "instruction {i}: account indices {malformed_accounts:?} are out of range (static={static_len}, loaded={loaded_len})"
             ));
@@ -469,8 +484,8 @@ fn reject_v0_if_any_ix_references_alts(
          Resolving ALT contents requires an on-chain lookup that the parser does not perform. \
          Refusing to display a partial transaction. Details: {details}",
         n_alt = v0_message.address_table_lookups.len(),
-        n_alt_off = alt_offenders.len(),
-        n_mal_off = malformed_offenders.len(),
+        n_alt_off = n_alt_refs,
+        n_mal_off = n_mal_refs,
         details = details_parts.join(" | ")
     )))
 }
@@ -1438,18 +1453,23 @@ mod tests {
 
         #[test]
         fn rejects_v0_when_account_index_lives_behind_an_alt() {
-            // Instruction's program_id is in-range, but one of its accounts
-            // points past the static keys, i.e. it lives in an ALT.
+            // Instruction's program_id is in-range, but two of its accounts
+            // point past the static keys into the ALT-loaded range. With
+            // static_len=2 and loaded_len=3 (writable=[0,1], readonly=[2])
+            // the valid resolved range is [0, 5); ALT-backed indices are
+            // [2, 5). Using accounts {2, 3} exercises the ALT-backed path
+            // (not the malformed-OOB path) and lets us assert the error
+            // surfaces them under the `ALT-backed:` section.
             let key0 = Pubkey::new_unique();
             let key1 = Pubkey::new_unique();
             let alt = MessageAddressTableLookup {
                 account_key: Pubkey::new_unique(),
-                writable_indexes: vec![0],
-                readonly_indexes: vec![],
+                writable_indexes: vec![0, 1],
+                readonly_indexes: vec![2],
             };
             let ix = CompiledInstruction {
                 program_id_index: 1,
-                accounts: vec![0, 7, 9],
+                accounts: vec![0, 2, 3],
                 data: vec![0xCC],
             };
             let msg = make_v0(vec![key0, key1], vec![ix], vec![alt]);
@@ -1459,12 +1479,20 @@ mod tests {
                 panic!("expected DecodeError, got {err:?}");
             };
             assert!(
+                text.contains("ALT-backed:"),
+                "error should classify these accounts under ALT-backed, not malformed: {text}"
+            );
+            assert!(
+                !text.contains("malformed:"),
+                "this case has no out-of-range references, only ALT-backed ones: {text}"
+            );
+            assert!(
                 text.contains("account indices"),
                 "error should mention account indices: {text}"
             );
             assert!(
-                text.contains("[7, 9]"),
-                "error should enumerate the offending indices as `[7, 9]`: {text}"
+                text.contains("[2, 3]"),
+                "error should enumerate the offending indices as `[2, 3]`: {text}"
             );
         }
 

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -1314,12 +1314,16 @@ mod tests {
                 signatures: vec![],
                 message: VersionedMessage::V0(v0_message.clone()),
             };
+            #[cfg(feature = "diagnostics")]
+            let lint_config = visualsign::lint::LintConfig::default();
             convert_v0_to_visual_sign_payload(
                 &versioned_tx,
                 v0_message,
                 false,
                 None,
                 &default_options(),
+                #[cfg(feature = "diagnostics")]
+                &lint_config,
             )
         }
 

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -351,6 +351,63 @@ fn convert_versioned_to_visual_sign_payload(
     }
 }
 
+/// Reject a V0 transaction when at least one instruction references a
+/// program_id or account that lives behind an address lookup table.
+///
+/// Rationale (PRS-226): VisualSign converts raw bytes; it has no RPC and cannot
+/// resolve ALT entries. Without resolution, the only safe choice is to refuse
+/// to render -- otherwise the displayed payload would omit instructions or
+/// account references that the validator will still execute, and a malicious
+/// instruction could be hidden behind an ALT entry while the user signs a
+/// benign-looking display.
+///
+/// When `address_table_lookups` is empty, any out-of-bounds index is a
+/// malformed transaction (not an ALT reference) and we keep the existing
+/// "render as `unresolved(N)` placeholder + diagnostic" behavior intact.
+fn reject_v0_if_any_ix_references_alts(
+    v0_message: &solana_sdk::message::v0::Message,
+) -> Result<(), VisualSignError> {
+    if v0_message.address_table_lookups.is_empty() {
+        return Ok(());
+    }
+
+    let static_len = v0_message.account_keys.len();
+    let mut offenders: Vec<String> = Vec::new();
+
+    for (i, ci) in v0_message.instructions.iter().enumerate() {
+        if (ci.program_id_index as usize) >= static_len {
+            offenders.push(format!(
+                "instruction {i}: program_id_index {} references an ALT entry",
+                ci.program_id_index
+            ));
+        }
+        let oob_accounts: Vec<u8> = ci
+            .accounts
+            .iter()
+            .copied()
+            .filter(|&idx| (idx as usize) >= static_len)
+            .collect();
+        if !oob_accounts.is_empty() {
+            offenders.push(format!(
+                "instruction {i}: account indices {oob_accounts:?} reference ALT entries"
+            ));
+        }
+    }
+
+    if offenders.is_empty() {
+        return Ok(());
+    }
+
+    Err(VisualSignError::DecodeError(format!(
+        "Cannot render V0 transaction: {n_alt} address lookup table(s) present and {n_offenders} unresolved reference(s) into them ({static_len} static account keys). \
+         Resolving ALT contents requires an on-chain lookup that the parser does not perform. \
+         Refusing to display a partial transaction. Details: {details}",
+        n_alt = v0_message.address_table_lookups.len(),
+        n_offenders = offenders.len(),
+        details = offenders.join("; ")
+    )))
+}
+
 /// Convert V0 transaction to visual sign payload
 fn convert_v0_to_visual_sign_payload(
     versioned_tx: &VersionedTransaction,
@@ -360,6 +417,16 @@ fn convert_v0_to_visual_sign_payload(
     options: &VisualSignOptions,
     #[cfg(feature = "diagnostics")] lint_config: &visualsign::lint::LintConfig,
 ) -> Result<SignablePayload, VisualSignError> {
+    // SECURITY (PRS-226): the parser does not perform on-chain ALT resolution,
+    // so any instruction or account that references an entry in
+    // `address_table_lookups` is unresolvable here. Historically those
+    // references were silently dropped from the displayed payload, letting an
+    // attacker hide malicious instructions behind ALTs while the user signed a
+    // benign-looking display. Reject the transaction instead -- we can either
+    // resolve ALTs and surface their contents, or refuse to render. We do the
+    // latter.
+    reject_v0_if_any_ix_references_alts(v0_message)?;
+
     // Create IDL registry from options metadata
     let idl_registry = create_idl_registry_from_options(options)?;
 
@@ -1202,5 +1269,194 @@ mod tests {
             note.contains("no account keys"),
             "note should propagate underlying error: {note}"
         );
+    }
+
+    // Regression tests for PRS-226: a V0 transaction that references an
+    // address lookup table entry (program_id or account index past the static
+    // keys, while `address_table_lookups` is non-empty) MUST be rejected, not
+    // silently rendered with the ALT-resolved data missing.
+    mod prs_226_alt_rejection {
+        use super::*;
+        use solana_sdk::instruction::CompiledInstruction;
+        use solana_sdk::message::MessageHeader;
+        use solana_sdk::message::v0::{Message as V0Message, MessageAddressTableLookup};
+        use solana_sdk::pubkey::Pubkey;
+
+        fn make_v0(
+            account_keys: Vec<Pubkey>,
+            instructions: Vec<CompiledInstruction>,
+            address_table_lookups: Vec<MessageAddressTableLookup>,
+        ) -> V0Message {
+            V0Message {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 0,
+                },
+                account_keys,
+                recent_blockhash: solana_sdk::hash::Hash::default(),
+                instructions,
+                address_table_lookups,
+            }
+        }
+
+        fn default_options() -> VisualSignOptions {
+            VisualSignOptions {
+                metadata: None,
+                decode_transfers: false,
+                transaction_name: Some("V0 ALT Regression".to_string()),
+                developer_config: None,
+            }
+        }
+
+        fn convert(v0_message: &V0Message) -> Result<SignablePayload, VisualSignError> {
+            let versioned_tx = VersionedTransaction {
+                signatures: vec![],
+                message: VersionedMessage::V0(v0_message.clone()),
+            };
+            convert_v0_to_visual_sign_payload(
+                &versioned_tx,
+                v0_message,
+                false,
+                None,
+                &default_options(),
+            )
+        }
+
+        #[test]
+        fn rejects_v0_when_program_id_lives_behind_an_alt() {
+            // 2 static account keys, 1 ALT supplying extra accounts, one
+            // benign instruction in-range, one instruction whose program_id
+            // points past the static keys (= ALT resolved).
+            let key0 = Pubkey::new_unique();
+            let key1 = Pubkey::new_unique();
+            let alt = MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![0, 1, 2],
+                readonly_indexes: vec![3],
+            };
+            let benign = CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![0xAA],
+            };
+            let malicious_via_alt = CompiledInstruction {
+                program_id_index: 5, // beyond the 2 static keys -> resolved via ALT
+                accounts: vec![0],
+                data: vec![0xBB],
+            };
+            let msg = make_v0(vec![key0, key1], vec![benign, malicious_via_alt], vec![alt]);
+
+            let err = convert(&msg).expect_err("must reject ALT-referenced instructions");
+            let VisualSignError::DecodeError(text) = err else {
+                panic!("expected DecodeError, got {err:?}");
+            };
+            assert!(
+                text.contains("Cannot render V0 transaction"),
+                "error should explain why: {text}"
+            );
+            assert!(
+                text.contains("program_id_index 5"),
+                "error should name the offending index: {text}"
+            );
+            assert!(
+                text.contains("instruction 1"),
+                "error should name the offending instruction index: {text}"
+            );
+        }
+
+        #[test]
+        fn rejects_v0_when_account_index_lives_behind_an_alt() {
+            // Instruction's program_id is in-range, but one of its accounts
+            // points past the static keys, i.e. it lives in an ALT.
+            let key0 = Pubkey::new_unique();
+            let key1 = Pubkey::new_unique();
+            let alt = MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![0],
+                readonly_indexes: vec![],
+            };
+            let ix = CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0, 7, 9],
+                data: vec![0xCC],
+            };
+            let msg = make_v0(vec![key0, key1], vec![ix], vec![alt]);
+
+            let err = convert(&msg).expect_err("must reject ALT-referenced accounts");
+            let VisualSignError::DecodeError(text) = err else {
+                panic!("expected DecodeError, got {err:?}");
+            };
+            assert!(
+                text.contains("account indices"),
+                "error should mention account indices: {text}"
+            );
+            assert!(
+                text.contains('7') && text.contains('9'),
+                "error should enumerate the offending indices: {text}"
+            );
+        }
+
+        #[test]
+        fn allows_v0_with_alt_when_no_instruction_references_alt_contents() {
+            // ALTs are present in the wire format (e.g. for future inner-CPIs
+            // a wallet pre-attached), but every compiled instruction's
+            // program_id and accounts resolve against the static keys. This is
+            // safe to render -- nothing about the displayed instructions is
+            // hidden by an ALT. The presence of `address_table_lookups` alone
+            // is not the threat; an unresolved reference into one is.
+            let key0 = Pubkey::new_unique();
+            let key1 = Pubkey::new_unique();
+            let alt = MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![0],
+                readonly_indexes: vec![1],
+            };
+            let ix = CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![0xDD],
+            };
+            let msg = make_v0(vec![key0, key1], vec![ix], vec![alt]);
+
+            let payload =
+                convert(&msg).expect("V0 with ALTs but only static-key references should render");
+            assert_eq!(payload.payload_type, "SolanaTx");
+            // Confirm the ALT itself is surfaced in the displayed payload.
+            let has_alt_field = payload
+                .fields
+                .iter()
+                .any(|f| matches!(f, SignablePayloadField::PreviewLayout { common, .. } if common.label == "Address Lookup Tables"));
+            assert!(
+                has_alt_field,
+                "Address Lookup Tables field must be present in payload"
+            );
+        }
+
+        #[test]
+        fn malformed_v0_without_alts_keeps_existing_behavior() {
+            // No ALTs: an OOB index here is just a malformed transaction, not
+            // a hidden-behind-ALT attack. The fix MUST NOT change behavior on
+            // this path -- the existing pipeline renders it with placeholders
+            // / diagnostics rather than rejecting.
+            let key0 = Pubkey::new_unique();
+            let ix = CompiledInstruction {
+                program_id_index: 99,
+                accounts: vec![0, 50],
+                data: vec![0xEE],
+            };
+            let msg = make_v0(vec![key0], vec![ix], vec![]);
+            // We don't assert success vs. failure of conversion here (other
+            // unrelated decode paths may still error on malformed input); we
+            // only assert it isn't being caught by the PRS-226 reject branch,
+            // which would produce the new "Cannot render V0 transaction"
+            // message.
+            if let Err(VisualSignError::DecodeError(text)) = convert(&msg) {
+                assert!(
+                    !text.contains("Cannot render V0 transaction"),
+                    "malformed-without-ALT path must not hit PRS-226 reject branch: {text}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

V0 Solana transactions can reference program ids and accounts that live behind address lookup tables. VisualSign converts raw bytes and has no RPC, so it cannot resolve those ALT entries. Today, any instruction whose `program_id_index` or account index points past the static account keys is silently dropped from the rendered payload. A malicious instruction can be hidden behind an ALT entry while the user signs a benign-looking display.

This change rejects the transaction in that case rather than rendering a partial view.

## What changed

- `src/chain_parsers/visualsign-solana/src/core/visualsign.rs`
  - New `reject_v0_if_any_ix_references_alts` helper. When `address_table_lookups` is non-empty, walks every compiled instruction and collects `program_id_index` and account indices that fall past the static account keys. If any are found, returns a `VisualSignError::DecodeError` naming the offending instruction(s) and index/indices.
  - `convert_v0_to_visual_sign_payload` calls the helper as its first step.
  - The classifier distinguishes ALT-backed account refs (`[static_len, static_len + loaded_len)`) from malformed refs (`>= static_len + loaded_len`). Per the V0 spec, program ids cannot be loaded via an ALT, so any `program_id_index >= static_len` is reported as malformed regardless of `loaded_len`.
  - Five regression tests under `v0_alt_rejection`:
    - `rejects_v0_when_program_id_index_points_past_static_keys` -- program ids cannot be ALT-loaded per spec; rejected and classified as `malformed:`
    - `rejects_v0_when_account_index_lives_behind_an_alt` -- account index resolves via an ALT; rejected and classified as `ALT-backed:`
    - `allows_v0_with_alt_when_no_instruction_references_alt_contents` -- ALTs are present but every instruction only references static keys; safe to render (no false positive)
    - `rejects_v0_with_malformed_index_when_alts_are_present` -- ALTs are present but an index is past `static_len + loaded_len`; rejected and classified as `malformed:`
    - `malformed_v0_without_alts_keeps_existing_behavior` -- legacy OOB-without-ALT path is untouched (no behavior regression)

## Rollback

Revert this commit. No data migrations, no config changes, no protobuf changes. The helper is additive; reverting restores the prior silent-drop behavior.

## Test plan

- [x] `cargo fmt` (no diff)
- [x] `cargo clippy -p visualsign-solana --all-targets -- -D warnings` (clean, with and without `--features diagnostics`)
- [x] `cargo test -p visualsign-solana` (all suites green, including the 5 new `v0_alt_rejection` tests under both feature variants)
- [ ] Reviewer: confirm the rejection branch is the desired UX over rendering a "this transaction touches ALTs we can't resolve" placeholder. The rationale in the helper doc-comment calls for rejection.

## Backwards compatibility

User-visible change: V0 transactions whose instructions referenced unresolved ALT entries used to render (with the ALT-resolved references missing). They now return a `DecodeError`. The previous behavior was the bug, so this is an intentional break. No proto/API changes.
