### PR TITLE
fix(parser_app): invoke validate_charset unconditionally on signing path

### DIFF
--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -12,7 +12,7 @@ use generated::{
 use qos_crypto::sha_256;
 use qos_p256::P256Pair;
 
-use visualsign::registry::Chain as VisualSignRegistryChain;
+use visualsign::registry::{Chain as VisualSignRegistryChain, TransactionConverterRegistry};
 use visualsign::vsptrait::VisualSignOptions;
 
 /// Parses an unsigned transaction payload and returns a signed parsed response.
@@ -24,6 +24,18 @@ use visualsign::vsptrait::VisualSignOptions;
 pub fn parse(
     parse_request: &ParseRequest,
     ephemeral_key: &P256Pair,
+) -> Result<ParseResponse, GrpcError> {
+    let registry = create_registry();
+    parse_with_registry(parse_request, ephemeral_key, &registry)
+}
+
+/// Same as [`parse`] but accepts a caller-provided registry. Exists primarily as
+/// a test seam so unit tests can inject stub converters and exercise the
+/// `parse()` pipeline without depending on the full production registry.
+pub(crate) fn parse_with_registry(
+    parse_request: &ParseRequest,
+    ephemeral_key: &P256Pair,
+    registry: &TransactionConverterRegistry,
 ) -> Result<ParseResponse, GrpcError> {
     let request_payload = parse_request.unsigned_payload.as_str();
     if request_payload.is_empty() {
@@ -39,17 +51,27 @@ pub fn parse(
         metadata: parse_request.chain_metadata.clone(),
         developer_config: None, // Production API: only accept unsigned transactions
     };
-    let registry = create_registry();
     let proto_chain = ProtoChain::from_i32(parse_request.chain)
         .ok_or_else(|| GrpcError::new(Code::InvalidArgument, "invalid chain"))?;
     let registry_chain: VisualSignRegistryChain = chain_conversion::proto_to_registry(proto_chain);
 
-    let signable_payload_str = registry
+    let signable_payload = registry
         .convert_transaction(&registry_chain, request_payload, options)
         .map_err(|e| GrpcError::new(Code::InvalidArgument, &format!("{e}")))?;
 
+    // Defense-in-depth: validate the charset of the SignablePayload unconditionally
+    // on the signing path, regardless of which converter produced it. Per-converter
+    // validation can be skipped by chain-specific overrides of
+    // `to_visual_sign_payload_from_string` (e.g. Ethereum), so we enforce here too.
+    // Caller-supplied metadata (Ethereum `abi_mappings`, Solana `idl_mappings`)
+    // could otherwise smuggle bidi controls or zero-width characters into the
+    // displayed strings.
+    signable_payload
+        .validate_charset()
+        .map_err(|e| GrpcError::new(Code::InvalidArgument, &format!("{e}")))?;
+
     // Convert SignablePayload to String (assuming you want JSON)
-    let parsed_payload_str = serde_json::to_string(&signable_payload_str).map_err(|e| {
+    let parsed_payload_str = serde_json::to_string(&signable_payload).map_err(|e| {
         GrpcError::new(Code::Internal, &format!("Failed to serialize payload: {e}"))
     })?;
 
@@ -94,6 +116,14 @@ mod tests {
     use super::*;
     use generated::parser::{Abi, ChainMetadata, EthereumMetadata, chain_metadata};
     use std::collections::HashMap;
+    use visualsign::vsptrait::{
+        Transaction, TransactionParseError, VisualSignConverter, VisualSignConverterFromString,
+        VisualSignError,
+    };
+    use visualsign::{
+        SignablePayload, SignablePayloadField, SignablePayloadFieldCommon,
+        SignablePayloadFieldTextV2,
+    };
 
     /// Verify that `metadata_digest` is deterministic for identical metadata,
     /// including non-empty `abi_mappings` (exercises `HashMap` key ordering through borsh).
@@ -135,5 +165,211 @@ mod tests {
             sha_256(&bytes_b),
             "metadata_digest must be identical for identical metadata"
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // PRS-230 regression test infrastructure
+    // ----------------------------------------------------------------------
+    //
+    // The fix under test is: `parse_with_registry` must invoke
+    // `SignablePayload::validate_charset` unconditionally on every signing
+    // path, regardless of which converter ran.
+    //
+    // Per-converter validation can be skipped by chain-specific overrides of
+    // `to_visual_sign_payload_from_string` (e.g. Ethereum's override at
+    // `chain_parsers/visualsign-ethereum/src/lib.rs` calls
+    // `to_visual_sign_payload` directly, bypassing the default's
+    // `to_validated_visual_sign_payload`).
+    //
+    // To prove the property holds regardless of converter, the tests below
+    // register a stub converter that intentionally emits a `SignablePayload`
+    // containing a non-ASCII character (U+202E RIGHT-TO-LEFT OVERRIDE) in
+    // its field strings. Without the unconditional check in
+    // `parse_with_registry`, this poisoned payload would be signed verbatim.
+
+    /// Stub transaction whose `from_string` always succeeds; the converter
+    /// decides what payload to emit based on construction args, not on tx data.
+    #[derive(Debug, Clone)]
+    struct StubTransaction;
+
+    impl Transaction for StubTransaction {
+        fn from_string(_data: &str) -> Result<Self, TransactionParseError> {
+            Ok(Self)
+        }
+
+        fn transaction_type(&self) -> String {
+            "Stub".to_string()
+        }
+    }
+
+    /// Stub converter that emits a `SignablePayload` whose label contains
+    /// the configured marker string. Crucially, this converter uses the
+    /// default `to_visual_sign_payload_from_string` impl from
+    /// `VisualSignConverterFromString`, which validates charset. The
+    /// regression test for the bypass case overrides that method below.
+    struct StubConverter {
+        label_text: String,
+    }
+
+    impl VisualSignConverter<StubTransaction> for StubConverter {
+        fn to_visual_sign_payload(
+            &self,
+            _transaction: StubTransaction,
+            _options: VisualSignOptions,
+        ) -> Result<SignablePayload, VisualSignError> {
+            Ok(SignablePayload::new(
+                0,
+                "Stub Transaction".to_string(),
+                None,
+                vec![SignablePayloadField::TextV2 {
+                    common: SignablePayloadFieldCommon {
+                        fallback_text: self.label_text.clone(),
+                        label: self.label_text.clone(),
+                    },
+                    text_v2: SignablePayloadFieldTextV2 {
+                        text: self.label_text.clone(),
+                    },
+                }],
+                "StubTx".to_string(),
+            ))
+        }
+    }
+
+    /// Converter whose `to_visual_sign_payload_from_string` bypasses the
+    /// default's `to_validated_visual_sign_payload` wrapper, mirroring the
+    /// production Ethereum converter's override. This is the discriminating
+    /// surface: without the unconditional check in `parse_with_registry`,
+    /// payloads from this converter would reach signing unvalidated.
+    struct BypassingConverter {
+        label_text: String,
+    }
+
+    impl VisualSignConverter<StubTransaction> for BypassingConverter {
+        fn to_visual_sign_payload(
+            &self,
+            _transaction: StubTransaction,
+            _options: VisualSignOptions,
+        ) -> Result<SignablePayload, VisualSignError> {
+            Ok(SignablePayload::new(
+                0,
+                "Stub Transaction".to_string(),
+                None,
+                vec![SignablePayloadField::TextV2 {
+                    common: SignablePayloadFieldCommon {
+                        fallback_text: self.label_text.clone(),
+                        label: self.label_text.clone(),
+                    },
+                    text_v2: SignablePayloadFieldTextV2 {
+                        text: self.label_text.clone(),
+                    },
+                }],
+                "StubTx".to_string(),
+            ))
+        }
+    }
+
+    impl VisualSignConverterFromString<StubTransaction> for BypassingConverter {
+        fn to_visual_sign_payload_from_string(
+            &self,
+            transaction_data: &str,
+            options: VisualSignOptions,
+        ) -> Result<SignablePayload, VisualSignError> {
+            // NOTE: intentionally calls `to_visual_sign_payload` directly,
+            // skipping `to_validated_visual_sign_payload`. Mirrors the
+            // production Ethereum override.
+            let transaction = StubTransaction::from_string(transaction_data)
+                .map_err(VisualSignError::ParseError)?;
+            self.to_visual_sign_payload(transaction, options)
+        }
+    }
+
+    impl VisualSignConverterFromString<StubTransaction> for StubConverter {}
+
+    /// Builds a request targeting the `Tron` chain slot. We pick `Tron` because
+    /// `chain_conversion::proto_to_registry` maps `ProtoChain::Tron` to
+    /// `RegistryChain::Tron`, which is what we register the stub under.
+    fn stub_request() -> ParseRequest {
+        ParseRequest {
+            unsigned_payload: "stub".to_string(),
+            chain: ProtoChain::Tron as i32,
+            chain_metadata: None,
+        }
+    }
+
+    /// PRS-230 regression: when the converter overrides
+    /// `to_visual_sign_payload_from_string` to bypass charset validation (as
+    /// the production Ethereum converter does), `parse_with_registry` must
+    /// still reject payloads containing non-ASCII characters before signing.
+    #[test]
+    fn parse_rejects_non_ascii_payload_when_converter_skips_validation() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE: a bidi control that flips display
+        // order and is the canonical spoofing primitive.
+        let poisoned = "transfer\u{202E}approve";
+
+        let mut registry = TransactionConverterRegistry::new();
+        registry.register::<StubTransaction, _>(
+            VisualSignRegistryChain::Tron,
+            BypassingConverter {
+                label_text: poisoned.to_string(),
+            },
+        );
+
+        let key = P256Pair::generate().expect("generate ephemeral key");
+        let err = parse_with_registry(&stub_request(), &key, &registry).expect_err(
+            "parse_with_registry must reject payloads whose strings contain \
+             non-ASCII characters, even when the converter skipped its own \
+             charset validation",
+        );
+        assert_eq!(
+            err.code,
+            Code::InvalidArgument,
+            "charset validation failure should map to InvalidArgument, got: {err:?}",
+        );
+    }
+
+    /// Sanity counterpart: a benign ASCII-only payload through the same
+    /// bypassing converter must still sign successfully. Confirms the
+    /// unconditional `validate_charset` call doesn't reject legitimate input.
+    #[test]
+    fn parse_accepts_ascii_payload_when_converter_skips_validation() {
+        let mut registry = TransactionConverterRegistry::new();
+        registry.register::<StubTransaction, _>(
+            VisualSignRegistryChain::Tron,
+            BypassingConverter {
+                label_text: "benign label".to_string(),
+            },
+        );
+
+        let key = P256Pair::generate().expect("generate ephemeral key");
+        let response = parse_with_registry(&stub_request(), &key, &registry).expect(
+            "benign ASCII payload must still parse successfully through a \
+             converter that skipped its own charset validation",
+        );
+        assert!(response.parsed_transaction.is_some());
+    }
+
+    /// PRS-230 regression: the unconditional check also fires for converters
+    /// that use the default `to_visual_sign_payload_from_string` impl. This
+    /// is double-validation by design (belt and suspenders), and verifying
+    /// it here guards against any future refactor that removes the default's
+    /// own validation call.
+    #[test]
+    fn parse_rejects_non_ascii_payload_via_default_converter_path() {
+        let poisoned = "transfer\u{202E}approve";
+
+        let mut registry = TransactionConverterRegistry::new();
+        registry.register::<StubTransaction, _>(
+            VisualSignRegistryChain::Tron,
+            StubConverter {
+                label_text: poisoned.to_string(),
+            },
+        );
+
+        let key = P256Pair::generate().expect("generate ephemeral key");
+        let err = parse_with_registry(&stub_request(), &key, &registry).expect_err(
+            "parse_with_registry must reject non-ASCII payloads even when the \
+             converter validates internally",
+        );
+        assert_eq!(err.code, Code::InvalidArgument);
     }
 }

--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -176,7 +176,7 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
-    // PRS-230 regression test infrastructure
+    // Charset-bypass regression test infrastructure
     // ----------------------------------------------------------------------
     //
     // The fix under test is: `parse_with_registry` must invoke
@@ -320,7 +320,7 @@ mod tests {
         }
     }
 
-    /// PRS-230 regression: when the converter overrides
+    /// Regression: when the converter overrides
     /// `to_visual_sign_payload_from_string` to bypass charset validation (as
     /// the production Ethereum converter does), `parse_with_registry` must
     /// still reject payloads containing non-ASCII characters before signing.
@@ -372,7 +372,7 @@ mod tests {
         assert!(response.parsed_transaction.is_some());
     }
 
-    /// PRS-230 regression: covers a second bypass surface. `StubConverter`
+    /// Regression: covers a second bypass surface. `StubConverter`
     /// uses the default `to_visual_sign_payload_from_string` impl but
     /// overrides `to_validated_visual_sign_payload` to skip the inner
     /// `validate_charset` call. Without the unconditional check in

--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -127,7 +127,6 @@ mod tests {
     use std::collections::HashMap;
     use visualsign::vsptrait::{
         Transaction, TransactionParseError, VisualSignConverter, VisualSignConverterFromString,
-        VisualSignError,
     };
     use visualsign::{
         SignablePayload, SignablePayloadField, SignablePayloadFieldCommon,
@@ -396,7 +395,7 @@ mod tests {
         let key = P256Pair::generate().expect("generate ephemeral key");
         let err = parse_with_registry(&stub_request(), &key, &registry).expect_err(
             "parse_with_registry must reject non-ASCII payloads even when the \
-             converter validates internally",
+             converter skips its inner validate_charset call",
         );
         assert_eq!(err.code, Code::InvalidArgument);
     }

--- a/src/parser/app/src/routes/parse.rs
+++ b/src/parser/app/src/routes/parse.rs
@@ -12,6 +12,7 @@ use generated::{
 use qos_crypto::sha_256;
 use qos_p256::P256Pair;
 
+use visualsign::errors::VisualSignError;
 use visualsign::registry::{Chain as VisualSignRegistryChain, TransactionConverterRegistry};
 use visualsign::vsptrait::VisualSignOptions;
 
@@ -66,9 +67,17 @@ pub(crate) fn parse_with_registry(
     // Caller-supplied metadata (Ethereum `abi_mappings`, Solana `idl_mappings`)
     // could otherwise smuggle bidi controls or zero-width characters into the
     // displayed strings.
-    signable_payload
-        .validate_charset()
-        .map_err(|e| GrpcError::new(Code::InvalidArgument, &format!("{e}")))?;
+    //
+    // `validate_charset` may also return non-validation errors (e.g.
+    // `SerializationError` if internal JSON serialization fails). Those are
+    // server-side bugs, not client input problems, so map them to `Internal`
+    // and reserve `InvalidArgument` for genuine validation rejections.
+    signable_payload.validate_charset().map_err(|e| match e {
+        VisualSignError::ValidationError(_) => {
+            GrpcError::new(Code::InvalidArgument, &format!("{e}"))
+        }
+        _ => GrpcError::new(Code::Internal, &format!("{e}")),
+    })?;
 
     // Convert SignablePayload to String (assuming you want JSON)
     let parsed_payload_str = serde_json::to_string(&signable_payload).map_err(|e| {
@@ -203,10 +212,14 @@ mod tests {
     }
 
     /// Stub converter that emits a `SignablePayload` whose label contains
-    /// the configured marker string. Crucially, this converter uses the
-    /// default `to_visual_sign_payload_from_string` impl from
-    /// `VisualSignConverterFromString`, which validates charset. The
-    /// regression test for the bypass case overrides that method below.
+    /// the configured marker string. Uses the default
+    /// `to_visual_sign_payload_from_string` impl (so the default
+    /// `VisualSignConverterFromString` path is exercised) but overrides
+    /// `to_validated_visual_sign_payload` below to skip its inner
+    /// `validate_charset` call. This is a different bypass surface than
+    /// `BypassingConverter`, which overrides `to_visual_sign_payload_from_string`
+    /// itself, and makes the regression test fail closed if the unconditional
+    /// check in `parse_with_registry` is removed.
     struct StubConverter {
         label_text: String,
     }
@@ -232,6 +245,18 @@ mod tests {
                 }],
                 "StubTx".to_string(),
             ))
+        }
+
+        /// Intentionally skips the default's `validate_charset()` call so the
+        /// default `to_visual_sign_payload_from_string` path delivers an
+        /// unvalidated payload to `parse_with_registry`. Without the
+        /// unconditional check there, the poisoned payload would reach signing.
+        fn to_validated_visual_sign_payload(
+            &self,
+            transaction: StubTransaction,
+            options: VisualSignOptions,
+        ) -> Result<SignablePayload, VisualSignError> {
+            self.to_visual_sign_payload(transaction, options)
         }
     }
 
@@ -348,11 +373,14 @@ mod tests {
         assert!(response.parsed_transaction.is_some());
     }
 
-    /// PRS-230 regression: the unconditional check also fires for converters
-    /// that use the default `to_visual_sign_payload_from_string` impl. This
-    /// is double-validation by design (belt and suspenders), and verifying
-    /// it here guards against any future refactor that removes the default's
-    /// own validation call.
+    /// PRS-230 regression: covers a second bypass surface. `StubConverter`
+    /// uses the default `to_visual_sign_payload_from_string` impl but
+    /// overrides `to_validated_visual_sign_payload` to skip the inner
+    /// `validate_charset` call. Without the unconditional check in
+    /// `parse_with_registry`, the poisoned payload would reach signing
+    /// through this path. Pairs with the `BypassingConverter` test, which
+    /// covers the other bypass surface (overriding
+    /// `to_visual_sign_payload_from_string` itself).
     #[test]
     fn parse_rejects_non_ascii_payload_via_default_converter_path() {
         let poisoned = "transfer\u{202E}approve";


### PR DESCRIPTION
## Summary

Strings drawn from caller-supplied metadata (Ethereum `abi_mappings`, Solana `idl_mappings`) flow into displayed `label` / `title` / `text` fields of the `SignablePayload`. `SignablePayload::validate_charset` existed but was only invoked inside `to_validated_visual_sign_payload`, which chain-specific converters can (and do) bypass. The production Ethereum converter overrides `to_visual_sign_payload_from_string` to call `to_visual_sign_payload` directly, leaving the charset unchecked on that path.

Result: a function name like `transfer\u{202E}approve` (right-to-left override) reaches the signed payload verbatim and renders backwards in the wallet, masking attacker intent.

## What changed

- `src/parser/app/src/routes/parse.rs`: `parse()` now calls `signable_payload.validate_charset()` unconditionally after `convert_transaction(...)` and before JSON serialization. Failures map to `Code::InvalidArgument`.
- Extracted a `parse_with_registry(...)` test seam so unit tests can inject a stub converter without depending on the production registry.
- Added 3 regression tests:
  - `parse_rejects_non_ascii_payload_when_converter_skips_validation` — the load-bearing one. Uses a stub converter that mirrors Ethereum's override (skips the default's `to_validated_visual_sign_payload` wrapper). Proves the unconditional check in `parse()` catches U+202E even when the converter doesn't validate.
  - `parse_rejects_non_ascii_payload_via_default_converter_path` — same poisoned input through the default-validating converter. Belt-and-suspenders: guards against a future refactor removing the default's own validation.
  - `parse_accepts_ascii_payload_when_converter_skips_validation` — benign input still parses. Confirms the new check doesn't reject legitimate payloads.

This is defense in depth: the existing per-converter validation stays, the new check guarantees the property holds at the signing boundary regardless of converter choice.

## Rollback

Revert this commit. No persisted state, no API surface changes (the `parse_with_registry` helper is `pub(crate)`), no protobuf changes. Safe rollback.

## Backwards compatibility

No breaking changes. The public `parse(...)` signature is unchanged. The validation only adds rejection of payloads that contain non-ASCII characters in displayed strings, which was already the intent of `validate_charset`; this PR ensures it's actually enforced on every code path.

## Test plan

- [x] `cd src && cargo fmt -- --check` clean
- [x] `cargo clippy -p parser_app --all-targets -- -D warnings` clean
- [x] `cargo clippy -p visualsign --all-targets -- -D warnings` clean
- [x] `cargo test -p parser_app` — 5/5 passing (3 new regression tests + 2 existing)
- [x] `cargo test -p visualsign` — 48/48 passing, doc-tests 3/3 passing
