### PR TITLE
fix(ethereum): stop silently truncating Universal Router U256 amounts to zero

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -2879,4 +2879,52 @@ mod tests {
             _ => panic!("Expected TextV2 field"),
         }
     }
+
+    /// Regression: a PAY_PORTION with `bips` greater than `u128::MAX` must not
+    /// silently render as "0%". `bips` is a `uint256` on-chain, so an adversarial
+    /// value above `u128::MAX` must surface as a raw figure rather than a
+    /// percentage that would tell the signer they are paying out nothing.
+    #[test]
+    fn test_decode_pay_portion_bips_above_u128_max_is_not_zero() {
+        let token: Address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        // u128::MAX + 1: the smallest U256 the old u128 conversion could not represent.
+        let bips = U256::from(u128::MAX) + U256::from(1u64);
+
+        let encoded = (token, recipient, bips).abi_encode();
+        let field = UniversalRouterVisualizer::decode_pay_portion(&encoded, 1, None);
+
+        match field {
+            SignablePayloadField::PreviewLayout { preview_layout, .. } => {
+                let percentage = preview_layout
+                    .expanded
+                    .expect("expanded present")
+                    .fields
+                    .iter()
+                    .find_map(|f| match &f.signable_payload_field {
+                        SignablePayloadField::TextV2 { common, text_v2 }
+                            if common.label == "Percentage" =>
+                        {
+                            Some(text_v2.text.clone())
+                        }
+                        _ => None,
+                    })
+                    .expect("Percentage field present");
+                // The bug: "0%" / "0.0000%". The fix must surface the raw bips value.
+                assert!(
+                    !percentage.starts_with('0'),
+                    "bips above u128::MAX rendered as a near-zero percentage: {percentage}"
+                );
+                assert!(
+                    percentage.contains("bips (raw)"),
+                    "oversized bips must surface as a raw figure, got: {percentage}"
+                );
+            }
+            _ => panic!("Expected PreviewLayout for Pay Portion"),
+        }
+    }
 }

--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -518,7 +518,7 @@ impl UniversalRouterVisualizer {
             .unwrap_or_else(|| format!("{token_out:?}"));
 
         // Format amounts directly from U256 so values above u128::MAX are surfaced
-        // accurately instead of silently truncated to "0". See PRS-234.
+        // accurately instead of silently truncated to "0".
         let (amount_in_str, _) = registry
             .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in))
             .unwrap_or_else(|| (amount_in.to_string(), token_in_symbol.clone()));
