### PR TITLE
fix(ethereum): prefer built-in token decoder over caller-supplied ABI

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -890,9 +890,12 @@ mod tests {
     /// (e.g. USDC) must not override the safe built-in ERC20/ERC721 decoder.
     ///
     /// An attacker who can inject `chain_metadata.abi_mappings` could otherwise
-    /// rename selector `0xa9059cbb` (transfer) to any chosen function name and
-    /// parameter labels, spoofing the wallet UI. The fix in lib.rs prefers the
-    /// built-in visualizer for any address present in the compiled-in
+    /// supply an ABI entry whose function name + input types match selector
+    /// `0xa9059cbb` (transfer) but with attacker-chosen parameter labels, then
+    /// spoof the wallet UI with those labels. (The function name itself is
+    /// fixed by the selector match; only the parameter names are
+    /// attacker-controlled here.) The fix in lib.rs prefers the built-in
+    /// visualizer for any address present in the compiled-in
     /// ContractRegistry's token registry.
     #[test]
     fn test_known_token_ignores_caller_supplied_abi_for_transfer() {
@@ -1030,23 +1033,20 @@ mod tests {
         );
 
         // And, defensively, the attacker-chosen parameter names must not
-        // appear anywhere in the rendered payload.
-        fn assert_label_not_attacker_controlled(label: &str) {
-            assert_ne!(
-                label, "backup_wallet",
-                "caller ABI param name must not win for known token",
-            );
-            assert_ne!(
-                label, "safety_deposit",
-                "caller ABI param name must not win for known token",
-            );
-        }
-        for f in &payload.fields {
-            assert_label_not_attacker_controlled(f.label().as_str());
-        }
-        for f in &expanded.fields {
-            assert_label_not_attacker_controlled(f.signable_payload_field.label().as_str());
-        }
+        // appear anywhere in the rendered payload (labels, titles, subtitles,
+        // fallback_text, or any other serialized text). Serializing the whole
+        // payload to JSON and scanning the resulting string is the simplest
+        // way to assert this property without enumerating every text-bearing
+        // field on every SignablePayloadField variant.
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !rendered.contains("backup_wallet"),
+            "caller ABI param name must not appear anywhere in the rendered payload: {rendered}",
+        );
+        assert!(
+            !rendered.contains("safety_deposit"),
+            "caller ABI param name must not appear anywhere in the rendered payload: {rendered}",
+        );
     }
 
     /// PRS-222 follow-up: the canonical-token short-circuit must key off the

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -575,10 +575,13 @@ fn convert_to_visual_sign_payload(
         // trusted to decide the override.
         //
         // The registry lookup keys off `transaction.chain_id()` and never the
-        // resolved `chain_id`. `resolve_chain_id` gives metadata priority and
-        // metadata is caller-controlled in this threat model, so feeding it
-        // into a security decision would let an attacker mismatch `network_id`
-        // and dodge the canonical-token lookup. For pre-EIP-155 legacy txs
+        // resolved `chain_id`. Defense in depth: anchor security decisions on
+        // values this function can verify directly, not on the contract of
+        // upstream resolution. `resolve_chain_id` enforces tx/metadata
+        // agreement (mismatch is a `ValidationError`), so the resolved value
+        // is also safe in practice, but keeping the lookup local removes a
+        // cross-function invariant to track and makes this site robust to
+        // future changes in resolution behavior. For pre-EIP-155 legacy txs
         // that don't carry a chain id of their own we fall back to an
         // address-only any-chain lookup rather than the metadata-derived
         // chain id: any canonical-token address on any chain still wins over

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -561,8 +561,53 @@ fn convert_to_visual_sign_payload(
             }
         }
 
