### PR TITLE
fix(ethereum): enforce charset validation in string-input converter

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -273,8 +273,9 @@ impl VisualSignConverterFromString<EthereumTransactionWrapper> for EthereumVisua
         // string that reaches a rendered field is screened for non-ASCII,
         // unicode escapes, and non-printable characters. Matches the default
         // impl every other chain converter inherits, and preserves the
-        // invariant that every payload returned by the converter has been
-        // charset-validated regardless of which chain produced it.
+        // invariant that every payload returned by `to_visual_sign_payload_from_string`
+        // is charset-validated. Callers that go through `to_visual_sign_payload`
+        // or `transaction_to_visual_sign` still bypass this check by design.
         self.to_validated_visual_sign_payload(wrapper, options)
     }
 }

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -269,7 +269,13 @@ impl VisualSignConverterFromString<EthereumTransactionWrapper> for EthereumVisua
             options.developer_config.as_ref(),
         )
         .map_err(VisualSignError::ParseError)?;
-        self.to_visual_sign_payload(wrapper, options)
+        // Use the validated variant so any wallet-supplied or caller-supplied
+        // string that reaches a rendered field is screened for non-ASCII,
+        // unicode escapes, and non-printable characters. Matches the default
+        // impl every other chain converter inherits, and preserves the
+        // invariant that every payload returned by the converter has been
+        // charset-validated regardless of which chain produced it.
+        self.to_validated_visual_sign_payload(wrapper, options)
     }
 }
 

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -7,7 +7,7 @@ use generated::parser::{Abi, ChainMetadata, EthereumMetadata, chain_metadata::Me
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use visualsign::vsptrait::{VisualSignConverterFromString, VisualSignOptions};
+use visualsign::vsptrait::{VisualSignConverterFromString, VisualSignError, VisualSignOptions};
 use visualsign_ethereum::EthereumVisualSignConverter;
 use visualsign_ethereum::transaction_string_to_visual_sign;
 
@@ -261,4 +261,49 @@ fn test_abi_from_metadata_decodes_function() {
         !json.contains("a9059cbb"),
         "Raw selector should not appear when ABI is decoded, got: {json}"
     );
+}
+
+#[test]
+fn test_non_ascii_payload_is_rejected_by_converter() {
+    // Regression for PRS-224: the Ethereum override of
+    // `to_visual_sign_payload_from_string` previously called the
+    // non-validated converter, so any non-ASCII text that reached the
+    // rendered payload was emitted into the signed JSON. Every other chain
+    // converter uses the default impl that runs charset validation; the
+    // Ethereum override must enforce the same invariant.
+    //
+    // The ticket's stated PoC uses wallet-supplied ABI `function.name` /
+    // parameter `input.name`. Today upstream `alloy_json_abi` validates
+    // those as Solidity identifiers and rejects U+202E before our code sees
+    // it, so we exercise the invariant via `VisualSignOptions::transaction_name`,
+    // which lands directly in `payload.title` with no upstream filtering.
+    // Either way the converter must reject non-ASCII content, since the
+    // invariant must not depend on which input field carries it.
+    let fixtures_dir = fixture_path("");
+    let input_path = fixtures_dir.join("1559.input");
+    let transaction_hex = fs::read_to_string(&input_path)
+        .expect("Failed to read 1559.input fixture")
+        .trim()
+        .to_string();
+
+    let options = VisualSignOptions {
+        decode_transfers: true,
+        transaction_name: Some("Send \u{202E}evil".to_string()),
+        metadata: None,
+        developer_config: None,
+    };
+
+    let converter = EthereumVisualSignConverter::new();
+    let result = converter.to_visual_sign_payload_from_string(&transaction_hex, options);
+
+    match result {
+        Ok(payload) => panic!(
+            "Expected non-ASCII title to be rejected by charset validation, got payload: {}",
+            payload.to_json().unwrap_or_default()
+        ),
+        Err(VisualSignError::ValidationError(_)) => {
+            // Expected: charset validation rejected the non-ASCII payload.
+        }
+        Err(other) => panic!("Expected VisualSignError::ValidationError, got: {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

The Ethereum override of `to_visual_sign_payload_from_string` was calling the non-validated `to_visual_sign_payload`, bypassing the charset check that every other chain converter inherits from the default trait impl. Any non-ASCII, unicode-escape, or non-printable content reaching a rendered field landed in the signed JSON unchecked. Switching the override to `to_validated_visual_sign_payload` restores parity and the invariant that every payload returned by the Ethereum converter has been charset-validated.

## What changed

- `src/chain_parsers/visualsign-ethereum/src/lib.rs` — `EthereumVisualSignConverter::to_visual_sign_payload_from_string` now delegates to `to_validated_visual_sign_payload` instead of `to_visual_sign_payload`. Inline comment explains why.
- `src/chain_parsers/visualsign-ethereum/tests/lib_test.rs` — adds `test_non_ascii_payload_is_rejected_by_converter`, a regression test that injects `U+202E` via `VisualSignOptions::transaction_name` (which flows to `payload.title` with no upstream filtering) and asserts the converter returns `VisualSignError::ValidationError`.

The PoC fields the ticket cites (`function.name`, parameter `input.name`) are currently scrubbed by `alloy_json_abi`'s Solidity-identifier validation before our code sees them, so the regression test exercises the invariant via `transaction_name`. The invariant must not depend on which input field carries the offending content.

## Rollback

Single-commit, surgical change. Revert this PR if the validated path regresses any legitimate non-ASCII payload that the team decides should be allowed through. No data migration, no config flag, no schema change.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -p visualsign-ethereum --all-targets -- -D warnings` clean
- [x] `cargo test -p visualsign-ethereum` — 199 unit + 5 integration + 3 doctests pass, including the new regression test
- [ ] CI: full workspace build + lint + test
- [ ] Confirm no existing fixture relies on non-ASCII rendered output

Closes PRS-224
Linear: https://linear.app/anchorlabs/issue/PRS-224