@@ -653,7 +653,7 @@ impl UniversalRouterVisualizer {
         // Convert bips to percentage (10000 bips = 100%).
         // Bips realistically fits in u128 (Uniswap caps at 10_000), but the on-chain
         // type is uint256, so we must surface oversized values rather than silently
-        // displaying "0%" for a transfer that pays out the entire balance. See PRS-234.
+        // displaying "0%" for a transfer that pays out the entire balance.
         let percentage_str = match u128::try_from(params.bips) {
             Ok(bips_value) => {
                 let bips_pct = (bips_value as f64) / 100.0;
@@ -754,7 +754,7 @@ impl UniversalRouterVisualizer {
         // Get WETH address for this chain and format the amount.
         // WETH is registered in the token registry via UniswapConfig::register_common_tokens.
         // Format directly from U256 so values above u128::MAX surface accurately
-        // instead of being silently truncated to "0". See PRS-234.
+        // instead of being silently truncated to "0".
         let amount_min_str =
             crate::protocols::uniswap::config::UniswapConfig::weth_address(chain_id)
                 .and_then(|weth_addr| {
@@ -877,7 +877,7 @@ impl UniversalRouterVisualizer {
             .unwrap_or_else(|| format!("{token_out:?}"));
 
         // Format amounts directly from U256 so values above u128::MAX are surfaced
-        // accurately instead of silently truncated to "0". See PRS-234.
+        // accurately instead of silently truncated to "0".
         let (amount_out_str, _) = registry
             .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out))
             .unwrap_or_else(|| (amount_out.to_string(), token_out_symbol.clone()));
@@ -1042,7 +1042,7 @@ impl UniversalRouterVisualizer {
             .unwrap_or_else(|| format!("{token_out:?}"));
 
         // Format amounts directly from U256 so values above u128::MAX are surfaced
-        // accurately instead of silently truncated to "0". See PRS-234.
+        // accurately instead of silently truncated to "0".
         let (amount_in_str, _) = registry
             .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in))
             .unwrap_or_else(|| (amount_in.to_string(), token_in_symbol.clone()));
@@ -1198,7 +1198,7 @@ impl UniversalRouterVisualizer {
             .unwrap_or_else(|| format!("{token_out:?}"));
 
         // Format amounts directly from U256 so values above u128::MAX are surfaced
-        // accurately instead of silently truncated to "0". See PRS-234.
+        // accurately instead of silently truncated to "0".
         let (amount_out_str, _) = registry
             .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out))
             .unwrap_or_else(|| (amount_out.to_string(), token_out_symbol.clone()));
@@ -1323,7 +1323,7 @@ impl UniversalRouterVisualizer {
         // Format amount with ETH decimals (18).
         // Get WETH address for this chain to use its decimals. Format directly from
         // U256 so values above u128::MAX surface accurately instead of being silently
-        // truncated to "0". See PRS-234.
+        // truncated to "0".
         let amount_min_str =
             crate::protocols::uniswap::config::UniswapConfig::weth_address(chain_id)
                 .and_then(|weth_addr| {
@@ -1375,7 +1375,6 @@ impl UniversalRouterVisualizer {
 
         // Format amount with token decimals directly from U256 so values above
         // u128::MAX are surfaced accurately instead of silently truncated to "0".
-        // See PRS-234.
         let (amount_min_str, _) = registry
             .and_then(|r| r.format_token_amount_u256(chain_id, params.token, params.amountMinimum))
             .unwrap_or_else(|| (params.amountMinimum.to_string(), token_symbol.clone()));
@@ -2810,7 +2809,7 @@ mod tests {
         }
     }
 
-    /// PRS-234 regression: a SWEEP with an `amountMinimum` greater than `u128::MAX`
+    /// Regression: a SWEEP with an `amountMinimum` greater than `u128::MAX`
     /// must not display as "0".
     ///
     /// The previous implementation did
@@ -2853,7 +2852,7 @@ mod tests {
         }
     }
 
-    /// PRS-234 regression: a WRAP_ETH with an `amountMin` greater than `u128::MAX`
+    /// Regression: a WRAP_ETH with an `amountMin` greater than `u128::MAX`
     /// must not display as "0".
     #[test]
     fn test_decode_wrap_eth_amount_above_u128_max_is_not_zero() {

--- a/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/protocols/uniswap/contracts/universal_router.rs
@@ -517,16 +517,14 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, token_out))
             .unwrap_or_else(|| format!("{token_out:?}"));
 
-        // Format amounts
-        let amount_in_u128: u128 = amount_in.to_string().parse().unwrap_or(0);
-        let amount_out_min_u128: u128 = amount_out_min.to_string().parse().unwrap_or(0);
-
+        // Format amounts directly from U256 so values above u128::MAX are surfaced
+        // accurately instead of silently truncated to "0". See PRS-234.
         let (amount_in_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_in, amount_in_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in))
             .unwrap_or_else(|| (amount_in.to_string(), token_in_symbol.clone()));
 
         let (amount_out_min_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_out, amount_out_min_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out_min))
             .unwrap_or_else(|| (amount_out_min.to_string(), token_out_symbol.clone()));
 
         // Calculate first-hop fee percentage. For multi-hop paths each hop may use a
@@ -652,13 +650,20 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, params.token))
             .unwrap_or_else(|| format!("{:?}", params.token));
 
-        // Convert bips to percentage (10000 bips = 100%)
-        let bips_value: u128 = params.bips.to_string().parse().unwrap_or(0);
-        let bips_pct = (bips_value as f64) / 100.0;
-        let percentage_str = if bips_pct >= 1.0 {
-            format!("{bips_pct:.2}%")
-        } else {
-            format!("{bips_pct:.4}%")
+        // Convert bips to percentage (10000 bips = 100%).
+        // Bips realistically fits in u128 (Uniswap caps at 10_000), but the on-chain
+        // type is uint256, so we must surface oversized values rather than silently
+        // displaying "0%" for a transfer that pays out the entire balance. See PRS-234.
+        let percentage_str = match u128::try_from(params.bips) {
+            Ok(bips_value) => {
+                let bips_pct = (bips_value as f64) / 100.0;
+                if bips_pct >= 1.0 {
+                    format!("{bips_pct:.2}%")
+                } else {
+                    format!("{bips_pct:.4}%")
+                }
+            }
+            Err(_) => format!("{} bips (raw)", params.bips),
         };
 
         // Create individual parameter fields
@@ -746,15 +751,16 @@ impl UniversalRouterVisualizer {
             }
         };
 