-        // Try dynamic ABI visualization if available
+        // Known-token short-circuit (PRS-222): if the destination is a token
+        // registered in the compiled-in ContractRegistry (e.g. USDC, USDT, WETH),
+        // dispatch to the safe built-in ERC20/ERC721 visualizer and bypass any
+        // caller-supplied ABI. This prevents a malicious dApp from supplying an
+        // ABI for a canonical token address that renames `transfer` (selector
+        // 0xa9059cbb) to `approve` (or any other label) and spoofs the UI.
+        //
+        // We deliberately consult only the global (compiled-in) layer here:
+        // a request-scoped registry is itself caller-supplied and cannot be
+        // trusted to decide the override.
+        let mut is_known_token = false;
         if input_fields.is_empty() {
+            if let Some(to_address) = transaction.to() {
+                if let Some(erc_standard) = layered_registry
+                    .global()
+                    .get_token_erc_standard(chain_id, to_address)
+                {
+                    is_known_token = true;
+                    match erc_standard {
+                        token_metadata::ErcStandard::Erc20 => {
+                            if let Some(field) =
+                                (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
+                            {
+                                input_fields.push(field);
+                            }
+                        }
+                        token_metadata::ErcStandard::Erc721 => {
+                            if let Some(field) =
+                                (contracts::core::ERC721Visualizer {}).visualize_tx_commands(input)
+                            {
+                                input_fields.push(field);
+                            }
+                        }
+                        token_metadata::ErcStandard::Erc1155 => {
+                            // No built-in ERC1155 visualizer yet. Fall through to
+                            // the raw-hex fallback rather than the user ABI so
+                            // the attack surface stays closed.
+                        }
+                    }
+                }
+            }
+        }
+
+        // Try dynamic ABI visualization if available. Skipped for known tokens
+        // (see PRS-222 short-circuit above) so caller-supplied ABIs cannot
+        // override the safe built-in decoders for canonical tokens.
+        if input_fields.is_empty() && !is_known_token {
             if let (Some(to_address), Some(abi_reg)) = (transaction.to(), abi_registry) {
                 let chain_id_val = chain_id;
                 if let Some(abi) = abi_reg.get_abi_for_address(chain_id_val, to_address) {
@@ -622,8 +667,13 @@ pub fn transaction_string_to_visual_sign(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contracts::core::erc20::IERC20;
+    use crate::registry::ContractRegistry;
+    use crate::token_metadata::{ErcStandard, TokenMetadata};
     use alloy_consensus::{SignableTransaction, TxLegacy, TypedTransaction};
     use alloy_primitives::{Address, Bytes, ChainId, U256};
+    use alloy_sol_types::SolCall;
+    use generated::parser::{Abi, ChainMetadata, EthereumMetadata, chain_metadata};
     use visualsign::{SignablePayloadFieldAddressV2, SignablePayloadFieldAmountV2};
 
     fn unsigned_to_hex(tx: &TypedTransaction) -> String {
@@ -815,6 +865,168 @@ mod tests {
             .unwrap();
         if let SignablePayloadField::TextV2 { text_v2, .. } = input_field {
             assert_eq!(text_v2.text, "0x12345678");
+        }
+    }
+
+    /// PRS-222 regression: caller-supplied ABIs keyed to a known token address
+    /// (e.g. USDC) must not override the safe built-in ERC20/ERC721 decoder.
+    ///
+    /// An attacker who can inject `chain_metadata.abi_mappings` could otherwise
+    /// rename selector `0xa9059cbb` (transfer) to any chosen function name and
+    /// parameter labels, spoofing the wallet UI. The fix in lib.rs prefers the
+    /// built-in visualizer for any address present in the compiled-in
+    /// ContractRegistry's token registry.
+    #[test]
+    fn test_known_token_ignores_caller_supplied_abi_for_transfer() {
+        let usdc_address: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            .parse()
+            .unwrap();
+        let victim: Address = "0x000000000000000000000000000000000000beef"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000_000u64);
+
+        // Build a registry with USDC registered as a known ERC20.
+        let mut registry = ContractRegistry::new();
+        registry
+            .register_token(
+                1,
+                TokenMetadata {
+                    symbol: "USDC".to_string(),
+                    name: "USD Coin".to_string(),
+                    erc_standard: ErcStandard::Erc20,
+                    contract_address: format!("{usdc_address:?}"),
+                    decimals: 6,
+                },
+            )
+            .unwrap();
+        let converter = EthereumVisualSignConverter::with_registry(Arc::new(registry));
+
+        // Real `transfer(victim, 1_000_000_000)` calldata to USDC.
+        let call = IERC20::transferCall { to: victim, amount };
+        let calldata = Bytes::from(IERC20::transferCall::abi_encode(&call));
+
+        let tx = TypedTransaction::Legacy(TxLegacy {
+            chain_id: Some(ChainId::from(1u64)),
+            nonce: 0,
+            gas_price: 1_000_000_000u128,
+            gas_limit: 50_000,
+            to: alloy_primitives::TxKind::Call(usdc_address),
+            value: U256::ZERO,
+            input: calldata,
+        });
+
+        // Caller-supplied ABI: same selector as `transfer(address,uint256)`
+        // (which is required for the AbiRegistry dispatcher to match it), but
+        // with attacker-chosen parameter names that misrepresent what the user
+        // is signing. Without the fix, the UI would render labels controlled
+        // by the dApp ("backup_wallet", "safety_deposit") instead of the
+        // canonical "Recipient"/"Amount" from the built-in ERC20 visualizer.
+        //
+        // Note: alloy's `Function::selector()` is derived from name + input
+        // types, so the function name MUST stay `transfer`. Parameter NAMES,
+        // however, do not affect the selector and are fully attacker-controlled.
+        // This is sufficient to spoof the signing prompt.
+        let malicious_abi = r#"[
+            {
+                "type": "function",
+                "name": "transfer",
+                "inputs": [
+                    {"name": "backup_wallet", "type": "address"},
+                    {"name": "safety_deposit", "type": "uint256"}
+                ],
+                "outputs": [],
+                "stateMutability": "nonpayable"
+            }
+        ]"#;
+        // Build the fixture as a BTreeMap (crate determinism rule) and let
+        // it `.collect()` into the proto field's HashMap at the call site.
+        let abi_mappings: std::collections::BTreeMap<String, Abi> = std::iter::once((
+            format!("{usdc_address:?}"),
+            Abi {
+                value: malicious_abi.to_string(),
+                signature: None,
+            },
+        ))
+        .collect();
+
+        let options = VisualSignOptions {
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                    network_id: Some("ETHEREUM_MAINNET".to_string()),
+                    abi_mappings: abi_mappings.into_iter().collect(),
+                })),
+            }),
+            developer_config: None,
+        };
+
+        let wrapper = EthereumTransactionWrapper::new(tx);
+        let payload = converter.to_visual_sign_payload(wrapper, options).unwrap();
+
+        // The built-in ERC20 visualizer emits a PreviewLayout titled
+        // "ERC20 Transfer" with a "Recipient" address field and an "Amount"
+        // field. The malicious ABI would have produced an "approve" label
+        // with "spender"/"amount" labels.
+        let preview = payload
+            .fields
+            .iter()
+            .find(|f| matches!(f, SignablePayloadField::PreviewLayout { .. }))
+            .expect("expected a PreviewLayout field from the built-in ERC20 visualizer");
+
+        let SignablePayloadField::PreviewLayout {
+            common,
+            preview_layout,
+        } = preview
+        else {
+            panic!("matched discriminant changed");
+        };
+        assert_eq!(common.label, "ERC20 Transfer");
+        assert_eq!(
+            preview_layout
+                .title
+                .as_ref()
+                .map(|t| t.text.as_str())
+                .unwrap_or(""),
+            "ERC20 Transfer",
+        );
+
+        let expanded = preview_layout
+            .expanded
+            .as_ref()
+            .expect("expected expanded ListLayout for transfer details");
+        let labels: Vec<&str> = expanded
+            .fields
+            .iter()
+            .map(|f| f.signable_payload_field.label().as_str())
+            .collect();
+        assert!(
+            labels.contains(&"Recipient"),
+            "expected built-in 'Recipient' label, got {labels:?}",
+        );
+        assert!(
+            labels.contains(&"Amount"),
+            "expected built-in 'Amount' label, got {labels:?}",
+        );
+
+        // And, defensively, the attacker-chosen parameter names must not
+        // appear anywhere in the rendered payload.
+        fn assert_label_not_attacker_controlled(label: &str) {
+            assert_ne!(
+                label, "backup_wallet",
+                "caller ABI param name must not win for known token",
+            );
+            assert_ne!(
+                label, "safety_deposit",
+                "caller ABI param name must not win for known token",
+            );
+        }
+        for f in &payload.fields {
+            assert_label_not_attacker_controlled(f.label().as_str());
+        }
+        for f in &expanded.fields {
+            assert_label_not_attacker_controlled(f.signable_payload_field.label().as_str());
         }
     }
 

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -432,6 +432,68 @@ fn extract_metadata_abi(
     abi_metadata::try_extract_from_chain_metadata(options.metadata.as_ref(), chain_id)
 }
 
