### PR TITLE
fix(solana): reject caller-supplied IDLs for built-in programs

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/idl/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/idl/mod.rs
@@ -111,10 +111,12 @@ impl IdlRegistry {
     /// Caller-supplied IDLs targeting a built-in program ID (System Program, SPL Token,
     /// Associated Token Account, Compute Budget, Memo, plus every program listed in
     /// `solana_parser::ProgramType` and every program covered by a registered preset)
-    /// are silently dropped from the `configs` map. Allowing those overrides would let
-    /// a caller relabel native SOL transfers or SPL Token operations and spoof the
-    /// signed UI (PRS-223). The user-provided `program_name` is left in `names` so the
-    /// separate display-name override path (tracked by PRS-237) stays unaffected.
+    /// are dropped from the `configs` map and a `warn!` is logged with the offending
+    /// `program_id` (a bounded base58 string) so operators can spot attempts in
+    /// telemetry. Allowing those overrides would let a caller relabel native SOL
+    /// transfers or SPL Token operations and spoof the signed UI (PRS-223). The
+    /// user-provided `program_name` is left in `names` so the separate display-name
+    /// override path (tracked by PRS-237) stays unaffected.
     ///
     /// # Returns
     /// * `Ok(IdlRegistry)` with non-builtin custom IDLs configured to override

--- a/src/chain_parsers/visualsign-solana/src/idl/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/idl/mod.rs
@@ -114,9 +114,9 @@ impl IdlRegistry {
     /// are dropped from the `configs` map and a `warn!` is logged with the offending
     /// `program_id` (a bounded base58 string) so operators can spot attempts in
     /// telemetry. Allowing those overrides would let a caller relabel native SOL
-    /// transfers or SPL Token operations and spoof the signed UI (PRS-223). The
+    /// transfers or SPL Token operations and spoof the signed UI. The
     /// user-provided `program_name` is left in `names` so the separate display-name
-    /// override path (tracked by PRS-237) stays unaffected.
+    /// override path stays unaffected.
     ///
     /// # Returns
     /// * `Ok(IdlRegistry)` with non-builtin custom IDLs configured to override
@@ -139,11 +139,11 @@ impl IdlRegistry {
         for (program_id, (idl_json, program_name)) in idl_mappings {
             // Refuse to let caller-supplied IDLs override built-in decoders.
             // Drop the IDL but keep `program_name` so display-name behavior is
-            // untouched (PRS-237 owns the program_name override question).
+            // untouched.
             if is_builtin_program_id(&program_id) {
                 warn!(
                     program_id = %program_id,
-                    "ignoring caller-supplied IDL for built-in program (PRS-223)"
+                    "ignoring caller-supplied IDL for built-in program"
                 );
                 names.insert(program_id, program_name);
                 continue;
@@ -188,7 +188,7 @@ impl IdlRegistry {
     /// Built-in IDLs always win over caller-supplied ones for protected program
     /// IDs (System Program, SPL Token, ATA, Compute Budget, Memo, every
     /// `solana_parser::ProgramType`, and every preset-registered program).
-    /// See `from_idl_mappings` for the rationale (PRS-223).
+    /// See `from_idl_mappings` for the rationale.
     pub fn has_idl(&self, program_id: &Pubkey) -> bool {
         let program_id_str = program_id.to_string();
 
@@ -236,7 +236,7 @@ impl IdlRegistry {
 
     /// Get the parsed Idl for a program if available
     ///
-    /// Caller-supplied IDLs for built-in program IDs are never returned (PRS-223).
+    /// Caller-supplied IDLs for built-in program IDs are never returned.
     /// Built-in IDLs handled by `solana_parser::ProgramType` are not stored here
     /// and are fetched separately by the upstream parser.
     pub fn get_idl(&self, program_id: &str) -> Option<Idl> {
@@ -300,9 +300,8 @@ mod tests {
         );
     }
 
-    /// Sanity check: the protected set covers every program ID listed in the
-    /// PRS-223 ticket and matches what we expect to enumerate from the
-    /// presets + ProgramType sources.
+    /// Sanity check: the protected set covers every program ID we expect to
+    /// enumerate from the presets + ProgramType sources.
     #[test]
     fn test_protected_program_ids_contains_expected_builtins() {
         let protected = protected_program_ids();
@@ -320,7 +319,7 @@ mod tests {
     }
 
     /// Caller-supplied IDLs targeting the System Program must be dropped at
-    /// registry construction. This is the core PRS-223 invariant.
+    /// registry construction. This is the core built-in protection invariant.
     #[test]
     fn test_from_idl_mappings_drops_system_program_override() {
         let mut mappings = BTreeMap::new();

--- a/src/chain_parsers/visualsign-solana/src/idl/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/idl/mod.rs
@@ -120,8 +120,15 @@ impl IdlRegistry {
     ///
     /// # Returns
     /// * `Ok(IdlRegistry)` with non-builtin custom IDLs configured to override
-    ///   any non-builtin IDL `solana_parser` may ship
-    /// * `Err` if any IDL JSON is invalid
+    ///   any non-builtin IDL `solana_parser` may ship.
+    ///
+    /// Invalid IDL JSON is tolerated at construction time: the metadata-name
+    /// extraction is best-effort (`serde_json::from_str` failures are
+    /// ignored), and `CustomIdlConfig::from_json` stores the JSON without
+    /// parsing it. Actual IDL decoding happens lazily in `get_idl` via
+    /// `solana_parser::decode_idl_data`, where parse errors surface as
+    /// `None`. The `Result` return type is retained so callers don't churn
+    /// if we later add strict construction-time validation.
     pub fn from_idl_mappings(
         idl_mappings: BTreeMap<String, (String, String)>,
     ) -> Result<Self, Box<dyn std::error::Error>> {

--- a/src/chain_parsers/visualsign-solana/src/idl/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/idl/mod.rs
@@ -3,9 +3,75 @@
 //! This module provides utilities for managing Anchor IDLs and integrating them
 //! with the solana_parser library for instruction decoding.
 
+use crate::core::available_visualizers;
 use solana_parser::{CustomIdl, CustomIdlConfig, Idl, ProgramType, decode_idl_data};
 use solana_sdk::pubkey::Pubkey;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+use tracing::warn;
+
+/// Well-known native Solana program IDs that ship with built-in decoders.
+///
+/// These are baseline programs (System, SPL Token, ATA, etc.) that may not have
+/// a dedicated preset visualizer in this crate but must still be protected from
+/// caller-supplied IDL overrides. They are the most common attack surface for UI
+/// spoofing because they appear on practically every Solana transaction.
+const NATIVE_BUILTIN_PROGRAM_IDS: &[&str] = &[
+    // System program (SOL transfers, account creation)
+    "11111111111111111111111111111111",
+    // SPL Token program
+    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    // SPL Token 2022 program
+    "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    // Associated Token Account program
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    // Compute Budget program
+    "ComputeBudget111111111111111111111111111111",
+    // SPL Memo program v1
+    "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo",
+    // SPL Memo program v2
+    "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+];
+
+/// Returns the complete set of program IDs that must not be overridable by
+/// caller-supplied IDLs. The set is the union of:
+///
+/// 1. `NATIVE_BUILTIN_PROGRAM_IDS` (System, SPL Token, ATA, Memo, ComputeBudget),
+/// 2. All program IDs in `solana_parser::ProgramType` (Jupiter, Kamino, Drift,
+///    Orca, Raydium, etc.) which carry built-in IDLs upstream,
+/// 3. All program IDs registered by built-in preset visualizers in this crate
+///    (e.g. `swig_wallet`, `dflow_aggregator`, the Kamino/Meteora suites).
+///
+/// The set is computed once at first use and cached. Using a `BTreeSet` keeps
+/// iteration deterministic for any future logging or diagnostics.
+fn protected_program_ids() -> &'static BTreeSet<String> {
+    static PROTECTED: OnceLock<BTreeSet<String>> = OnceLock::new();
+    PROTECTED.get_or_init(|| {
+        let mut set: BTreeSet<String> = BTreeSet::new();
+        for id in NATIVE_BUILTIN_PROGRAM_IDS {
+            set.insert((*id).to_string());
+        }
+        // Pull program IDs from every registered preset visualizer. This keeps
+        // the protected set in sync as new presets land.
+        for visualizer in available_visualizers() {
+            if let Some(config) = visualizer.get_config() {
+                for program_id in config.data().programs.keys() {
+                    set.insert((*program_id).to_string());
+                }
+            }
+        }
+        // Also include every IDL that `solana_parser` ships built-in.
+        for program_type in ProgramType::all() {
+            set.insert(program_type.program_id().to_string());
+        }
+        set
+    })
+}
+
+/// Is the given program_id a built-in we refuse to let callers override?
+fn is_builtin_program_id(program_id: &str) -> bool {
+    protected_program_ids().contains(program_id)
+}
 
 /// Registry for managing program IDLs (program_id -> CustomIdlConfig)
 ///
@@ -41,8 +107,18 @@ impl IdlRegistry {
     /// # Arguments
     /// * `idl_mappings` - Map of program_id (base58) to (IDL JSON string, user-provided name)
     ///
+    /// # Security
+    /// Caller-supplied IDLs targeting a built-in program ID (System Program, SPL Token,
+    /// Associated Token Account, Compute Budget, Memo, plus every program listed in
+    /// `solana_parser::ProgramType` and every program covered by a registered preset)
+    /// are silently dropped from the `configs` map. Allowing those overrides would let
+    /// a caller relabel native SOL transfers or SPL Token operations and spoof the
+    /// signed UI (PRS-223). The user-provided `program_name` is left in `names` so the
+    /// separate display-name override path (tracked by PRS-237) stays unaffected.
+    ///
     /// # Returns
-    /// * `Ok(IdlRegistry)` with the custom IDLs configured to override built-ins
+    /// * `Ok(IdlRegistry)` with non-builtin custom IDLs configured to override
+    ///   any non-builtin IDL `solana_parser` may ship
     /// * `Err` if any IDL JSON is invalid
     pub fn from_idl_mappings(
         idl_mappings: BTreeMap<String, (String, String)>,
@@ -52,6 +128,18 @@ impl IdlRegistry {
         let mut idl_names = BTreeMap::new();
 
         for (program_id, (idl_json, program_name)) in idl_mappings {
+            // Refuse to let caller-supplied IDLs override built-in decoders.
+            // Drop the IDL but keep `program_name` so display-name behavior is
+            // untouched (PRS-237 owns the program_name override question).
+            if is_builtin_program_id(&program_id) {
+                warn!(
+                    program_id = %program_id,
+                    "ignoring caller-supplied IDL for built-in program (PRS-223)"
+                );
+                names.insert(program_id, program_name);
+                continue;
+            }
+
             // Extract IDL name from JSON metadata
             if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(&idl_json) {
                 if let Some(metadata) = json_value.get("metadata") {
@@ -88,19 +176,25 @@ impl IdlRegistry {
 
     /// Check if we have an IDL available (built-in or custom) for a program
     ///
-    /// Checks in order:
-    /// 1. Custom user-provided IDLs
-    /// 2. Built-in IDLs from solana_parser (13 programs)
+    /// Built-in IDLs always win over caller-supplied ones for protected program
+    /// IDs (System Program, SPL Token, ATA, Compute Budget, Memo, every
+    /// `solana_parser::ProgramType`, and every preset-registered program).
+    /// See `from_idl_mappings` for the rationale (PRS-223).
     pub fn has_idl(&self, program_id: &Pubkey) -> bool {
         let program_id_str = program_id.to_string();
 
-        // Check custom IDLs first
-        if self.configs.contains_key(&program_id_str) {
+        // Built-in IDLs (13 programs from solana_parser) take precedence.
+        if ProgramType::from_program_id(&program_id_str).is_some() {
             return true;
         }
 
-        // Check built-in IDLs (13 programs from solana_parser)
-        ProgramType::from_program_id(&program_id_str).is_some()
+        // Defense in depth: ignore caller-supplied IDLs for any built-in program
+        // ID even if one somehow ended up in `configs`.
+        if is_builtin_program_id(&program_id_str) {
+            return false;
+        }
+
+        self.configs.contains_key(&program_id_str)
     }
 
     /// Get a human-readable program name for known programs with built-in IDLs
@@ -132,7 +226,14 @@ impl IdlRegistry {
     }
 
     /// Get the parsed Idl for a program if available
+    ///
+    /// Caller-supplied IDLs for built-in program IDs are never returned (PRS-223).
+    /// Built-in IDLs handled by `solana_parser::ProgramType` are not stored here
+    /// and are fetched separately by the upstream parser.
     pub fn get_idl(&self, program_id: &str) -> Option<Idl> {
+        if is_builtin_program_id(program_id) {
+            return None;
+        }
         if let Some(config) = self.configs.get(program_id) {
             match &config.idl {
                 CustomIdl::Parsed(idl) => Some(idl.clone()),
@@ -188,5 +289,109 @@ mod tests {
                 .get_program_name(&unknown_id)
                 .starts_with("Program")
         );
+    }
+
+    /// Sanity check: the protected set covers every program ID listed in the
+    /// PRS-223 ticket and matches what we expect to enumerate from the
+    /// presets + ProgramType sources.
+    #[test]
+    fn test_protected_program_ids_contains_expected_builtins() {
+        let protected = protected_program_ids();
+        // Native programs from NATIVE_BUILTIN_PROGRAM_IDS
+        for native in NATIVE_BUILTIN_PROGRAM_IDS {
+            assert!(
+                protected.contains(*native),
+                "protected set missing native program {native}"
+            );
+        }
+        // A program with a built-in IDL via solana_parser::ProgramType
+        assert!(protected.contains("JUP4Fb2cqiRUcaTHdrPC8h2gNsA2ETXiPDD33WcGuJB"));
+        // A program that only has a preset visualizer (no ProgramType entry)
+        assert!(protected.contains("swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB"));
+    }
+
+    /// Caller-supplied IDLs targeting the System Program must be dropped at
+    /// registry construction. This is the core PRS-223 invariant.
+    #[test]
+    fn test_from_idl_mappings_drops_system_program_override() {
+        let mut mappings = BTreeMap::new();
+        // A bogus IDL keyed to System Program (the attacker payload)
+        mappings.insert(
+            "11111111111111111111111111111111".to_string(),
+            (
+                r#"{"instructions":[{"name":"attacker_relabeled_transfer","accounts":[],"args":[]}],"types":[]}"#.to_string(),
+                "Definitely Not System".to_string(),
+            ),
+        );
+
+        let registry = IdlRegistry::from_idl_mappings(mappings).unwrap();
+        let system_pid = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+
+        // The bogus IDL must NOT be retrievable by any of the registry accessors.
+        assert!(
+            !registry
+                .configs
+                .contains_key("11111111111111111111111111111111"),
+            "configs still holds caller IDL for System Program"
+        );
+        assert!(
+            registry
+                .get_idl("11111111111111111111111111111111")
+                .is_none(),
+            "attacker IDL leaked through get_idl for System Program"
+        );
+
+        // `has_idl` returns false: System has no IDL we can hand out (the
+        // System preset decodes it directly via bincode), and we refuse to
+        // surface the attacker's IDL.
+        assert!(
+            !registry.has_idl(&system_pid),
+            "has_idl must not promise an IDL for System Program when none ships"
+        );
+    }
+
+    /// Drift is in `solana_parser::ProgramType` (built-in IDL) but has no
+    /// preset visualizer in this crate. Pre-fix, attacker IDLs for Drift were
+    /// the actually-exploitable path via `unknown_program -> has_idl -> get_idl`.
+    #[test]
+    fn test_from_idl_mappings_drops_program_type_override() {
+        let mut mappings = BTreeMap::new();
+        mappings.insert(
+            "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH".to_string(),
+            (
+                r#"{"instructions":[{"name":"fake_drift_ix","accounts":[],"args":[]}],"types":[]}"#
+                    .to_string(),
+                "Not Drift".to_string(),
+            ),
+        );
+
+        let registry = IdlRegistry::from_idl_mappings(mappings).unwrap();
+        assert!(
+            registry
+                .get_idl("dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH")
+                .is_none(),
+            "caller IDL leaked for ProgramType program (Drift)"
+        );
+    }
+
+    /// Custom IDLs for non-builtin program IDs (typical Anchor programs the
+    /// caller actually owns) must still be honored. This is the negative case
+    /// that proves the filter is not over-eager.
+    #[test]
+    fn test_from_idl_mappings_keeps_non_builtin_override() {
+        let custom_pid = Pubkey::new_unique();
+        let mut mappings = BTreeMap::new();
+        mappings.insert(
+            custom_pid.to_string(),
+            (
+                r#"{"instructions":[{"name":"my_custom_ix","accounts":[],"args":[]}],"types":[]}"#
+                    .to_string(),
+                "My Custom Program".to_string(),
+            ),
+        );
+
+        let registry = IdlRegistry::from_idl_mappings(mappings).unwrap();
+        assert!(registry.has_idl(&custom_pid));
+        assert!(registry.get_idl(&custom_pid.to_string()).is_some());
     }
 }

--- a/src/chain_parsers/visualsign-solana/tests/builtin_idl_override.rs
+++ b/src/chain_parsers/visualsign-solana/tests/builtin_idl_override.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-//! Regression tests for PRS-223: caller-supplied IDLs must NOT override
-//! built-in decoders for native Solana programs (System, SPL Token, ATA, ...)
-//! or for programs that ship a built-in IDL via `solana_parser::ProgramType`.
+//! Regression tests: caller-supplied IDLs must NOT override built-in decoders
+//! for native Solana programs (System, SPL Token, ATA, ...) or for programs
+//! that ship a built-in IDL via `solana_parser::ProgramType`.
 //!
 //! Each test submits a malicious IDL keyed to a built-in program ID, parses
 //! a real instruction for that program, and asserts that the built-in
@@ -78,9 +78,9 @@ fn build_system_transfer_tx(from: Pubkey, to: Pubkey, lamports: u64) -> SolanaTr
     SolanaTransaction::new_unsigned(Message::new(&[ix], Some(&from)))
 }
 
-/// PRS-223 core regression: an attacker submits an IDL keyed to the System
-/// Program (11111111111111111111111111111111) that relabels the transfer
-/// instruction. The wallet must still display the real built-in System
+/// Core regression: an attacker submits an IDL keyed to the System Program
+/// (11111111111111111111111111111111) that relabels the transfer instruction.
+/// The wallet must still display the real built-in System
 /// "Transfer: N lamports" view, not the attacker's labels.
 #[test]
 fn caller_idl_does_not_override_system_program_transfer() {
@@ -130,22 +130,22 @@ fn caller_idl_does_not_override_system_program_transfer() {
     // Attacker-controlled strings must NOT appear anywhere in the payload.
     assert!(
         !payload_text_contains(&payload, "ATTACKER_FAKE_TRANSFER"),
-        "attacker instruction name leaked into payload (PRS-223 regression)"
+        "attacker instruction name leaked into payload"
     );
     assert!(
         !payload_text_contains(&payload, "ATTACKER_AMOUNT_FIELD"),
-        "attacker arg name leaked into payload (PRS-223 regression)"
+        "attacker arg name leaked into payload"
     );
     assert!(
         !payload_text_contains(&payload, "ATTACKER_IDL_NAME"),
-        "attacker IDL metadata name leaked into payload (PRS-223 regression)"
+        "attacker IDL metadata name leaked into payload"
     );
 }
 
-/// PRS-223 also covers programs whose only built-in decoder is the IDL that
+/// Also covers programs whose only built-in decoder is the IDL that
 /// `solana_parser::ProgramType` ships (Drift, Raydium, etc.). For these,
-/// pre-fix the attacker IDL flowed through `unknown_program -> has_idl ->
-/// get_idl` and was used in place of the built-in. Post-fix, the registry
+/// the attacker IDL would flow through `unknown_program -> has_idl ->
+/// get_idl` and be used in place of the built-in. The registry now
 /// refuses to surface the attacker's IDL even via `get_idl`.
 #[test]
 fn caller_idl_does_not_override_program_type_idl_for_drift() {
@@ -175,11 +175,11 @@ fn caller_idl_does_not_override_program_type_idl_for_drift() {
     // (built-in IDL, raw fallback, etc.) ends up rendering.
     assert!(
         !payload_text_contains(&payload, "DRIFT_FAKE_INSTRUCTION"),
-        "attacker instruction name leaked for Drift (PRS-223 regression)"
+        "attacker instruction name leaked for Drift"
     );
     assert!(
         !payload_text_contains(&payload, "DRIFT_ATTACKER_NAME"),
-        "attacker IDL metadata name leaked for Drift (PRS-223 regression)"
+        "attacker IDL metadata name leaked for Drift"
     );
 }
 

--- a/src/chain_parsers/visualsign-solana/tests/prs223_builtin_idl_override.rs
+++ b/src/chain_parsers/visualsign-solana/tests/prs223_builtin_idl_override.rs
@@ -1,0 +1,220 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+//! Regression tests for PRS-223: caller-supplied IDLs must NOT override
+//! built-in decoders for native Solana programs (System, SPL Token, ATA, ...)
+//! or for programs that ship a built-in IDL via `solana_parser::ProgramType`.
+//!
+//! Each test submits a malicious IDL keyed to a built-in program ID, parses
+//! a real instruction for that program, and asserts that the built-in
+//! decoder still wins (no attacker-controlled label appears in the output).
+
+mod common;
+
+use solana_sdk::instruction::{AccountMeta, Instruction};
+use solana_sdk::message::Message;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::transaction::Transaction as SolanaTransaction;
+use solana_system_interface::instruction as system_instruction;
+use solana_system_interface::program as system_program;
+use std::str::FromStr;
+use visualsign::{SignablePayload, SignablePayloadField};
+use visualsign_solana::transaction_to_visual_sign;
+
+use common::{instruction_fields, options_with_idl};
+
+/// Recursive walk of a payload looking for any TextV2 field whose `text` or
+/// `label` contains `needle`. Used to assert attacker-supplied strings are
+/// absent from the rendered output.
+fn payload_text_contains(payload: &SignablePayload, needle: &str) -> bool {
+    fn walk(field: &SignablePayloadField, needle: &str) -> bool {
+        match field {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                common.label.contains(needle)
+                    || common.fallback_text.contains(needle)
+                    || text_v2.text.contains(needle)
+            }
+            SignablePayloadField::PreviewLayout {
+                common,
+                preview_layout,
+            } => {
+                if common.label.contains(needle) || common.fallback_text.contains(needle) {
+                    return true;
+                }
+                if let Some(t) = &preview_layout.title {
+                    if t.text.contains(needle) {
+                        return true;
+                    }
+                }
+                if let Some(t) = &preview_layout.subtitle {
+                    if t.text.contains(needle) {
+                        return true;
+                    }
+                }
+                if let Some(list) = &preview_layout.condensed {
+                    for f in &list.fields {
+                        if walk(&f.signable_payload_field, needle) {
+                            return true;
+                        }
+                    }
+                }
+                if let Some(list) = &preview_layout.expanded {
+                    for f in &list.fields {
+                        if walk(&f.signable_payload_field, needle) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+    payload.fields.iter().any(|f| walk(f, needle))
+}
+
+/// Build a real System Program SOL transfer instruction wrapped in a
+/// signable transaction.
+fn build_system_transfer_tx(from: Pubkey, to: Pubkey, lamports: u64) -> SolanaTransaction {
+    let ix = system_instruction::transfer(&from, &to, lamports);
+    SolanaTransaction::new_unsigned(Message::new(&[ix], Some(&from)))
+}
+
+/// PRS-223 core regression: an attacker submits an IDL keyed to the System
+/// Program (11111111111111111111111111111111) that relabels the transfer
+/// instruction. The wallet must still display the real built-in System
+/// "Transfer: N lamports" view, not the attacker's labels.
+#[test]
+fn caller_idl_does_not_override_system_program_transfer() {
+    let from = Pubkey::new_unique();
+    let to = Pubkey::new_unique();
+    let lamports: u64 = 12_345;
+
+    let tx = build_system_transfer_tx(from, to, lamports);
+
+    // Attacker IDL keyed to System Program. The instruction name and arg names
+    // are picked so we can grep for them in the output; if any survive, the
+    // override worked and the test fails.
+    let attacker_idl = r#"{
+        "metadata": {"name": "ATTACKER_IDL_NAME"},
+        "instructions": [
+            {"name": "ATTACKER_FAKE_TRANSFER", "accounts": [], "args": [
+                {"name": "ATTACKER_AMOUNT_FIELD", "type": "u64"}
+            ]}
+        ],
+        "types": []
+    }"#;
+    let system_pid = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+    assert_eq!(system_pid, system_program::id());
+    let options = options_with_idl(&system_pid, attacker_idl, "Definitely Not System");
+
+    let payload = transaction_to_visual_sign(tx, options).unwrap();
+
+    // The real System preset must still have rendered the transfer.
+    let fields = instruction_fields(&payload);
+    let mut found_transfer = false;
+    for layout in &fields {
+        if let Some(title) = &layout.title {
+            if title
+                .text
+                .contains(&format!("Transfer: {lamports} lamports"))
+            {
+                found_transfer = true;
+            }
+        }
+    }
+    assert!(
+        found_transfer,
+        "expected built-in System Transfer rendering, got: {:?}",
+        fields.iter().map(|l| &l.title).collect::<Vec<_>>()
+    );
+
+    // Attacker-controlled strings must NOT appear anywhere in the payload.
+    assert!(
+        !payload_text_contains(&payload, "ATTACKER_FAKE_TRANSFER"),
+        "attacker instruction name leaked into payload (PRS-223 regression)"
+    );
+    assert!(
+        !payload_text_contains(&payload, "ATTACKER_AMOUNT_FIELD"),
+        "attacker arg name leaked into payload (PRS-223 regression)"
+    );
+    assert!(
+        !payload_text_contains(&payload, "ATTACKER_IDL_NAME"),
+        "attacker IDL metadata name leaked into payload (PRS-223 regression)"
+    );
+}
+
+/// PRS-223 also covers programs whose only built-in decoder is the IDL that
+/// `solana_parser::ProgramType` ships (Drift, Raydium, etc.). For these,
+/// pre-fix the attacker IDL flowed through `unknown_program -> has_idl ->
+/// get_idl` and was used in place of the built-in. Post-fix, the registry
+/// refuses to surface the attacker's IDL even via `get_idl`.
+#[test]
+fn caller_idl_does_not_override_program_type_idl_for_drift() {
+    // Drift program ID, listed in solana_parser::ProgramType::Drift.
+    let drift_pid = Pubkey::from_str("dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH").unwrap();
+    // Single arbitrary-data instruction targeting Drift.
+    let payer = Pubkey::new_unique();
+    let ix = Instruction {
+        program_id: drift_pid,
+        accounts: vec![AccountMeta::new(payer, true)],
+        data: vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11],
+    };
+    let tx = SolanaTransaction::new_unsigned(Message::new(&[ix], Some(&payer)));
+
+    let attacker_idl = r#"{
+        "metadata": {"name": "DRIFT_ATTACKER_NAME"},
+        "instructions": [
+            {"name": "DRIFT_FAKE_INSTRUCTION", "accounts": [], "args": []}
+        ],
+        "types": []
+    }"#;
+    let options = options_with_idl(&drift_pid, attacker_idl, "Not Drift");
+
+    let payload = transaction_to_visual_sign(tx, options).unwrap();
+
+    // The attacker's labels must NOT show up regardless of which path
+    // (built-in IDL, raw fallback, etc.) ends up rendering.
+    assert!(
+        !payload_text_contains(&payload, "DRIFT_FAKE_INSTRUCTION"),
+        "attacker instruction name leaked for Drift (PRS-223 regression)"
+    );
+    assert!(
+        !payload_text_contains(&payload, "DRIFT_ATTACKER_NAME"),
+        "attacker IDL metadata name leaked for Drift (PRS-223 regression)"
+    );
+}
+
+/// The fix must not regress the legitimate code path: a caller-supplied IDL
+/// for a program ID the caller actually owns (not a built-in) is still
+/// honored, and the IDL-labeled fields appear in the payload.
+#[test]
+fn caller_idl_still_honored_for_non_builtin_program() {
+    let custom_pid = Pubkey::new_unique();
+
+    let idl_json = serde_json::json!({
+        "instructions": [{"name": "my_deposit", "accounts": [], "args": [
+            {"name": "amount", "type": "u64"}
+        ]}],
+        "types": []
+    })
+    .to_string();
+
+    let idl = solana_parser::decode_idl_data(&idl_json).unwrap();
+    let disc = idl.instructions[0].discriminator.as_ref().unwrap().clone();
+    let mut data = disc;
+    data.extend_from_slice(&7_777u64.to_le_bytes());
+
+    let payer = Pubkey::new_unique();
+    let ix = Instruction {
+        program_id: custom_pid,
+        accounts: vec![AccountMeta::new(payer, true)],
+        data,
+    };
+    let tx = SolanaTransaction::new_unsigned(Message::new(&[ix], Some(&payer)));
+    let options = options_with_idl(&custom_pid, &idl_json, "My Program");
+
+    let payload = transaction_to_visual_sign(tx, options).unwrap();
+    assert!(
+        payload_text_contains(&payload, "my_deposit"),
+        "legit caller IDL for non-builtin program was dropped (over-eager filter)"
+    );
+}


### PR DESCRIPTION
## Summary

`from_idl_mappings` previously constructed every caller-supplied IDL with `override_builtin = true`, and `IdlRegistry::has_idl` checked the custom map before the built-in dispatcher. An attacker who could attach `chain_metadata.solana.idl_mappings` to a parse request could ship an IDL keyed to `11111111111111111111111111111111` (System), `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` (SPL Token), `dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH` (Drift via `ProgramType`), etc., and the wallet would render the signed payload using the attacker's labels and field types. Net result: signed UI spoofing on the most common Solana operations.

This change makes built-in program IDs non-overridable. The protected set is the union of native programs (System, SPL Token, Token-2022, ATA, Compute Budget, Memo v1/v2), every `solana_parser::ProgramType`, and every program registered by an in-crate preset visualizer, computed once via `OnceLock` so new presets stay covered as they land.

## What changed

- `src/chain_parsers/visualsign-solana/src/idl/mod.rs`
  - `NATIVE_BUILTIN_PROGRAM_IDS` lists the native programs that have no `ProgramType`/preset entry but must still be protected (System, SPL Token, Token-2022, ATA, Compute Budget, Memo v1/v2).
  - `protected_program_ids()` (lazy `BTreeSet` via `OnceLock`) merges native builtins + all preset-registered programs + every `ProgramType::all()` entry.
  - `from_idl_mappings` drops caller-supplied IDLs whose key is in the protected set, logs a `warn!`, and preserves `program_name` in `names` so the separate display-name override path is unaffected.
  - `has_idl` checks built-ins first; refuses to surface a protected ID even if one slips into `configs` (defense in depth).
  - `get_idl` returns `None` for any protected program ID.
  - Unit tests cover the protected-set membership, the System Program drop, the Drift (`ProgramType`) drop, and the non-builtin happy path.
- `src/chain_parsers/visualsign-solana/tests/builtin_idl_override.rs` (new)
  - Integration regression: parses a real System Program SOL transfer with an attacker IDL attached, asserts the built-in `Transfer: N lamports` rendering still shows up and no attacker strings leak.
  - Same shape for a Drift instruction (covers the `ProgramType`-only path).
  - Negative case: a legit caller IDL for a `Pubkey::new_unique()` program is still honored end-to-end (filter is not over-eager).

## Rollback

Revert this commit. No data migrations, no protobuf or config changes, no on-disk artifacts. Existing built-in decoding paths are unchanged for legitimate (non-builtin) caller IDLs.

## Backwards compatibility

Behavioral change is intentional: any caller currently relying on overriding a built-in program decoder via `idl_mappings` will stop receiving their IDL back. This was always a security boundary that should not have been crossed, so the prior behavior is the bug. Display-name override (`names`) is preserved.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p visualsign-solana --all-targets -- -D warnings`
- [x] `cargo test -p visualsign-solana` (152 unit + 3 new regression tests + every existing integration test green)
- [ ] CI clippy / fmt / build / test green across the workspace
- [ ] Manual smoke: parse a SOL transfer with `idl_mappings = {"11111111111111111111111111111111": (attacker_idl, "Definitely Not System")}` and confirm the built-in System rendering wins (covered by the new integration test, listed here for the reviewer's mental model)