-        // Get WETH address for this chain and format the amount
-        // WETH is registered in the token registry via UniswapConfig::register_common_tokens
+        // Get WETH address for this chain and format the amount.
+        // WETH is registered in the token registry via UniswapConfig::register_common_tokens.
+        // Format directly from U256 so values above u128::MAX surface accurately
+        // instead of being silently truncated to "0". See PRS-234.
         let amount_min_str =
             crate::protocols::uniswap::config::UniswapConfig::weth_address(chain_id)
                 .and_then(|weth_addr| {
-                    let amount_min_u128: u128 =
-                        params.amountMinimum.to_string().parse().unwrap_or(0);
-                    registry
-                        .and_then(|r| r.format_token_amount(chain_id, weth_addr, amount_min_u128))
+                    registry.and_then(|r| {
+                        r.format_token_amount_u256(chain_id, weth_addr, params.amountMinimum)
+                    })
                 })
                 .map(|(amt, _)| amt)
                 .unwrap_or_else(|| params.amountMinimum.to_string());
@@ -870,17 +876,14 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, token_out))
             .unwrap_or_else(|| format!("{token_out:?}"));
 
-        // Convert amounts to u128 for formatting
-        let amount_out_u128: u128 = amount_out.to_string().parse().unwrap_or(0);
-        let amount_in_max_u128: u128 = amount_in_max.to_string().parse().unwrap_or(0);
-
-        // Format amounts with token decimals
+        // Format amounts directly from U256 so values above u128::MAX are surfaced
+        // accurately instead of silently truncated to "0". See PRS-234.
         let (amount_out_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_out, amount_out_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out))
             .unwrap_or_else(|| (amount_out.to_string(), token_out_symbol.clone()));
 
         let (amount_in_max_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_in, amount_in_max_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in_max))
             .unwrap_or_else(|| (amount_in_max.to_string(), token_in_symbol.clone()));
 
         // Calculate first-hop fee percentage. For multi-hop paths each hop may use a
@@ -1038,15 +1041,14 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, token_out))
             .unwrap_or_else(|| format!("{token_out:?}"));
 
-        let amount_in_u128: u128 = amount_in.to_string().parse().unwrap_or(0);
-        let amount_out_min_u128: u128 = amount_out_minimum.to_string().parse().unwrap_or(0);
-
+        // Format amounts directly from U256 so values above u128::MAX are surfaced
+        // accurately instead of silently truncated to "0". See PRS-234.
         let (amount_in_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_in, amount_in_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in))
             .unwrap_or_else(|| (amount_in.to_string(), token_in_symbol.clone()));
 
         let (amount_out_min_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_out, amount_out_min_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out_minimum))
             .unwrap_or_else(|| (amount_out_minimum.to_string(), token_out_symbol.clone()));
 
         let hops = path.len() - 1;
@@ -1195,15 +1197,14 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, token_out))
             .unwrap_or_else(|| format!("{token_out:?}"));
 
-        let amount_out_u128: u128 = amount_out.to_string().parse().unwrap_or(0);
-        let amount_in_max_u128: u128 = amount_in_maximum.to_string().parse().unwrap_or(0);
-
+        // Format amounts directly from U256 so values above u128::MAX are surfaced
+        // accurately instead of silently truncated to "0". See PRS-234.
         let (amount_out_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_out, amount_out_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_out, amount_out))
             .unwrap_or_else(|| (amount_out.to_string(), token_out_symbol.clone()));
 
         let (amount_in_max_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, token_in, amount_in_max_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, token_in, amount_in_maximum))
             .unwrap_or_else(|| (amount_in_maximum.to_string(), token_in_symbol.clone()));
 
         let hops = path.len() - 1;
@@ -1319,14 +1320,16 @@ impl UniversalRouterVisualizer {
             }
         };
 