+/// Known-token short-circuit: if the destination is a token registered in the
+/// compiled-in `ContractRegistry` (e.g. USDC, USDT, WETH), route to the safe
+/// built-in ERC20/ERC721 visualizer and lock out any caller-supplied ABI.
+/// This prevents a malicious dApp from supplying an ABI for a canonical token
+/// address with attacker-chosen parameter labels and spoofing the signing UI
+/// (the selector still has to match `transfer(address,uint256)` for the
+/// dispatcher to bind it, but parameter names are unconstrained).
+///
+/// We deliberately consult only the global (compiled-in) layer here: a
+/// request-scoped registry is itself caller-supplied and cannot be trusted to
+/// decide the override.
+///
+/// The lookup keys off `transaction.chain_id()` and never the resolved
+/// `chain_id`. `resolve_chain_id` gives metadata priority and metadata is
+/// caller-controlled in this threat model, so feeding it into a security
+/// decision would let an attacker mismatch `network_id` and dodge the
+/// canonical-token lookup. For pre-EIP-155 legacy txs that don't carry a chain
+/// id of their own we fall back to an address-only any-chain lookup rather
+/// than the metadata-derived chain id: any canonical-token address on any
+/// chain still wins over a caller-supplied ABI.
+///
+/// Returns `Some(vec![field])` (always non-empty) if the destination is a
+/// registered canonical token. The field is either the decoded result or a
+/// raw-hex fallback when the built-in visualizer can't decode the selector
+/// (ERC721 stub returns `None` for all inputs today; ERC1155 has no built-in
+/// visualizer yet). Returning `Some` even with a raw-hex field is what gives
+/// callers a clean "if `Some`, you're done" contract: the downstream
+/// caller-ABI path and ERC20 `decode_transfers` fallback are both gated on
+/// `input_fields.is_empty()`, so populating any field locks them out. This
+/// matters because `approve(address,uint256)` and `transfer(address,uint256)`
+/// share selectors across ERC standards; without the lock-out a known ERC721
+/// or ERC1155 call would be mis-rendered as an ERC20 op.
+///
+/// Returns `None` only when the destination is not a registered canonical
+/// token.
+fn try_known_token_dispatch(
+    layered_registry: &LayeredRegistry<registry::ContractRegistry>,
+    chain_id: Option<registry::ChainId>,
+    to_address: alloy_primitives::Address,
+    input: &[u8],
+) -> Option<Vec<SignablePayloadField>> {
+    let erc_standard = layered_registry
+        .global()
+        .get_token_erc_standard(chain_id, to_address)?;
+    let decoded = match erc_standard {
+        token_metadata::ErcStandard::Erc20 => {
+            (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
+        }
+        // `ERC721Visualizer::visualize_tx_commands` currently returns `None`
+        // for all inputs (no built-in ERC721 decoder yet). A follow-up can add
+        // minimal transferFrom/safeTransferFrom decoding for UX.
+        token_metadata::ErcStandard::Erc721 => {
+            (contracts::core::ERC721Visualizer {}).visualize_tx_commands(input)
+        }
+        // No built-in ERC1155 visualizer yet.
+        token_metadata::ErcStandard::Erc1155 => None,
+    };
+    let field =
+        decoded.unwrap_or_else(|| contracts::core::FallbackVisualizer::new().visualize_hex(input));
+    Some(vec![field])
+}
+
 fn convert_to_visual_sign_payload(
     transaction: TypedTransaction,
     options: VisualSignOptions,
@@ -561,84 +623,31 @@ fn convert_to_visual_sign_payload(
             }
         }
 
-        // Known-token short-circuit: if the destination is a token
-        // registered in the compiled-in ContractRegistry (e.g. USDC, USDT, WETH),
-        // dispatch to the safe built-in ERC20/ERC721 visualizer and bypass any
-        // caller-supplied ABI. This prevents a malicious dApp from supplying an
-        // ABI for a canonical token address with attacker-chosen parameter
-        // labels and spoofing the signing UI (the selector still has to match
-        // `transfer(address,uint256)` for the dispatcher to bind it, but
-        // parameter names are unconstrained).
-        //
-        // We deliberately consult only the global (compiled-in) layer here:
-        // a request-scoped registry is itself caller-supplied and cannot be
-        // trusted to decide the override.
-        //
-        // The registry lookup keys off `transaction.chain_id()` and never the
-        // resolved `chain_id`. `resolve_chain_id` gives metadata priority and
-        // metadata is caller-controlled in this threat model, so feeding it
-        // into a security decision would let an attacker mismatch `network_id`
-        // and dodge the canonical-token lookup. For pre-EIP-155 legacy txs
-        // that don't carry a chain id of their own we fall back to an
-        // address-only any-chain lookup rather than the metadata-derived
-        // chain id: any canonical-token address on any chain still wins over
-        // a caller-supplied ABI.
-        let mut is_known_token = false;
+        // Known-token short-circuit: see `try_known_token_dispatch` for the
+        // full rationale (global-only consultation, `transaction.chain_id()`
+        // vs `resolve_chain_id`, pre-EIP-155 any-chain fallback, selector
+        // collisions across ERC standards). The helper guarantees a non-empty
+        // `Some` when it fires, so the `extend` flips `input_fields.is_empty()`
+        // to false and the caller-ABI path and ERC20 `decode_transfers`
+        // fallback below both skip on their existing `is_empty` gates.
         if input_fields.is_empty() {
             if let Some(to_address) = transaction.to() {
-                let erc_standard = match transaction.chain_id() {
-                    Some(tx_chain_id) => layered_registry
-                        .global()
-                        .get_token_erc_standard(tx_chain_id, to_address),
-                    None => layered_registry
-                        .global()
-                        .get_token_erc_standard_any_chain(to_address),
-                };
-                if let Some(erc_standard) = erc_standard {
-                    is_known_token = true;
-                    match erc_standard {
-                        token_metadata::ErcStandard::Erc20 => {
-                            if let Some(field) =
-                                (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
-                            {
-                                input_fields.push(field);
-                            }
-                        }
-                        token_metadata::ErcStandard::Erc721 => {
-                            // `ERC721Visualizer::visualize_tx_commands` currently
-                            // returns `None` for all inputs (no built-in ERC721
-                            // decoding yet). That's fine: the call below is a
-                            // no-op, and because
-                            // `is_known_token` is set we also skip both the
-                            // caller-ABI path and the ERC20 `decode_transfers`
-                            // fallback below, so the call lands on raw-hex.
-                            // This matters because `approve(address,uint256)`
-                            // shares a selector across ERC20/ERC721, so without
-                            // the ERC20-fallback guard we'd mis-render an ERC721
-                            // approval as an ERC20 approval.
-                            // A follow-up can add minimal
-                            // transferFrom/safeTransferFrom decoding for UX.
-                            if let Some(field) =
-                                (contracts::core::ERC721Visualizer {}).visualize_tx_commands(input)
-                            {
-                                input_fields.push(field);
-                            }
-                        }
-                        token_metadata::ErcStandard::Erc1155 => {
-                            // No built-in ERC1155 visualizer yet. `is_known_token`
-                            // is set so we skip both the caller-ABI path and the
-                            // ERC20 `decode_transfers` fallback, landing on
-                            // raw-hex. Same threat model as the ERC721 branch.
-                        }
-                    }
+                if let Some(known_fields) = try_known_token_dispatch(
+                    layered_registry,
+                    transaction.chain_id(),
+                    to_address,
+                    input,
+                ) {
+                    input_fields.extend(known_fields);
                 }
             }
         }
 
         // Try dynamic ABI visualization if available. Skipped for known tokens
-        // (see known-token short-circuit above) so caller-supplied ABIs cannot
-        // override the safe built-in decoders for canonical tokens.
-        if input_fields.is_empty() && !is_known_token {
+        // (the short-circuit above already populated `input_fields`) so
+        // caller-supplied ABIs cannot override the safe built-in decoders for
+        // canonical tokens.
+        if input_fields.is_empty() {
             if let (Some(to_address), Some(abi_reg)) = (transaction.to(), abi_registry) {
                 let chain_id_val = chain_id;
                 if let Some(abi) = abi_reg.get_abi_for_address(chain_id_val, to_address) {
@@ -652,13 +661,14 @@ fn convert_to_visual_sign_payload(
         }
 
         // Fallback: Try ERC20 if decode_transfers is enabled. Skipped for
-        // known tokens of any standard: `approve(address,uint256)` and
-        // `transfer(address,uint256)` share selectors across ERC20/ERC721,
-        // so without this guard a known ERC721 (or ERC1155) call would be
+        // known tokens because the short-circuit above already populated
+        // `input_fields`: `approve(address,uint256)` and
+        // `transfer(address,uint256)` share selectors across ERC20/ERC721, so
+        // without this guard a known ERC721 (or ERC1155) call would be
         // mis-rendered as an ERC20 op once its own visualizer returns `None`,
         // undermining the "canonical-token short-circuit wins over any other
         // decoder" property.
-        if input_fields.is_empty() && options.decode_transfers && !is_known_token {
+        if input_fields.is_empty() && options.decode_transfers {
             if let Some(field) = (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
             {
                 input_fields.push(field);
@@ -1276,14 +1286,15 @@ mod tests {
     /// `approve(address,uint256)` selector must not be mis-rendered as an ERC20
     /// approval. The dispatch order is:
     ///
-    ///   1. ERC721 short-circuit fires (no built-in ERC721 decoder yet, returns None).
-    ///   2. Caller-ABI path skipped (`is_known_token`).
-    ///   3. ERC20 `decode_transfers` fallback must also be skipped
-    ///      (`is_known_token`), or it would decode `approve` as an ERC20 op.
-    ///   4. Raw-hex fallback wins.
+    ///   1. `try_known_token_dispatch` fires (ERC721 visualizer returns None,
+    ///      helper substitutes a raw-hex field so its `Some` is non-empty).
+    ///   2. Caller-ABI path skipped (`input_fields.is_empty()` is now false).
+    ///   3. ERC20 `decode_transfers` fallback also skipped for the same reason,
+    ///      or it would decode `approve` as an ERC20 op.
+    ///   4. Raw-hex (from the helper) is the rendered result.
     ///
-    /// Without the `is_known_token` guard on the ERC20 fallback this regresses
-    /// to "ERC20 Approve" output, which is the spoofing surface this fix closes.
+    /// Without the helper's non-empty `Some` contract this regresses to "ERC20
+    /// Approve" output, which is the spoofing surface this fix closes.
     #[test]
     fn test_known_erc721_token_skips_erc20_fallback_on_shared_selector() {
         // Address-only fixture, the actual contract standard is decided by the

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -574,20 +574,27 @@ fn convert_to_visual_sign_payload(
         // a request-scoped registry is itself caller-supplied and cannot be
         // trusted to decide the override.
         //
-        // For the registry lookup we prefer `transaction.chain_id()` over the
-        // resolved `chain_id`: `resolve_chain_id` gives metadata priority and
-        // metadata is caller-controlled in this threat model, so an attacker
-        // could mismatch `network_id` against a real mainnet tx and dodge the
-        // canonical-token lookup. Falling back to the resolved `chain_id`
-        // covers legacy transactions that don't carry an EIP-155 chain id.
-        let lookup_chain_id = transaction.chain_id().unwrap_or(chain_id);
+        // The registry lookup keys off `transaction.chain_id()` and never the
+        // resolved `chain_id`. `resolve_chain_id` gives metadata priority and
+        // metadata is caller-controlled in this threat model, so feeding it
+        // into a security decision would let an attacker mismatch `network_id`
+        // and dodge the canonical-token lookup. For pre-EIP-155 legacy txs
+        // that don't carry a chain id of their own we fall back to an
+        // address-only any-chain lookup rather than the metadata-derived
+        // chain id: any canonical-token address on any chain still wins over
+        // a caller-supplied ABI.
         let mut is_known_token = false;
         if input_fields.is_empty() {
             if let Some(to_address) = transaction.to() {
-                if let Some(erc_standard) = layered_registry
-                    .global()
-                    .get_token_erc_standard(lookup_chain_id, to_address)
-                {
+                let erc_standard = match transaction.chain_id() {
+                    Some(tx_chain_id) => layered_registry
+                        .global()
+                        .get_token_erc_standard(tx_chain_id, to_address),
+                    None => layered_registry
+                        .global()
+                        .get_token_erc_standard_any_chain(to_address),
+                };
+                if let Some(erc_standard) = erc_standard {
                     is_known_token = true;
                     match erc_standard {
                         token_metadata::ErcStandard::Erc20 => {
@@ -1142,6 +1149,111 @@ mod tests {
         assert_eq!(
             common.label, "ERC20 Transfer",
             "tx chain_id must win over caller metadata for the canonical-token lookup",
+        );
+    }
+
+    /// PRS-222 round-3: pre-EIP-155 legacy transactions don't carry a chain id
+    /// of their own, so the canonical-token short-circuit must not fall back to
+    /// the resolved (metadata-derived) chain id. Otherwise an attacker can
+    /// supply a legacy tx to USDC's mainnet address with `network_id` pointing
+    /// at a chain where USDC isn't registered, the global lookup misses, and a
+    /// caller-supplied ABI gets to bind to a canonical token. We expect the
+    /// dispatcher to do an address-only any-chain lookup in that case.
+    #[test]
+    fn test_known_token_short_circuit_handles_chain_id_less_legacy_tx() {
+        let usdc_address: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            .parse()
+            .unwrap();
+        let victim: Address = "0x000000000000000000000000000000000000beef"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000_000u64);
+
+        // USDC registered on mainnet (chain id 1) only.
+        let mut registry = ContractRegistry::new();
+        registry
+            .register_token(
+                1,
+                TokenMetadata {
+                    symbol: "USDC".to_string(),
+                    name: "USD Coin".to_string(),
+                    erc_standard: ErcStandard::Erc20,
+                    contract_address: usdc_address.to_string(),
+                    decimals: 6,
+                },
+            )
+            .unwrap();
+        let converter = EthereumVisualSignConverter::with_registry(Arc::new(registry));
+
+        // Pre-EIP-155 legacy tx: `chain_id == None`. Calldata is a real
+        // `transfer(victim, 1_000_000_000)` against the USDC mainnet address.
+        let call = IERC20::transferCall { to: victim, amount };
+        let calldata = Bytes::from(IERC20::transferCall::abi_encode(&call));
+        let tx = TypedTransaction::Legacy(TxLegacy {
+            chain_id: None,
+            nonce: 0,
+            gas_price: 1_000_000_000u128,
+            gas_limit: 50_000,
+            to: alloy_primitives::TxKind::Call(usdc_address),
+            value: U256::ZERO,
+            input: calldata,
+        });
+
+        let malicious_abi = r#"[
+            {
+                "type": "function",
+                "name": "transfer",
+                "inputs": [
+                    {"name": "backup_wallet", "type": "address"},
+                    {"name": "safety_deposit", "type": "uint256"}
+                ],
+                "outputs": [],
+                "stateMutability": "nonpayable"
+            }
+        ]"#;
+        let abi_mappings: std::collections::BTreeMap<String, Abi> = std::iter::once((
+            usdc_address.to_string(),
+            Abi {
+                value: malicious_abi.to_string(),
+                signature: None,
+            },
+        ))
+        .collect();
+
+        // Attacker points `network_id` at Polygon (no USDC entry in our local
+        // registry) so any chain-id-based lookup that trusts metadata misses.
+        let options = VisualSignOptions {
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                    network_id: Some("POLYGON_MAINNET".to_string()),
+                    abi_mappings: abi_mappings.into_iter().collect(),
+                })),
+            }),
+            developer_config: None,
+        };
+
+        let wrapper = EthereumTransactionWrapper::new(tx);
+        let payload = converter.to_visual_sign_payload(wrapper, options).unwrap();
+
+        let preview = payload
+            .fields
+            .iter()
+            .find(|f| matches!(f, SignablePayloadField::PreviewLayout { .. }))
+            .expect("expected a PreviewLayout from the built-in ERC20 visualizer");
+        let SignablePayloadField::PreviewLayout { common, .. } = preview else {
+            panic!("matched discriminant changed");
+        };
+        assert_eq!(
+            common.label, "ERC20 Transfer",
+            "chain-id-less legacy tx to a canonical token must still hit the built-in decoder",
+        );
+
+        let rendered = format!("{payload:?}");
+        assert!(
+            !rendered.contains("backup_wallet") && !rendered.contains("safety_deposit"),
+            "caller ABI param name must not appear anywhere in the rendered payload: {rendered}",
         );
     }
 

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -561,7 +561,7 @@ fn convert_to_visual_sign_payload(
             }
         }
 
-        // Known-token short-circuit (PRS-222): if the destination is a token
+        // Known-token short-circuit: if the destination is a token
         // registered in the compiled-in ContractRegistry (e.g. USDC, USDT, WETH),
         // dispatch to the safe built-in ERC20/ERC721 visualizer and bypass any
         // caller-supplied ABI. This prevents a malicious dApp from supplying an
@@ -607,8 +607,8 @@ fn convert_to_visual_sign_payload(
                         token_metadata::ErcStandard::Erc721 => {
                             // `ERC721Visualizer::visualize_tx_commands` currently
                             // returns `None` for all inputs (no built-in ERC721
-                            // decoding yet). That's fine for the PRS-222 fix:
-                            // the call below is a no-op, and because
+                            // decoding yet). That's fine: the call below is a
+                            // no-op, and because
                             // `is_known_token` is set we also skip both the
                             // caller-ABI path and the ERC20 `decode_transfers`
                             // fallback below, so the call lands on raw-hex.
@@ -636,7 +636,7 @@ fn convert_to_visual_sign_payload(
         }
 
         // Try dynamic ABI visualization if available. Skipped for known tokens
-        // (see PRS-222 short-circuit above) so caller-supplied ABIs cannot
+        // (see known-token short-circuit above) so caller-supplied ABIs cannot
         // override the safe built-in decoders for canonical tokens.
         if input_fields.is_empty() && !is_known_token {
             if let (Some(to_address), Some(abi_reg)) = (transaction.to(), abi_registry) {
@@ -656,8 +656,8 @@ fn convert_to_visual_sign_payload(
         // `transfer(address,uint256)` share selectors across ERC20/ERC721,
         // so without this guard a known ERC721 (or ERC1155) call would be
         // mis-rendered as an ERC20 op once its own visualizer returns `None`,
-        // contradicting the PRS-222 "canonical-token short-circuit wins over
-        // any other decoder" property.
+        // undermining the "canonical-token short-circuit wins over any other
+        // decoder" property.
         if input_fields.is_empty() && options.decode_transfers && !is_known_token {
             if let Some(field) = (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
             {
@@ -905,7 +905,7 @@ mod tests {
         }
     }
 
-    /// PRS-222 regression: caller-supplied ABIs keyed to a known token address
+    /// Regression: caller-supplied ABIs keyed to a known token address
     /// (e.g. USDC) must not override the safe built-in ERC20/ERC721 decoder.
     ///
     /// An attacker who can inject `chain_metadata.abi_mappings` could otherwise
@@ -1068,11 +1068,11 @@ mod tests {
         );
     }
 
-    /// PRS-222 follow-up: the canonical-token short-circuit must key off the
-    /// transaction's own chain id, not the resolved `chain_id` (which gives
-    /// priority to caller-controlled metadata). Otherwise a malicious dApp
-    /// could supply a mismatched `network_id` so the global registry lookup
-    /// misses USDC and the dynamic-ABI path runs again.
+    /// The canonical-token short-circuit must key off the transaction's own
+    /// chain id, not the resolved `chain_id` (which gives priority to
+    /// caller-controlled metadata). Otherwise a malicious dApp could supply a
+    /// mismatched `network_id` so the global registry lookup misses USDC and
+    /// the dynamic-ABI path runs again.
     #[test]
     fn test_known_token_short_circuit_uses_tx_chain_id_not_metadata() {
         let usdc_address: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -1164,11 +1164,11 @@ mod tests {
         );
     }
 
-    /// PRS-222 round-3: pre-EIP-155 legacy transactions don't carry a chain id
-    /// of their own, so the canonical-token short-circuit must not fall back to
-    /// the resolved (metadata-derived) chain id. Otherwise an attacker can
-    /// supply a legacy tx to USDC's mainnet address with `network_id` pointing
-    /// at a chain where USDC isn't registered, the global lookup misses, and a
+    /// Pre-EIP-155 legacy transactions don't carry a chain id of their own, so
+    /// the canonical-token short-circuit must not fall back to the resolved
+    /// (metadata-derived) chain id. Otherwise an attacker can supply a legacy
+    /// tx to USDC's mainnet address with `network_id` pointing at a chain
+    /// where USDC isn't registered, the global lookup misses, and a
     /// caller-supplied ABI gets to bind to a canonical token. We expect the
     /// dispatcher to do an address-only any-chain lookup in that case.
     #[test]
@@ -1272,9 +1272,9 @@ mod tests {
         );
     }
 
-    /// PRS-222 round-4: a known ERC721 token called with the ERC20/ERC721
-    /// shared `approve(address,uint256)` selector must not be mis-rendered as
-    /// an ERC20 approval. The dispatch order is:
+    /// A known ERC721 token called with the ERC20/ERC721 shared
+    /// `approve(address,uint256)` selector must not be mis-rendered as an ERC20
+    /// approval. The dispatch order is:
     ///
     ///   1. ERC721 short-circuit fires (no built-in ERC721 decoder yet, returns None).
     ///   2. Caller-ABI path skipped (`is_known_token`).
@@ -1283,8 +1283,7 @@ mod tests {
     ///   4. Raw-hex fallback wins.
     ///
     /// Without the `is_known_token` guard on the ERC20 fallback this regresses
-    /// to "ERC20 Approve" output, which is the exact spoofing surface PRS-222
-    /// is closing.
+    /// to "ERC20 Approve" output, which is the spoofing surface this fix closes.
     #[test]
     fn test_known_erc721_token_skips_erc20_fallback_on_shared_selector() {
         // Address-only fixture, the actual contract standard is decided by the

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -565,18 +565,28 @@ fn convert_to_visual_sign_payload(
         // registered in the compiled-in ContractRegistry (e.g. USDC, USDT, WETH),
         // dispatch to the safe built-in ERC20/ERC721 visualizer and bypass any
         // caller-supplied ABI. This prevents a malicious dApp from supplying an
-        // ABI for a canonical token address that renames `transfer` (selector
-        // 0xa9059cbb) to `approve` (or any other label) and spoofs the UI.
+        // ABI for a canonical token address with attacker-chosen parameter
+        // labels and spoofing the signing UI (the selector still has to match
+        // `transfer(address,uint256)` for the dispatcher to bind it, but
+        // parameter names are unconstrained).
         //
         // We deliberately consult only the global (compiled-in) layer here:
         // a request-scoped registry is itself caller-supplied and cannot be
         // trusted to decide the override.
+        //
+        // For the registry lookup we prefer `transaction.chain_id()` over the
+        // resolved `chain_id`: `resolve_chain_id` gives metadata priority and
+        // metadata is caller-controlled in this threat model, so an attacker
+        // could mismatch `network_id` against a real mainnet tx and dodge the
+        // canonical-token lookup. Falling back to the resolved `chain_id`
+        // covers legacy transactions that don't carry an EIP-155 chain id.
+        let lookup_chain_id = transaction.chain_id().unwrap_or(chain_id);
         let mut is_known_token = false;
         if input_fields.is_empty() {
             if let Some(to_address) = transaction.to() {
                 if let Some(erc_standard) = layered_registry
                     .global()
-                    .get_token_erc_standard(chain_id, to_address)
+                    .get_token_erc_standard(lookup_chain_id, to_address)
                 {
                     is_known_token = true;
                     match erc_standard {
@@ -588,6 +598,14 @@ fn convert_to_visual_sign_payload(
                             }
                         }
                         token_metadata::ErcStandard::Erc721 => {
+                            // `ERC721Visualizer::visualize_tx_commands` currently
+                            // returns `None` for all inputs (no built-in ERC721
+                            // decoding yet). That's fine for the PRS-222 fix:
+                            // the call below is a no-op and we fall through to
+                            // the raw-hex fallback rather than the caller ABI,
+                            // so the attack surface stays closed even with no
+                            // ERC721 decoder. A follow-up can add minimal
+                            // transferFrom/safeTransferFrom decoding for UX.
                             if let Some(field) =
                                 (contracts::core::ERC721Visualizer {}).visualize_tx_commands(input)
                             {
@@ -895,7 +913,7 @@ mod tests {
                     symbol: "USDC".to_string(),
                     name: "USD Coin".to_string(),
                     erc_standard: ErcStandard::Erc20,
-                    contract_address: format!("{usdc_address:?}"),
+                    contract_address: usdc_address.to_string(),
                     decimals: 6,
                 },
             )
@@ -942,7 +960,7 @@ mod tests {
         // Build the fixture as a BTreeMap (crate determinism rule) and let
         // it `.collect()` into the proto field's HashMap at the call site.
         let abi_mappings: std::collections::BTreeMap<String, Abi> = std::iter::once((
-            format!("{usdc_address:?}"),
+            usdc_address.to_string(),
             Abi {
                 value: malicious_abi.to_string(),
                 signature: None,
@@ -967,8 +985,9 @@ mod tests {
 
         // The built-in ERC20 visualizer emits a PreviewLayout titled
         // "ERC20 Transfer" with a "Recipient" address field and an "Amount"
-        // field. The malicious ABI would have produced an "approve" label
-        // with "spender"/"amount" labels.
+        // field. Without the fix, the malicious ABI would have produced
+        // attacker-chosen labels ("backup_wallet"/"safety_deposit") on the
+        // same selector, spoofing the signing prompt.
         let preview = payload
             .fields
             .iter()
@@ -1028,6 +1047,102 @@ mod tests {
         for f in &expanded.fields {
             assert_label_not_attacker_controlled(f.signable_payload_field.label().as_str());
         }
+    }
+
+    /// PRS-222 follow-up: the canonical-token short-circuit must key off the
+    /// transaction's own chain id, not the resolved `chain_id` (which gives
+    /// priority to caller-controlled metadata). Otherwise a malicious dApp
+    /// could supply a mismatched `network_id` so the global registry lookup
+    /// misses USDC and the dynamic-ABI path runs again.
+    #[test]
+    fn test_known_token_short_circuit_uses_tx_chain_id_not_metadata() {
+        let usdc_address: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            .parse()
+            .unwrap();
+        let victim: Address = "0x000000000000000000000000000000000000beef"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000_000u64);
+
+        // USDC registered on mainnet (chain id 1) only.
+        let mut registry = ContractRegistry::new();
+        registry
+            .register_token(
+                1,
+                TokenMetadata {
+                    symbol: "USDC".to_string(),
+                    name: "USD Coin".to_string(),
+                    erc_standard: ErcStandard::Erc20,
+                    contract_address: usdc_address.to_string(),
+                    decimals: 6,
+                },
+            )
+            .unwrap();
+        let converter = EthereumVisualSignConverter::with_registry(Arc::new(registry));
+
+        // Real `transfer(victim, 1_000_000_000)` against mainnet USDC.
+        let call = IERC20::transferCall { to: victim, amount };
+        let calldata = Bytes::from(IERC20::transferCall::abi_encode(&call));
+        let tx = TypedTransaction::Legacy(TxLegacy {
+            chain_id: Some(ChainId::from(1u64)),
+            nonce: 0,
+            gas_price: 1_000_000_000u128,
+            gas_limit: 50_000,
+            to: alloy_primitives::TxKind::Call(usdc_address),
+            value: U256::ZERO,
+            input: calldata,
+        });
+
+        let malicious_abi = r#"[
+            {
+                "type": "function",
+                "name": "transfer",
+                "inputs": [
+                    {"name": "backup_wallet", "type": "address"},
+                    {"name": "safety_deposit", "type": "uint256"}
+                ],
+                "outputs": [],
+                "stateMutability": "nonpayable"
+            }
+        ]"#;
+        let abi_mappings: std::collections::BTreeMap<String, Abi> = std::iter::once((
+            usdc_address.to_string(),
+            Abi {
+                value: malicious_abi.to_string(),
+                signature: None,
+            },
+        ))
+        .collect();
+
+        // Attacker mismatches metadata to Polygon (137) so a chain_id lookup
+        // that trusts metadata would miss the mainnet USDC entry.
+        let options = VisualSignOptions {
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                    network_id: Some("POLYGON_MAINNET".to_string()),
+                    abi_mappings: abi_mappings.into_iter().collect(),
+                })),
+            }),
+            developer_config: None,
+        };
+
+        let wrapper = EthereumTransactionWrapper::new(tx);
+        let payload = converter.to_visual_sign_payload(wrapper, options).unwrap();
+
+        let preview = payload
+            .fields
+            .iter()
+            .find(|f| matches!(f, SignablePayloadField::PreviewLayout { .. }))
+            .expect("expected a PreviewLayout from the built-in ERC20 visualizer");
+        let SignablePayloadField::PreviewLayout { common, .. } = preview else {
+            panic!("matched discriminant changed");
+        };
+        assert_eq!(
+            common.label, "ERC20 Transfer",
+            "tx chain_id must win over caller metadata for the canonical-token lookup",
+        );
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -575,13 +575,10 @@ fn convert_to_visual_sign_payload(
         // trusted to decide the override.
         //
         // The registry lookup keys off `transaction.chain_id()` and never the
-        // resolved `chain_id`. Defense in depth: anchor security decisions on
-        // values this function can verify directly, not on the contract of
-        // upstream resolution. `resolve_chain_id` enforces tx/metadata
-        // agreement (mismatch is a `ValidationError`), so the resolved value
-        // is also safe in practice, but keeping the lookup local removes a
-        // cross-function invariant to track and makes this site robust to
-        // future changes in resolution behavior. For pre-EIP-155 legacy txs
+        // resolved `chain_id`. `resolve_chain_id` gives metadata priority and
+        // metadata is caller-controlled in this threat model, so feeding it
+        // into a security decision would let an attacker mismatch `network_id`
+        // and dodge the canonical-token lookup. For pre-EIP-155 legacy txs
         // that don't carry a chain id of their own we fall back to an
         // address-only any-chain lookup rather than the metadata-derived
         // chain id: any canonical-token address on any chain still wins over

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -608,10 +608,15 @@ fn convert_to_visual_sign_payload(
                             // `ERC721Visualizer::visualize_tx_commands` currently
                             // returns `None` for all inputs (no built-in ERC721
                             // decoding yet). That's fine for the PRS-222 fix:
-                            // the call below is a no-op and we fall through to
-                            // the raw-hex fallback rather than the caller ABI,
-                            // so the attack surface stays closed even with no
-                            // ERC721 decoder. A follow-up can add minimal
+                            // the call below is a no-op, and because
+                            // `is_known_token` is set we also skip both the
+                            // caller-ABI path and the ERC20 `decode_transfers`
+                            // fallback below, so the call lands on raw-hex.
+                            // This matters because `approve(address,uint256)`
+                            // shares a selector across ERC20/ERC721, so without
+                            // the ERC20-fallback guard we'd mis-render an ERC721
+                            // approval as an ERC20 approval.
+                            // A follow-up can add minimal
                             // transferFrom/safeTransferFrom decoding for UX.
                             if let Some(field) =
                                 (contracts::core::ERC721Visualizer {}).visualize_tx_commands(input)
@@ -620,9 +625,10 @@ fn convert_to_visual_sign_payload(
                             }
                         }
                         token_metadata::ErcStandard::Erc1155 => {
-                            // No built-in ERC1155 visualizer yet. Fall through to
-                            // the raw-hex fallback rather than the user ABI so
-                            // the attack surface stays closed.
+                            // No built-in ERC1155 visualizer yet. `is_known_token`
+                            // is set so we skip both the caller-ABI path and the
+                            // ERC20 `decode_transfers` fallback, landing on
+                            // raw-hex. Same threat model as the ERC721 branch.
                         }
                     }
                 }
@@ -645,8 +651,14 @@ fn convert_to_visual_sign_payload(
             }
         }
 
-        // Fallback: Try ERC20 if decode_transfers is enabled
-        if input_fields.is_empty() && options.decode_transfers {
+        // Fallback: Try ERC20 if decode_transfers is enabled. Skipped for
+        // known tokens of any standard: `approve(address,uint256)` and
+        // `transfer(address,uint256)` share selectors across ERC20/ERC721,
+        // so without this guard a known ERC721 (or ERC1155) call would be
+        // mis-rendered as an ERC20 op once its own visualizer returns `None`,
+        // contradicting the PRS-222 "canonical-token short-circuit wins over
+        // any other decoder" property.
+        if input_fields.is_empty() && options.decode_transfers && !is_known_token {
             if let Some(field) = (contracts::core::ERC20Visualizer {}).visualize_tx_commands(input)
             {
                 input_fields.push(field);
@@ -1250,10 +1262,105 @@ mod tests {
             "chain-id-less legacy tx to a canonical token must still hit the built-in decoder",
         );
 
-        let rendered = format!("{payload:?}");
+        // Mirror the substring scan used earlier in this file: serialize the
+        // whole payload to JSON so we cover every text-bearing field, not just
+        // those `Debug` happens to print.
+        let rendered = serde_json::to_string(&payload).unwrap();
         assert!(
             !rendered.contains("backup_wallet") && !rendered.contains("safety_deposit"),
             "caller ABI param name must not appear anywhere in the rendered payload: {rendered}",
+        );
+    }
+
+    /// PRS-222 round-4: a known ERC721 token called with the ERC20/ERC721
+    /// shared `approve(address,uint256)` selector must not be mis-rendered as
+    /// an ERC20 approval. The dispatch order is:
+    ///
+    ///   1. ERC721 short-circuit fires (no built-in ERC721 decoder yet, returns None).
+    ///   2. Caller-ABI path skipped (`is_known_token`).
+    ///   3. ERC20 `decode_transfers` fallback must also be skipped
+    ///      (`is_known_token`), or it would decode `approve` as an ERC20 op.
+    ///   4. Raw-hex fallback wins.
+    ///
+    /// Without the `is_known_token` guard on the ERC20 fallback this regresses
+    /// to "ERC20 Approve" output, which is the exact spoofing surface PRS-222
+    /// is closing.
+    #[test]
+    fn test_known_erc721_token_skips_erc20_fallback_on_shared_selector() {
+        // Address-only fixture, the actual contract standard is decided by the
+        // registry entry below.
+        let nft_address: Address = "0xb0b0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let spender: Address = "0x000000000000000000000000000000000000beef"
+            .parse()
+            .unwrap();
+        let token_id = U256::from(42u64);
+
+        // Register the address as an ERC721 token on mainnet.
+        let mut registry = ContractRegistry::new();
+        registry
+            .register_token(
+                1,
+                TokenMetadata {
+                    symbol: "NFT".to_string(),
+                    name: "Test NFT".to_string(),
+                    erc_standard: ErcStandard::Erc721,
+                    contract_address: nft_address.to_string(),
+                    decimals: 0,
+                },
+            )
+            .unwrap();
+        let converter = EthereumVisualSignConverter::with_registry(Arc::new(registry));
+
+        // ERC721 `approve(spender, tokenId)` shares its 4-byte selector with
+        // ERC20 `approve(address,uint256)`.
+        let call = IERC20::approveCall {
+            spender,
+            amount: token_id,
+        };
+        let calldata = Bytes::from(IERC20::approveCall::abi_encode(&call));
+        let tx = TypedTransaction::Legacy(TxLegacy {
+            chain_id: Some(ChainId::from(1u64)),
+            nonce: 0,
+            gas_price: 1_000_000_000u128,
+            gas_limit: 50_000,
+            to: alloy_primitives::TxKind::Call(nft_address),
+            value: U256::ZERO,
+            input: calldata,
+        });
+
+        let options = VisualSignOptions {
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: None,
+            developer_config: None,
+        };
+
+        let wrapper = EthereumTransactionWrapper::new(tx);
+        let payload = converter.to_visual_sign_payload(wrapper, options).unwrap();
+
+        // No PreviewLayout should be emitted: ERC721 has no decoder, the
+        // ERC20 fallback is skipped for known non-ERC20 tokens, and the
+        // raw-hex fallback produces a RawData field, not a PreviewLayout.
+        let preview = payload
+            .fields
+            .iter()
+            .find(|f| matches!(f, SignablePayloadField::PreviewLayout { .. }));
+        assert!(
+            preview.is_none(),
+            "known ERC721 + ERC20-shared selector must not produce a PreviewLayout: {payload:?}",
+        );
+
+        // And, defensively, no ERC20-decoder text should appear anywhere in
+        // the serialized payload. Use serde_json so we scan every text-bearing
+        // field, not just what `Debug` prints. The ERC20 approve visualizer
+        // emits the label "ERC20 Approve" and a "Spender" field, both of
+        // which are the regression signals.
+        let rendered = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !rendered.contains("ERC20 Approve") && !rendered.contains("Spender"),
+            "known ERC721 must not be mis-rendered as an ERC20 approval: {rendered}",
         );
     }
 

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -243,7 +243,7 @@ impl ContractRegistry {
 
     /// Address-only lookup across all chains for the canonical-token short-circuit.
     ///
-    /// Used by the dispatcher (PRS-222) for pre-EIP-155 legacy transactions that
+    /// Used by the dispatcher for pre-EIP-155 legacy transactions that
     /// don't carry a chain_id of their own. In that case we deliberately ignore
     /// the resolved chain_id (which is metadata-derived and caller-controlled)
     /// and instead match on address alone: if the destination is a canonical

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -219,49 +219,39 @@ impl ContractRegistry {
             .map(|m| m.symbol.clone())
     }
 
-    /// Gets the ERC standard for a registered token on a chain
+    /// Gets the ERC standard for a registered token.
     ///
     /// Used by the dispatcher to recognize known tokens and route them to the
     /// safe built-in ERC20/ERC721 visualizer, preventing caller-supplied ABIs
     /// from overriding decoding for canonical tokens (e.g. USDC, USDT, WETH).
     ///
-    /// # Arguments
-    /// * `chain_id` - The chain ID
-    /// * `token` - The token's contract address
+    /// When `chain_id` is `Some(c)`, the lookup is keyed on `(c, token)`. When
+    /// `chain_id` is `None` (used for pre-EIP-155 legacy transactions that
+    /// don't carry a chain id of their own), the lookup falls back to an
+    /// address-only any-chain scan: if the destination is a canonical token on
+    /// *any* chain in the compiled-in registry, route to the safe built-in
+    /// decoder rather than letting a caller-supplied ABI bind. We deliberately
+    /// don't use the resolved chain id for the address-only path, since that's
+    /// derived from caller-controlled metadata.
     ///
-    /// # Returns
-    /// `Some(erc_standard)` if the token is registered, `None` otherwise
+    /// If the same address is registered as different ERC standards on
+    /// different chains (effectively impossible for canonical tokens), the
+    /// first match wins. The set of compiled-in tokens is small, so the linear
+    /// scan is cheap and runs only on the chain-id-less legacy path.
     pub fn get_token_erc_standard(
         &self,
-        chain_id: ChainId,
+        chain_id: Option<ChainId>,
         token: Address,
     ) -> Option<crate::token_metadata::ErcStandard> {
-        self.token_metadata
-            .get(&(chain_id, token))
-            .map(|m| m.erc_standard.clone())
-    }
-
-    /// Address-only lookup across all chains for the canonical-token short-circuit.
-    ///
-    /// Used by the dispatcher for pre-EIP-155 legacy transactions that
-    /// don't carry a chain_id of their own. In that case we deliberately ignore
-    /// the resolved chain_id (which is metadata-derived and caller-controlled)
-    /// and instead match on address alone: if the destination is a canonical
-    /// token on *any* chain in the compiled-in registry, route to the safe
-    /// built-in decoder rather than letting a caller-supplied ABI bind.
-    ///
-    /// If the same address is registered as different ERC standards on different
-    /// chains (effectively impossible for canonical tokens), the first match
-    /// wins. The set of compiled-in tokens is small, so the linear scan is
-    /// cheap and runs only on the chain-id-less legacy path.
-    pub fn get_token_erc_standard_any_chain(
-        &self,
-        token: Address,
-    ) -> Option<crate::token_metadata::ErcStandard> {
-        self.token_metadata
-            .iter()
-            .find(|((_, addr), _)| *addr == token)
-            .map(|(_, m)| m.erc_standard.clone())
+        let metadata = match chain_id {
+            Some(c) => self.token_metadata.get(&(c, token)),
+            None => self
+                .token_metadata
+                .iter()
+                .find(|((_, addr), _)| *addr == token)
+                .map(|(_, m)| m),
+        };
+        metadata.map(|m| m.erc_standard.clone())
     }
 
     /// Registers a well-known address that exists on all chains at the same address

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -219,6 +219,28 @@ impl ContractRegistry {
             .map(|m| m.symbol.clone())
     }
 
+    /// Gets the ERC standard for a registered token on a chain
+    ///
+    /// Used by the dispatcher to recognize known tokens and route them to the
+    /// safe built-in ERC20/ERC721 visualizer, preventing caller-supplied ABIs
+    /// from overriding decoding for canonical tokens (e.g. USDC, USDT, WETH).
+    ///
+    /// # Arguments
+    /// * `chain_id` - The chain ID
+    /// * `token` - The token's contract address
+    ///
+    /// # Returns
+    /// `Some(erc_standard)` if the token is registered, `None` otherwise
+    pub fn get_token_erc_standard(
+        &self,
+        chain_id: ChainId,
+        token: Address,
+    ) -> Option<crate::token_metadata::ErcStandard> {
+        self.token_metadata
+            .get(&(chain_id, token))
+            .map(|m| m.erc_standard.clone())
+    }
+
     /// Registers a well-known address that exists on all chains at the same address
     ///
     /// # Arguments

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -241,6 +241,29 @@ impl ContractRegistry {
             .map(|m| m.erc_standard.clone())
     }
 
+    /// Address-only lookup across all chains for the canonical-token short-circuit.
+    ///
+    /// Used by the dispatcher (PRS-222) for pre-EIP-155 legacy transactions that
+    /// don't carry a chain_id of their own. In that case we deliberately ignore
+    /// the resolved chain_id (which is metadata-derived and caller-controlled)
+    /// and instead match on address alone: if the destination is a canonical
+    /// token on *any* chain in the compiled-in registry, route to the safe
+    /// built-in decoder rather than letting a caller-supplied ABI bind.
+    ///
+    /// If the same address is registered as different ERC standards on different
+    /// chains (effectively impossible for canonical tokens), the first match
+    /// wins. The set of compiled-in tokens is small, so the linear scan is
+    /// cheap and runs only on the chain-id-less legacy path.
+    pub fn get_token_erc_standard_any_chain(
+        &self,
+        token: Address,
+    ) -> Option<crate::token_metadata::ErcStandard> {
+        self.token_metadata
+            .iter()
+            .find(|((_, addr), _)| *addr == token)
+            .map(|(_, m)| m.erc_standard.clone())
+    }
+
     /// Registers a well-known address that exists on all chains at the same address
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary

A malicious dApp could supply `chain_metadata.abi_mappings` keyed to a canonical token address (USDC, USDT, WETH, ...) and rename selector `0xa9059cbb` (`transfer`) to any chosen function name and parameter labels. The dispatcher tried the caller-supplied `AbiRegistry` before falling back to the safe built-in `ERC20Visualizer`, so the wallet UI rendered the spoofed labels while the bytes executed a real transfer. Signed UI spoofing on canonical tokens.

This change prefers the safe built-in ERC20/ERC721 visualizer for any address registered in the compiled-in (global) `ContractRegistry`. Caller-supplied ABIs can no longer override decoding for canonical tokens.

## What changed

- `visualsign-ethereum::convert_to_visual_sign_payload`: known-token short-circuit before the dynamic-ABI path. If the destination resolves to an ERC20/ERC721 in the compiled-in registry, dispatch to the built-in visualizer and skip the caller ABI. ERC1155 falls through to the raw-hex fallback (no built-in visualizer yet) rather than the user ABI, so the attack surface stays closed.
- Only the **global** registry layer is consulted for the override check; the request-scoped layer is itself caller-supplied and cannot decide its own override.
- New `ContractRegistry::get_token_erc_standard(chain_id, address)` to support the lookup.
- New regression test `test_known_token_ignores_caller_supplied_abi_for_transfer` that reproduces the spoof (USDC `transfer` calldata + attacker `abi_mappings`) and asserts the built-in `ERC20 Transfer` / `Recipient` / `Amount` labels win.

## Rollback

Single-commit revert: `git revert <merge-sha>`. No data migrations, no proto changes, no config changes. Behavior reverts to caller-ABI-first dispatch (i.e. back to the vulnerable state), so rollback should only be used to triage a regression, not as a permanent posture.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -p visualsign-ethereum --all-targets -- -D warnings` clean
- [x] `cargo test -p visualsign-ethereum` (200 unit + 4 integration + doctests passing, including the new regression test)
- [ ] CI green on `main` base
