### PR TITLE
fix(ethereum): read V3 swap output token from end of path

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -394,14 +394,22 @@ impl UniversalRouterVisualizer {
         })
     }
 
-    /// Decodes a Uniswap V3 swap path.
+    /// Decodes a Uniswap V3 swap path into raw byte positions.
     ///
-    /// Paths are encoded as: tokenIn(20) | fee(3) | nextToken(20) | fee(3) | ... | tokenOut(20).
+    /// Paths are encoded as: token(20) | fee(3) | token(20) | fee(3) | ... | token(20).
     /// A valid N-hop path therefore has length 20 + N * 23.
     ///
-    /// Returns (token_in, token_out, first_hop_fee, hop_count) or None for malformed paths.
-    /// The output token is always read from the FINAL 20 bytes of the path so that multi-hop
-    /// swaps display the actual destination token, not the first intermediate hop.
+    /// Returns `(first_token, last_token, first_hop_fee, hop_count)` or `None` for malformed
+    /// paths, where `first_token` is the leading 20 bytes and `last_token` is the trailing
+    /// 20 bytes. The helper is intentionally semantics-free: role assignment depends on the
+    /// caller's swap direction.
+    ///
+    /// - ExactIn paths are encoded `tokenIn || fee || ... || tokenOut`, so callers alias
+    ///   `first_token = tokenIn`, `last_token = tokenOut`.
+    /// - ExactOut paths are encoded in reverse (`tokenOut || fee || ... || tokenIn`) per
+    ///   Uniswap V3 convention (see `SwapRouter.exactOutputInternal` /
+    ///   `Path.decodeFirstPool`), so callers must alias
+    ///   `first_token = tokenOut`, `last_token = tokenIn`.
     fn decode_v3_path(path: &[u8]) -> Option<(Address, Address, u32, usize)> {
         // Single hop minimum: 20 + 23 = 43 bytes. Each additional hop adds 23 bytes.
         if path.len() < 43 || (path.len() - 20) % 23 != 0 {
@@ -791,9 +799,11 @@ impl UniversalRouterVisualizer {
 
         let (_recipient, amount_out, amount_in_max, path, _payer_is_user) = params;
 
-        // Decode V3 path. For multi-hop paths, the output token MUST be read from the
-        // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
-        let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
+        // Decode V3 path. ExactOut paths are encoded in reverse vs ExactIn per Uniswap V3
+        // convention (see `SwapRouter.exactOutputInternal` / `Path.decodeFirstPool`): the
+        // on-chain layout is `tokenOut || fee || ... || tokenIn`. The helper returns raw
+        // byte positions, so we alias `first_token = tokenOut`, `last_token = tokenIn`.
+        let (token_out, token_in, fee, hops) = match Self::decode_v3_path(&path) {
             Some(decoded) => decoded,
             None => {
                 return SignablePayloadField::TextV2 {
@@ -2457,21 +2467,26 @@ mod tests {
 
     #[test]
     fn test_decode_v3_swap_exact_out_multi_hop_displays_final_token() {
-        // End-to-end for the exact-out variant.
+        // End-to-end for the exact-out variant. Uniswap V3 ExactOut paths are encoded in
+        // reverse vs ExactIn (`tokenOut || fee || ... || tokenIn`), so we build the test
+        // path in the same reversed shape a real Universal Router payload would carry.
         let recipient: Address = "0x1111111111111111111111111111111111111111"
             .parse()
             .unwrap();
-        let token_in: Address = "0xdddddddddddddddddddddddddddddddddddddddd"
+        // Real swap semantics: signer pays `real_token_in`, receives `real_token_out`.
+        let real_token_in: Address = "0xdddddddddddddddddddddddddddddddddddddddd"
             .parse()
             .unwrap();
         let token_mid: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
             .parse()
             .unwrap();
-        let token_out: Address = "0xffffffffffffffffffffffffffffffffffffffff"
+        let real_token_out: Address = "0xffffffffffffffffffffffffffffffffffffffff"
             .parse()
             .unwrap();
 
-        let path = build_v3_path(&[token_in, token_mid, token_out], &[100, 10000]);
+        // Reversed on-chain layout: first 20 bytes = tokenOut, last 20 bytes = tokenIn.
+        // Fees are listed in the same reversed order as the tokens.
+        let path = build_v3_path(&[real_token_out, token_mid, real_token_in], &[10000, 100]);
 
         type V3OutTuple = (Address, U256, U256, Bytes, bool);
         let encoded: Vec<u8> = <V3OutTuple as SolValue>::abi_encode_params(&(
@@ -2493,8 +2508,12 @@ mod tests {
                     .text
                     .clone();
                 assert!(
-                    subtitle.contains(&format!("{token_out:?}")),
-                    "subtitle must reference final output token, got: {subtitle}"
+                    subtitle.contains(&format!("{real_token_out:?}")),
+                    "subtitle must reference real output token, got: {subtitle}"
+                );
+                assert!(
+                    subtitle.contains(&format!("{real_token_in:?}")),
+                    "subtitle must reference real input token, got: {subtitle}"
                 );
                 assert!(
                     !subtitle.contains(&format!("{token_mid:?}")),
@@ -2506,20 +2525,24 @@ mod tests {
                 );
 
                 let expanded = preview_layout.expanded.expect("expanded present");
-                let output_token_text = expanded
-                    .fields
-                    .iter()
-                    .find_map(|f| match &f.signable_payload_field {
-                        SignablePayloadField::TextV2 { common, text_v2 }
-                            if common.label == "Output Token" =>
-                        {
-                            Some(text_v2.text.clone())
-                        }
-                        _ => None,
-                    })
-                    .expect("Output Token field present");
-                assert_eq!(output_token_text, format!("{token_out:?}"));
-                assert_ne!(output_token_text, format!("{token_mid:?}"));
+                let find_field = |label: &str| -> String {
+                    expanded
+                        .fields
+                        .iter()
+                        .find_map(|f| match &f.signable_payload_field {
+                            SignablePayloadField::TextV2 { common, text_v2 }
+                                if common.label == label =>
+                            {
+                                Some(text_v2.text.clone())
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| panic!("{label} field present"))
+                };
+                // Critical: the signer must see the REAL output token as `Output Token`,
+                // not whatever happens to sit at the trailing bytes of the on-chain path.
+                assert_eq!(find_field("Output Token"), format!("{real_token_out:?}"));
+                assert_eq!(find_field("Input Token"), format!("{real_token_in:?}"));
             }
             _ => panic!("Expected PreviewLayout for V3 Swap Exact Out"),
         }

--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -399,28 +399,42 @@ impl UniversalRouterVisualizer {
     /// Paths are encoded as: token(20) | fee(3) | token(20) | fee(3) | ... | token(20).
     /// A valid N-hop path therefore has length 20 + N * 23.
     ///
-    /// Returns `(first_token, last_token, first_hop_fee, hop_count)` or `None` for malformed
-    /// paths, where `first_token` is the leading 20 bytes and `last_token` is the trailing
-    /// 20 bytes. The helper is intentionally semantics-free: role assignment depends on the
-    /// caller's swap direction.
+    /// Returns `(first_token, last_token, leading_fee, trailing_fee, hop_count)` or `None`
+    /// for malformed paths, where `first_token` is the leading 20 bytes, `last_token` is
+    /// the trailing 20 bytes, `leading_fee` is the fee immediately after `first_token`
+    /// (`path[20..23]`), and `trailing_fee` is the fee immediately before `last_token`
+    /// (`path[len-23..len-20]`). On a single-hop path the two fees coincide.
     ///
-    /// - ExactIn paths are encoded `tokenIn || fee || ... || tokenOut`, so callers alias
-    ///   `first_token = tokenIn`, `last_token = tokenOut`.
-    /// - ExactOut paths are encoded in reverse (`tokenOut || fee || ... || tokenIn`) per
-    ///   Uniswap V3 convention (see `SwapRouter.exactOutputInternal` /
-    ///   `Path.decodeFirstPool`), so callers must alias
-    ///   `first_token = tokenOut`, `last_token = tokenIn`.
-    fn decode_v3_path(path: &[u8]) -> Option<(Address, Address, u32, usize)> {
+    /// The helper is intentionally semantics-free: token and fee role assignment depends
+    /// on the caller's swap direction.
+    ///
+    /// - ExactIn paths are encoded `tokenIn || fee_0 || ... || tokenOut`, where execution
+    ///   flows left-to-right, so callers alias `first_token = tokenIn`,
+    ///   `last_token = tokenOut`, first-execution-hop fee = `leading_fee`.
+    /// - ExactOut paths are encoded in reverse (`tokenOut || fee_{N-1} || ... || tokenIn`)
+    ///   per Uniswap V3 convention (see `SwapRouter.exactOutputInternal` /
+    ///   `Path.decodeFirstPool`). Execution flows right-to-left from the signer's view,
+    ///   so callers alias `first_token = tokenOut`, `last_token = tokenIn`, and the
+    ///   first-execution-hop fee (the fee the signer's input pays first) is
+    ///   `trailing_fee`, not `leading_fee`.
+    fn decode_v3_path(path: &[u8]) -> Option<(Address, Address, u32, u32, usize)> {
         // Single hop minimum: 20 + 23 = 43 bytes. Each additional hop adds 23 bytes.
         if path.len() < 43 || (path.len() - 20) % 23 != 0 {
             return None;
         }
-        let token_in = Address::from_slice(&path[0..20]);
-        let first_fee = u32::from_be_bytes([0, path[20], path[21], path[22]]);
-        let token_out_start = path.len() - 20;
-        let token_out = Address::from_slice(&path[token_out_start..]);
+        let first_token = Address::from_slice(&path[0..20]);
+        let leading_fee = u32::from_be_bytes([0, path[20], path[21], path[22]]);
+        let last_token_start = path.len() - 20;
+        let last_token = Address::from_slice(&path[last_token_start..]);
+        let trailing_fee_start = last_token_start - 3;
+        let trailing_fee = u32::from_be_bytes([
+            0,
+            path[trailing_fee_start],
+            path[trailing_fee_start + 1],
+            path[trailing_fee_start + 2],
+        ]);
         let hops = (path.len() - 20) / 23;
-        Some((token_in, token_out, first_fee, hops))
+        Some((first_token, last_token, leading_fee, trailing_fee, hops))
     }
 
     /// Decodes V3_SWAP_EXACT_IN command parameters
@@ -454,7 +468,10 @@ impl UniversalRouterVisualizer {
 
         // Decode V3 path. For multi-hop paths, the output token MUST be read from the
         // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
-        let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
+        // ExactIn paths flow in execution order, so the first-execution-hop fee is the
+        // leading fee. `trailing_fee` (the last execution hop's fee) is intentionally
+        // discarded here, the caller surfaces only the first-hop fee for disclosure.
+        let (token_in, token_out, fee, _trailing_fee, hops) = match Self::decode_v3_path(&path) {
             Some(decoded) => decoded,
             None => {
                 return SignablePayloadField::TextV2 {
@@ -801,9 +818,13 @@ impl UniversalRouterVisualizer {
 
         // Decode V3 path. ExactOut paths are encoded in reverse vs ExactIn per Uniswap V3
         // convention (see `SwapRouter.exactOutputInternal` / `Path.decodeFirstPool`): the
-        // on-chain layout is `tokenOut || fee || ... || tokenIn`. The helper returns raw
-        // byte positions, so we alias `first_token = tokenOut`, `last_token = tokenIn`.
-        let (token_out, token_in, fee, hops) = match Self::decode_v3_path(&path) {
+        // on-chain layout is `tokenOut || fee_{N-1} || ... || fee_0 || tokenIn`. The helper
+        // returns raw byte positions, so we alias `first_token = tokenOut`,
+        // `last_token = tokenIn`. Execution flows right-to-left from the signer's view, so
+        // the first-execution-hop fee (the fee the signer's input pays first) is the
+        // helper's `trailing_fee`, NOT `leading_fee`. The leading fee corresponds to the
+        // final hop (tokenMid -> tokenOut) and is intentionally discarded for disclosure.
+        let (token_out, token_in, _leading_fee, fee, hops) = match Self::decode_v3_path(&path) {
             Some(decoded) => decoded,
             None => {
                 return SignablePayloadField::TextV2 {
@@ -2318,11 +2339,13 @@ mod tests {
         let path = build_v3_path(&[token_in, token_out], &[3000]);
         assert_eq!(path.len(), 43);
 
-        let (in_, out_, fee, hops) =
+        let (in_, out_, leading_fee, trailing_fee, hops) =
             UniversalRouterVisualizer::decode_v3_path(&path).expect("valid single-hop path");
         assert_eq!(in_, token_in);
         assert_eq!(out_, token_out);
-        assert_eq!(fee, 3000);
+        assert_eq!(leading_fee, 3000);
+        // Single-hop path: leading and trailing fees coincide.
+        assert_eq!(trailing_fee, 3000);
         assert_eq!(hops, 1);
     }
 
@@ -2343,13 +2366,15 @@ mod tests {
         // 20 + 2*23 = 66 bytes
         assert_eq!(path.len(), 66);
 
-        let (in_, out_, fee, hops) =
+        let (in_, out_, leading_fee, trailing_fee, hops) =
             UniversalRouterVisualizer::decode_v3_path(&path).expect("valid two-hop path");
         assert_eq!(in_, token_in);
         // Critical: this must be the FINAL token, not the intermediate.
         assert_eq!(out_, token_out);
         assert_ne!(out_, token_mid, "regression: must not return intermediate");
-        assert_eq!(fee, 500);
+        assert_eq!(leading_fee, 500);
+        // Distinct fees: trailing fee is the second-to-last 3 bytes of the path.
+        assert_eq!(trailing_fee, 3000);
         assert_eq!(hops, 2);
     }
 
@@ -2371,11 +2396,14 @@ mod tests {
         // 20 + 3*23 = 89
         assert_eq!(path.len(), 89);
 
-        let (in_, out_, fee, hops) =
+        let (in_, out_, leading_fee, trailing_fee, hops) =
             UniversalRouterVisualizer::decode_v3_path(&path).expect("valid three-hop path");
         assert_eq!(in_, t0);
         assert_eq!(out_, t3);
-        assert_eq!(fee, 100);
+        assert_eq!(leading_fee, 100);
+        // Three-hop fees are [100, 500, 10000]; the trailing fee sits in the bytes
+        // immediately before the last token, i.e. the final entry of the fee list.
+        assert_eq!(trailing_fee, 10000);
         assert_eq!(hops, 3);
     }
 
@@ -2442,6 +2470,18 @@ mod tests {
                 assert!(
                     subtitle.contains("2 hops"),
                     "subtitle should disclose hop count, got: {subtitle}"
+                );
+                // ExactIn execution flows tokenIn -> tokenMid -> tokenOut; the first
+                // execution hop uses the FIRST entry in the fee list (500 = 0.05%).
+                // Anything else would mean the signer is shown a hop fee that doesn't
+                // apply to the first leg.
+                assert!(
+                    subtitle.contains("first fee 0.05%"),
+                    "subtitle should disclose first-hop fee (0.05%), got: {subtitle}"
+                );
+                assert!(
+                    !subtitle.contains("first fee 0.3%"),
+                    "subtitle must NOT disclose the second-hop fee as the first, got: {subtitle}"
                 );
 
                 let expanded = preview_layout.expanded.expect("expanded present");
@@ -2522,6 +2562,20 @@ mod tests {
                 assert!(
                     subtitle.contains("2 hops"),
                     "subtitle should disclose hop count, got: {subtitle}"
+                );
+                // ExactOut path bytes for this fixture: [real_token_out | 10000 | token_mid
+                // | 100 | real_token_in]. Execution flows real_token_in -> token_mid first
+                // (the signer's first leg, paid out of the user's input), using fee=100 =
+                // 0.01%. The leading-byte fee (10000 = 1.0%) corresponds to the FINAL
+                // execution hop. Disclosing the leading-byte fee as "first fee" misleads
+                // the signer about the hop their input touches first.
+                assert!(
+                    subtitle.contains("first fee 0.01%"),
+                    "subtitle should disclose first-execution-hop fee (0.01%), got: {subtitle}"
+                );
+                assert!(
+                    !subtitle.contains("first fee 1%"),
+                    "subtitle must NOT disclose the final-hop fee as the first, got: {subtitle}"
                 );
 
                 let expanded = preview_layout.expanded.expect("expanded present");

--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -394,6 +394,27 @@ impl UniversalRouterVisualizer {
         })
     }
 
+    /// Decodes a Uniswap V3 swap path.
+    ///
+    /// Paths are encoded as: tokenIn(20) | fee(3) | nextToken(20) | fee(3) | ... | tokenOut(20).
+    /// A valid N-hop path therefore has length 20 + N * 23.
+    ///
+    /// Returns (token_in, token_out, first_hop_fee, hop_count) or None for malformed paths.
+    /// The output token is always read from the FINAL 20 bytes of the path so that multi-hop
+    /// swaps display the actual destination token, not the first intermediate hop.
+    fn decode_v3_path(path: &[u8]) -> Option<(Address, Address, u32, usize)> {
+        // Single hop minimum: 20 + 23 = 43 bytes. Each additional hop adds 23 bytes.
+        if path.len() < 43 || (path.len() - 20) % 23 != 0 {
+            return None;
+        }
+        let token_in = Address::from_slice(&path[0..20]);
+        let first_fee = u32::from_be_bytes([0, path[20], path[21], path[22]]);
+        let token_out_start = path.len() - 20;
+        let token_out = Address::from_slice(&path[token_out_start..]);
+        let hops = (path.len() - 20) / 23;
+        Some((token_in, token_out, first_fee, hops))
+    }
+
     /// Decodes V3_SWAP_EXACT_IN command parameters
     /// Uses abi_decode_params for proper ABI decoding of raw calldata bytes
     fn decode_v3_swap_exact_in(
@@ -423,23 +444,23 @@ impl UniversalRouterVisualizer {
 
         let (_recipient, amount_in, amount_out_min, path, _payer_is_user) = params;
 
-        // Validate path length (minimum 43 bytes for single hop: token + fee + token)
-        if path.len() < 43 {
-            return SignablePayloadField::TextV2 {
-                common: SignablePayloadFieldCommon {
-                    fallback_text: "V3 Swap Exact In: Invalid path".to_string(),
-                    label: "V3 Swap Exact In".to_string(),
-                },
-                text_v2: SignablePayloadFieldTextV2 {
-                    text: format!("Path length: {} bytes (expected >=43)", path.len()),
-                },
-            };
-        }
-
-        // Extract token addresses and fee from path
-        let token_in = Address::from_slice(&path[0..20]);
-        let fee = u32::from_be_bytes([0, path[20], path[21], path[22]]);
-        let token_out = Address::from_slice(&path[23..43]);
+        // Decode V3 path. For multi-hop paths, the output token MUST be read from the
+        // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
+        // See PRS-229.
+        let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
+            Some(decoded) => decoded,
+            None => {
+                return SignablePayloadField::TextV2 {
+                    common: SignablePayloadFieldCommon {
+                        fallback_text: "V3 Swap Exact In: Invalid path".to_string(),
+                        label: "V3 Swap Exact In".to_string(),
+                    },
+                    text_v2: SignablePayloadFieldTextV2 {
+                        text: format!("Path length: {} bytes (expected 20 + N*23)", path.len()),
+                    },
+                };
+            }
+        };
 
         // Resolve token symbols
         let token_in_symbol = registry
@@ -461,11 +482,18 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.format_token_amount(chain_id, token_out, amount_out_min_u128))
             .unwrap_or_else(|| (amount_out_min.to_string(), token_out_symbol.clone()));
 
-        // Calculate fee percentage
+        // Calculate first-hop fee percentage. For multi-hop paths each hop may use a
+        // different fee tier; we surface the first one and disclose the hop count.
         let fee_pct = fee as f64 / 10000.0;
-        let text = format!(
-            "Swap {amount_in_str} {token_in_symbol} for >={amount_out_min_str} {token_out_symbol} via V3 ({fee_pct}% fee)"
-        );
+        let text = if hops == 1 {
+            format!(
+                "Swap {amount_in_str} {token_in_symbol} for >={amount_out_min_str} {token_out_symbol} via V3 ({fee_pct}% fee)"
+            )
+        } else {
+            format!(
+                "Swap {amount_in_str} {token_in_symbol} for >={amount_out_min_str} {token_out_symbol} via V3 ({hops} hops, first fee {fee_pct}%)"
+            )
+        };
 
         // Create individual parameter fields
         let fields = vec![
@@ -764,23 +792,23 @@ impl UniversalRouterVisualizer {
 
         let (_recipient, amount_out, amount_in_max, path, _payer_is_user) = params;
 
-        // Validate path length (minimum 43 bytes for single hop: token + fee + token)
-        if path.len() < 43 {
-            return SignablePayloadField::TextV2 {
-                common: SignablePayloadFieldCommon {
-                    fallback_text: "V3 Swap Exact Out: Invalid path".to_string(),
-                    label: "V3 Swap Exact Out".to_string(),
-                },
-                text_v2: SignablePayloadFieldTextV2 {
-                    text: format!("Path length: {} bytes (expected >=43)", path.len()),
-                },
-            };
-        }
-
-        // Extract token addresses and fee from path
-        let token_in = Address::from_slice(&path[0..20]);
-        let fee = u32::from_be_bytes([0, path[20], path[21], path[22]]);
-        let token_out = Address::from_slice(&path[23..43]);
+        // Decode V3 path. For multi-hop paths, the output token MUST be read from the
+        // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
+        // See PRS-229.
+        let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
+            Some(decoded) => decoded,
+            None => {
+                return SignablePayloadField::TextV2 {
+                    common: SignablePayloadFieldCommon {
+                        fallback_text: "V3 Swap Exact Out: Invalid path".to_string(),
+                        label: "V3 Swap Exact Out".to_string(),
+                    },
+                    text_v2: SignablePayloadFieldTextV2 {
+                        text: format!("Path length: {} bytes (expected 20 + N*23)", path.len()),
+                    },
+                };
+            }
+        };
 
         // Resolve token symbols
         let token_in_symbol = registry
@@ -803,11 +831,18 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.format_token_amount(chain_id, token_in, amount_in_max_u128))
             .unwrap_or_else(|| (amount_in_max.to_string(), token_in_symbol.clone()));
 
-        // Calculate fee percentage
+        // Calculate first-hop fee percentage. For multi-hop paths each hop may use a
+        // different fee tier; we surface the first one and disclose the hop count.
         let fee_pct = fee as f64 / 10000.0;
-        let text = format!(
-            "Swap <={amount_in_max_str} {token_in_symbol} for {amount_out_str} {token_out_symbol} via V3 ({fee_pct}% fee)"
-        );
+        let text = if hops == 1 {
+            format!(
+                "Swap <={amount_in_max_str} {token_in_symbol} for {amount_out_str} {token_out_symbol} via V3 ({fee_pct}% fee)"
+            )
+        } else {
+            format!(
+                "Swap <={amount_in_max_str} {token_in_symbol} for {amount_out_str} {token_out_symbol} via V3 ({hops} hops, first fee {fee_pct}%)"
+            )
+        };
 
         // Create individual parameter fields
         let fields = vec![
@@ -2246,6 +2281,276 @@ mod tests {
                 );
             }
             _ => panic!("Expected TextV2 field"),
+        }
+    }
+
+    // Helper: build a V3 path from an interleaved list of tokens and fees.
+    // tokens.len() must be fees.len() + 1. Encoding: token | fee(u24 big-endian) | token | ...
+    fn build_v3_path(tokens: &[Address], fees: &[u32]) -> Vec<u8> {
+        assert_eq!(tokens.len(), fees.len() + 1);
+        let mut out = Vec::with_capacity(20 + fees.len() * 23);
+        out.extend_from_slice(tokens[0].as_slice());
+        for (i, fee) in fees.iter().enumerate() {
+            let fee_bytes = fee.to_be_bytes();
+            // Take the low 3 bytes as a u24
+            out.extend_from_slice(&fee_bytes[1..4]);
+            out.extend_from_slice(tokens[i + 1].as_slice());
+        }
+        out
+    }
+
+    #[test]
+    fn test_decode_v3_path_single_hop() {
+        let token_in: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0x2222222222222222222222222222222222222222"
+            .parse()
+            .unwrap();
+        let path = build_v3_path(&[token_in, token_out], &[3000]);
+        assert_eq!(path.len(), 43);
+
+        let (in_, out_, fee, hops) =
+            UniversalRouterVisualizer::decode_v3_path(&path).expect("valid single-hop path");
+        assert_eq!(in_, token_in);
+        assert_eq!(out_, token_out);
+        assert_eq!(fee, 3000);
+        assert_eq!(hops, 1);
+    }
+
+    #[test]
+    fn test_decode_v3_path_multi_hop_reads_final_token() {
+        // PRS-229 regression: the output token must be the LAST 20 bytes, not path[23..43].
+        let token_in: Address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .parse()
+            .unwrap();
+        let token_mid: Address = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0xcccccccccccccccccccccccccccccccccccccccc"
+            .parse()
+            .unwrap();
+
+        let path = build_v3_path(&[token_in, token_mid, token_out], &[500, 3000]);
+        // 20 + 2*23 = 66 bytes
+        assert_eq!(path.len(), 66);
+
+        let (in_, out_, fee, hops) =
+            UniversalRouterVisualizer::decode_v3_path(&path).expect("valid two-hop path");
+        assert_eq!(in_, token_in);
+        // Critical: this must be the FINAL token, not the intermediate.
+        assert_eq!(out_, token_out);
+        assert_ne!(out_, token_mid, "regression: must not return intermediate");
+        assert_eq!(fee, 500);
+        assert_eq!(hops, 2);
+    }
+
+    #[test]
+    fn test_decode_v3_path_three_hop() {
+        let t0: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let t1: Address = "0x0000000000000000000000000000000000000002"
+            .parse()
+            .unwrap();
+        let t2: Address = "0x0000000000000000000000000000000000000003"
+            .parse()
+            .unwrap();
+        let t3: Address = "0x0000000000000000000000000000000000000004"
+            .parse()
+            .unwrap();
+        let path = build_v3_path(&[t0, t1, t2, t3], &[100, 500, 10000]);
+        // 20 + 3*23 = 89
+        assert_eq!(path.len(), 89);
+
+        let (in_, out_, fee, hops) =
+            UniversalRouterVisualizer::decode_v3_path(&path).expect("valid three-hop path");
+        assert_eq!(in_, t0);
+        assert_eq!(out_, t3);
+        assert_eq!(fee, 100);
+        assert_eq!(hops, 3);
+    }
+
+    #[test]
+    fn test_decode_v3_path_rejects_malformed_length() {
+        // Too short
+        assert!(UniversalRouterVisualizer::decode_v3_path(&[0u8; 42]).is_none());
+        // 44 bytes: passes the old `>= 43` check but is not 20 + N*23
+        assert!(UniversalRouterVisualizer::decode_v3_path(&[0u8; 44]).is_none());
+        // 65 bytes: between one-hop (43) and two-hop (66), still malformed
+        assert!(UniversalRouterVisualizer::decode_v3_path(&[0u8; 65]).is_none());
+        // 43 bytes: exactly one hop, valid
+        assert!(UniversalRouterVisualizer::decode_v3_path(&[0u8; 43]).is_some());
+        // 66 bytes: exactly two hops, valid
+        assert!(UniversalRouterVisualizer::decode_v3_path(&[0u8; 66]).is_some());
+    }
+
+    #[test]
+    fn test_decode_v3_swap_exact_in_multi_hop_displays_final_token() {
+        // PRS-229 end-to-end: the Output Token subfield must reflect the final token
+        // for a multi-hop V3 path, not the first intermediate.
+        let recipient: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let token_in: Address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .parse()
+            .unwrap();
+        let token_mid: Address = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0xcccccccccccccccccccccccccccccccccccccccc"
+            .parse()
+            .unwrap();
+
+        let path = build_v3_path(&[token_in, token_mid, token_out], &[500, 3000]);
+
+        type V3InTuple = (Address, U256, U256, Bytes, bool);
+        let encoded: Vec<u8> = <V3InTuple as SolValue>::abi_encode_params(&(
+            recipient,
+            U256::from(1_000_000u64),
+            U256::from(900_000u64),
+            Bytes::from(path),
+            true,
+        ));
+
+        let field = UniversalRouterVisualizer::decode_v3_swap_exact_in(&encoded, 1, None);
+
+        match field {
+            SignablePayloadField::PreviewLayout { preview_layout, .. } => {
+                let subtitle = preview_layout
+                    .subtitle
+                    .as_ref()
+                    .expect("subtitle present")
+                    .text
+                    .clone();
+                assert!(
+                    subtitle.contains(&format!("{token_out:?}")),
+                    "subtitle must reference final output token, got: {subtitle}"
+                );
+                assert!(
+                    !subtitle.contains(&format!("{token_mid:?}")),
+                    "subtitle must NOT reference intermediate token, got: {subtitle}"
+                );
+                assert!(
+                    subtitle.contains("2 hops"),
+                    "subtitle should disclose hop count, got: {subtitle}"
+                );
+
+                let expanded = preview_layout.expanded.expect("expanded present");
+                // Find the "Output Token" field.
+                let output_token_text = expanded
+                    .fields
+                    .iter()
+                    .find_map(|f| match &f.signable_payload_field {
+                        SignablePayloadField::TextV2 { common, text_v2 }
+                            if common.label == "Output Token" =>
+                        {
+                            Some(text_v2.text.clone())
+                        }
+                        _ => None,
+                    })
+                    .expect("Output Token field present");
+                assert_eq!(output_token_text, format!("{token_out:?}"));
+                assert_ne!(output_token_text, format!("{token_mid:?}"));
+            }
+            _ => panic!("Expected PreviewLayout for V3 Swap Exact In"),
+        }
+    }
+
+    #[test]
+    fn test_decode_v3_swap_exact_out_multi_hop_displays_final_token() {
+        // PRS-229 end-to-end for the exact-out variant.
+        let recipient: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let token_in: Address = "0xdddddddddddddddddddddddddddddddddddddddd"
+            .parse()
+            .unwrap();
+        let token_mid: Address = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            .parse()
+            .unwrap();
+        let token_out: Address = "0xffffffffffffffffffffffffffffffffffffffff"
+            .parse()
+            .unwrap();
+
+        let path = build_v3_path(&[token_in, token_mid, token_out], &[100, 10000]);
+
+        type V3OutTuple = (Address, U256, U256, Bytes, bool);
+        let encoded: Vec<u8> = <V3OutTuple as SolValue>::abi_encode_params(&(
+            recipient,
+            U256::from(2_000_000u64),
+            U256::from(3_000_000u64),
+            Bytes::from(path),
+            true,
+        ));
+
+        let field = UniversalRouterVisualizer::decode_v3_swap_exact_out(&encoded, 1, None);
+
+        match field {
+            SignablePayloadField::PreviewLayout { preview_layout, .. } => {
+                let subtitle = preview_layout
+                    .subtitle
+                    .as_ref()
+                    .expect("subtitle present")
+                    .text
+                    .clone();
+                assert!(
+                    subtitle.contains(&format!("{token_out:?}")),
+                    "subtitle must reference final output token, got: {subtitle}"
+                );
+                assert!(
+                    !subtitle.contains(&format!("{token_mid:?}")),
+                    "subtitle must NOT reference intermediate token, got: {subtitle}"
+                );
+                assert!(
+                    subtitle.contains("2 hops"),
+                    "subtitle should disclose hop count, got: {subtitle}"
+                );
+
+                let expanded = preview_layout.expanded.expect("expanded present");
+                let output_token_text = expanded
+                    .fields
+                    .iter()
+                    .find_map(|f| match &f.signable_payload_field {
+                        SignablePayloadField::TextV2 { common, text_v2 }
+                            if common.label == "Output Token" =>
+                        {
+                            Some(text_v2.text.clone())
+                        }
+                        _ => None,
+                    })
+                    .expect("Output Token field present");
+                assert_eq!(output_token_text, format!("{token_out:?}"));
+                assert_ne!(output_token_text, format!("{token_mid:?}"));
+            }
+            _ => panic!("Expected PreviewLayout for V3 Swap Exact Out"),
+        }
+    }
+
+    #[test]
+    fn test_decode_v3_swap_exact_in_rejects_malformed_path() {
+        // 44-byte path passes the legacy `>= 43` check but is not a valid V3 path
+        // (not 20 + N*23). Must surface an "Invalid path" error rather than silently
+        // synthesizing addresses from junk bytes.
+        let recipient: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        type V3InTuple = (Address, U256, U256, Bytes, bool);
+        let encoded: Vec<u8> = <V3InTuple as SolValue>::abi_encode_params(&(
+            recipient,
+            U256::from(1u64),
+            U256::from(1u64),
+            Bytes::from(vec![0u8; 44]),
+            true,
+        ));
+
+        let field = UniversalRouterVisualizer::decode_v3_swap_exact_in(&encoded, 1, None);
+        match field {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                assert!(common.fallback_text.contains("Invalid path"));
+                assert!(text_v2.text.contains("44 bytes"));
+            }
+            _ => panic!("Expected TextV2 for malformed path"),
         }
     }
 }

--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -446,7 +446,6 @@ impl UniversalRouterVisualizer {
 
         // Decode V3 path. For multi-hop paths, the output token MUST be read from the
         // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
-        // See PRS-229.
         let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
             Some(decoded) => decoded,
             None => {
@@ -794,7 +793,6 @@ impl UniversalRouterVisualizer {
 
         // Decode V3 path. For multi-hop paths, the output token MUST be read from the
         // FINAL 20 bytes, not from offset 23..43 (which is the first intermediate token).
-        // See PRS-229.
         let (token_in, token_out, fee, hops) = match Self::decode_v3_path(&path) {
             Some(decoded) => decoded,
             None => {
@@ -2320,7 +2318,7 @@ mod tests {
 
     #[test]
     fn test_decode_v3_path_multi_hop_reads_final_token() {
-        // PRS-229 regression: the output token must be the LAST 20 bytes, not path[23..43].
+        // Regression: the output token must be the LAST 20 bytes, not path[23..43].
         let token_in: Address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             .parse()
             .unwrap();
@@ -2387,7 +2385,7 @@ mod tests {
 
     #[test]
     fn test_decode_v3_swap_exact_in_multi_hop_displays_final_token() {
-        // PRS-229 end-to-end: the Output Token subfield must reflect the final token
+        // End-to-end: the Output Token subfield must reflect the final token
         // for a multi-hop V3 path, not the first intermediate.
         let recipient: Address = "0x1111111111111111111111111111111111111111"
             .parse()
@@ -2459,7 +2457,7 @@ mod tests {
 
     #[test]
     fn test_decode_v3_swap_exact_out_multi_hop_displays_final_token() {
-        // PRS-229 end-to-end for the exact-out variant.
+        // End-to-end for the exact-out variant.
         let recipient: Address = "0x1111111111111111111111111111111111111111"
             .parse()
             .unwrap();


### PR DESCRIPTION
## Summary

Universal Router V3 swap decoders were reading the output token from `path[23..43]`, which on multi-hop V3 paths is the first intermediate token, not the destination. Users signing a 2-hop swap saw the middle token displayed as "Output Token", masking the actual asset they were buying.

## What changed

- New `decode_v3_path` helper in `universal_router.rs` parses the V3 path correctly:
  - Encoding is `tokenIn(20) | fee(3) | nextToken(20) | fee(3) | ... | tokenOut(20)`, so a valid N-hop path is `20 + N*23` bytes.
  - Output token is read from the final 20 bytes, never from a fixed offset.
  - Returns `(token_in, token_out, first_hop_fee, hop_count)`.
- Both `decode_v3_swap_exact_in` and `decode_v3_swap_exact_out` use the helper.
- Multi-hop swaps now disclose the hop count and clarify that the surfaced fee is the first hop's (`"... via V3 (2 hops, first fee 0.05%)"`).
- Path-length validation tightened: previously a 44-byte blob passed the legacy `>= 43` check and silently synthesized addresses from junk bytes; it now returns an "Invalid path" error.

## Rollback

Single-file change. Revert this commit on the affected branch; no schema, registry, or proto changes.

## Test plan

- [x] Unit: `decode_v3_path` single-hop, two-hop (regression: output must be final token, not intermediate), three-hop, malformed length rejections.
- [x] End-to-end: `decode_v3_swap_exact_in` and `decode_v3_swap_exact_out` on a 2-hop encoded payload assert that the `Output Token` field and the subtitle reference the final token (not the intermediate) and that the subtitle discloses `"2 hops"`.
- [x] Negative: malformed 44-byte path surfaces an `Invalid path` error instead of garbage addresses.
- [x] `cargo fmt`, `cargo clippy -p visualsign-ethereum --all-targets -- -D warnings`, `cargo test -p visualsign-ethereum` all green locally.