-        // Format amount with ETH decimals (18)
-        // Get WETH address for this chain to use its decimals
+        // Format amount with ETH decimals (18).
+        // Get WETH address for this chain to use its decimals. Format directly from
+        // U256 so values above u128::MAX surface accurately instead of being silently
+        // truncated to "0". See PRS-234.
         let amount_min_str =
             crate::protocols::uniswap::config::UniswapConfig::weth_address(chain_id)
                 .and_then(|weth_addr| {
-                    let amount_min_u128: u128 = params.amountMin.to_string().parse().unwrap_or(0);
-                    registry
-                        .and_then(|r| r.format_token_amount(chain_id, weth_addr, amount_min_u128))
+                    registry.and_then(|r| {
+                        r.format_token_amount_u256(chain_id, weth_addr, params.amountMin)
+                    })
                 })
                 .map(|(amt, _)| amt)
                 .unwrap_or_else(|| {
@@ -1370,10 +1373,11 @@ impl UniversalRouterVisualizer {
             .and_then(|r| r.get_token_symbol(chain_id, params.token))
             .unwrap_or_else(|| format!("{:?}", params.token));
 
-        // Format amount with token decimals
-        let amount_min_u128: u128 = params.amountMinimum.to_string().parse().unwrap_or(0);
+        // Format amount with token decimals directly from U256 so values above
+        // u128::MAX are surfaced accurately instead of silently truncated to "0".
+        // See PRS-234.
         let (amount_min_str, _) = registry
-            .and_then(|r| r.format_token_amount(chain_id, params.token, amount_min_u128))
+            .and_then(|r| r.format_token_amount_u256(chain_id, params.token, params.amountMinimum))
             .unwrap_or_else(|| (params.amountMinimum.to_string(), token_symbol.clone()));
 
         let text = format!(
@@ -2803,6 +2807,77 @@ mod tests {
                 assert!(text_v2.text.contains("44 bytes"));
             }
             _ => panic!("Expected TextV2 for malformed path"),
+        }
+    }
+
+    /// PRS-234 regression: a SWEEP with an `amountMinimum` greater than `u128::MAX`
+    /// must not display as "0".
+    ///
+    /// The previous implementation did
+    /// `params.amountMinimum.to_string().parse::<u128>().unwrap_or(0)`, so any
+    /// adversarially-large amount became "0" and the wallet would happily show
+    /// "Sweep >=0 WETH ...". This test fails on the old code, passes on the fix.
+    #[test]
+    fn test_decode_sweep_amount_above_u128_max_is_not_zero() {
+        let (registry, _) = crate::registry::ContractRegistry::with_default_protocols();
+
+        // WETH on mainnet, present in the default registry with 18 decimals.
+        let token: Address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        // u128::MAX + 1, the smallest U256 that the old u128 parse path could not represent.
+        let amount_min = U256::from(u128::MAX) + U256::from(1u64);
+
+        let encoded = (token, recipient, amount_min).abi_encode();
+        let field = UniversalRouterVisualizer::decode_sweep(&encoded, 1, Some(&registry));
+
+        match field {
+            SignablePayloadField::TextV2 { text_v2, .. } => {
+                // The bug: ">=0 WETH". The fix must surface the real (huge) amount.
+                assert!(
+                    !text_v2.text.contains(">=0 WETH")
+                        && !text_v2.text.contains(">=0.000000000000000000 WETH"),
+                    "Amount above u128::MAX rendered as zero: {}",
+                    text_v2.text
+                );
+                assert!(
+                    text_v2.text.contains("WETH"),
+                    "Expected WETH symbol, got: {}",
+                    text_v2.text
+                );
+            }
+            _ => panic!("Expected TextV2 field"),
+        }
+    }
+
+    /// PRS-234 regression: a WRAP_ETH with an `amountMin` greater than `u128::MAX`
+    /// must not display as "0".
+    #[test]
+    fn test_decode_wrap_eth_amount_above_u128_max_is_not_zero() {
+        let (registry, _) = crate::registry::ContractRegistry::with_default_protocols();
+
+        let recipient: Address = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let amount_min = U256::from(u128::MAX) + U256::from(1u64);
+
+        let encoded = (recipient, amount_min).abi_encode();
+        let field = UniversalRouterVisualizer::decode_wrap_eth(&encoded, 1, Some(&registry));
+
+        match field {
+            SignablePayloadField::TextV2 { text_v2, .. } => {
+                // The bug: "Wrap >=0 ETH to WETH".
+                assert!(
+                    !text_v2.text.contains(">=0 ETH")
+                        && !text_v2.text.contains(">=0.000000000000000000 ETH"),
+                    "Amount above u128::MAX rendered as zero: {}",
+                    text_v2.text
+                );
+            }
+            _ => panic!("Expected TextV2 field"),
         }
     }
 }

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -1,5 +1,5 @@
 use crate::token_metadata::{ChainMetadata, TokenMetadata, parse_network_id};
-use alloy_primitives::{Address, utils::format_units};
+use alloy_primitives::{Address, U256, utils::format_units};
 use std::collections::BTreeMap;
 
 /// Type alias for chain ID to avoid depending on external chain types
@@ -364,6 +364,37 @@ impl ContractRegistry {
         Some((formatted, metadata.symbol.clone()))
     }
 
+    /// Formats a raw `U256` token amount with the proper number of decimal places.
+    ///
+    /// This is the U256-aware counterpart of [`format_token_amount`]. It exists because
+    /// on-chain integer types in Solidity are typically `uint256`, and silently
+    /// truncating them to `u128` (as a previous version of this code did via
+    /// `value.to_string().parse::<u128>().unwrap_or(0)`) can render a transfer that
+    /// moves billions of tokens as the string "0", hiding the real amount the user
+    /// is about to sign.
+    ///
+    /// # Arguments
+    /// * `chain_id` - The chain ID
+    /// * `token` - The token's contract address
+    /// * `raw_amount` - The raw amount as a `U256` in the token's smallest units
+    ///
+    /// # Returns
+    /// `Some((formatted_amount, symbol))` if the token is registered and formatting succeeds.
+    /// `None` if the token is not registered or `format_units` rejects the decimals.
+    pub fn format_token_amount_u256(
+        &self,
+        chain_id: ChainId,
+        token: Address,
+        raw_amount: U256,
+    ) -> Option<(String, String)> {
+        let metadata = self.token_metadata.get(&(chain_id, token))?;
+
+        // Use Alloy's format_units, which accepts U256 directly (via Into<ParseUnits>).
+        let formatted = format_units(raw_amount, metadata.decimals).ok()?;
+
+        Some((formatted, metadata.symbol.clone()))
+    }
+
     /// Loads token metadata from wallet ChainMetadata structure
     ///
     /// This method parses network_id to determine the chain ID and registers
@@ -579,6 +610,90 @@ mod tests {
         // Test: 0 USDC
         let result = registry.format_token_amount(1, usdc_address(), 0);
         assert_eq!(result, Some(("0.000000".to_string(), "USDC".to_string())));
+    }
+
+    /// PRS-234 regression: values larger than u128::MAX must not silently render as "0".
+    ///
+    /// The previous implementation in `universal_router.rs` did
+    /// `value.to_string().parse::<u128>().unwrap_or(0)`, which would turn any U256
+    /// above `u128::MAX` into the string "0". `format_token_amount_u256` formats
+    /// directly from U256 and must surface the true amount.
+    #[test]
+    fn test_format_token_amount_u256_above_u128_max_is_not_zero() {
+        let mut registry = ContractRegistry::new();
+        let usdc = create_token_metadata(
+            "USDC",
+            "USD Coin",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            6,
+        );
+        registry.register_token(1, usdc).unwrap();
+
+        // u128::MAX + 1, well above what the old u128 parse path could represent.
+        let above_u128 = U256::from(u128::MAX) + U256::from(1u64);
+        let (amount_str, symbol) = registry
+            .format_token_amount_u256(1, usdc_address(), above_u128)
+            .expect("registered token should format");
+
+        assert_eq!(symbol, "USDC");
+        // The bug rendered this as "0.000000". The fix must render the real value.
+        assert_ne!(amount_str, "0.000000");
+        assert_ne!(amount_str, "0");
+        assert!(
+            !amount_str.starts_with("0."),
+            "amount above u128::MAX rendered as fractional zero: {amount_str}"
+        );
+
+        // Sanity: confirm the exact rendering matches what format_units produces
+        // for (u128::MAX + 1) with 6 decimals.
+        let expected = format_units(above_u128, 6).expect("format_units U256");
+        assert_eq!(amount_str, expected);
+    }
+
+    /// PRS-234 regression: U256::MAX must not silently render as "0" either.
+    #[test]
+    fn test_format_token_amount_u256_max_is_not_zero() {
+        let mut registry = ContractRegistry::new();
+        let weth = create_token_metadata(
+            "WETH",
+            "Wrapped Ether",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            18,
+        );
+        registry.register_token(1, weth).unwrap();
+
+        let (amount_str, symbol) = registry
+            .format_token_amount_u256(1, weth_address(), U256::MAX)
+            .expect("registered token should format");
+
+        assert_eq!(symbol, "WETH");
+        assert_ne!(amount_str, "0.000000000000000000");
+        assert_ne!(amount_str, "0");
+        assert!(
+            !amount_str.starts_with("0."),
+            "U256::MAX rendered as fractional zero: {amount_str}"
+        );
+    }
+
+    /// PRS-234 regression: the U256-aware formatter must agree with the u128 path
+    /// for values that fit in u128, so we don't introduce a behavioural difference
+    /// on the happy path.
+    #[test]
+    fn test_format_token_amount_u256_matches_u128_in_range() {
+        let mut registry = ContractRegistry::new();
+        let usdc = create_token_metadata(
+            "USDC",
+            "USD Coin",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            6,
+        );
+        registry.register_token(1, usdc).unwrap();
+
+        let raw_u128: u128 = 1_500_000;
+        let u128_result = registry.format_token_amount(1, usdc_address(), raw_u128);
+        let u256_result =
+            registry.format_token_amount_u256(1, usdc_address(), U256::from(raw_u128));
+        assert_eq!(u128_result, u256_result);
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -612,7 +612,7 @@ mod tests {
         assert_eq!(result, Some(("0.000000".to_string(), "USDC".to_string())));
     }
 
-    /// PRS-234 regression: values larger than u128::MAX must not silently render as "0".
+    /// Regression: values larger than u128::MAX must not silently render as "0".
     ///
     /// The previous implementation in `universal_router.rs` did
     /// `value.to_string().parse::<u128>().unwrap_or(0)`, which would turn any U256
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(amount_str, expected);
     }
 
-    /// PRS-234 regression: U256::MAX must not silently render as "0" either.
+    /// Regression: U256::MAX must not silently render as "0" either.
     #[test]
     fn test_format_token_amount_u256_max_is_not_zero() {
         let mut registry = ContractRegistry::new();
@@ -675,7 +675,7 @@ mod tests {
         );
     }
 
-    /// PRS-234 regression: the U256-aware formatter must agree with the u128 path
+    /// Regression: the U256-aware formatter must agree with the u128 path
     /// for values that fit in u128, so we don't introduce a behavioural difference
     /// on the happy path.
     #[test]


### PR DESCRIPTION
## Summary

The Universal Router visualizer was running every on-chain `uint256` amount through `value.to_string().parse::<u128>().unwrap_or(0)` before handing it to `format_units`. Any value above `u128::MAX` was therefore rendered as `0` in the signing payload, hiding the real amount the user was about to authorise. A malicious frontend can craft an `amountMinimum` above `2^128` to make a SWEEP, WRAP_ETH, or V2/V3 swap look like "Sweep >=0 WETH ..." while actually emptying the account.

## What changed

- Added `ContractRegistry::format_token_amount_u256`, the U256-native counterpart of `format_token_amount`, which calls `alloy_primitives::utils::format_units` directly on the U256.
- Replaced every `u128 = value.to_string().parse().unwrap_or(0)` site in `universal_router.rs` (`decode_sweep`, `decode_wrap_eth`, `decode_unwrap_weth`, V2/V3 exact-in and exact-out swaps, `decode_pay_portion`) with the new U256 path.
- Replaced the bips `unwrap_or(0)` with `u128::try_from`. In range it formats as a percentage like today, out of range it now renders as `<raw> bips (raw)` instead of "0%". Bips realistically fit in `u128`, but the on-chain type is `uint256`, so out-of-range values must surface, not silently zero.
- Regression tests:
  - `registry::tests::test_format_token_amount_u256_above_u128_max_is_not_zero` (u128::MAX + 1)
  - `registry::tests::test_format_token_amount_u256_max_is_not_zero` (U256::MAX)
  - `registry::tests::test_format_token_amount_u256_matches_u128_in_range` (parity with the u128 path)
  - `universal_router::tests::test_decode_sweep_amount_above_u128_max_is_not_zero`
  - `universal_router::tests::test_decode_wrap_eth_amount_above_u128_max_is_not_zero`

Scope is Universal Router only, matching the ticket. `permit2.rs` and the DECODER_GUIDE.md still teach/use the old `unwrap_or(0)` pattern and should be cleaned up in follow-ups.

## Rollback

Revert this commit. No data or schema changes, no protobuf regeneration, no migrations. The new `format_token_amount_u256` method is additive and would simply become unused; the call sites in `universal_router.rs` revert to their previous string-parse-truncate behaviour.

## Test plan

- [x] `cargo fmt --check -p visualsign-ethereum` clean
- [x] `cargo clippy -p visualsign-ethereum --all-targets -- -D warnings` clean
- [x] `cargo test -p visualsign-ethereum` (204 unit + 4 lib + 3 doc tests pass, including the 5 new U256 truncation regressions)
- [ ] Manual: parse a Universal Router calldata that uses an `amountMinimum > u128::MAX` and confirm the rendered field shows the real amount, not "0".
