### PR TITLE
fix(grpc-server): refuse to start without explicit EPHEMERAL_FILE

### DIFF
--- a/docs/wallet-integration/grpc-server/getting-started.mdx
+++ b/docs/wallet-integration/grpc-server/getting-started.mdx
@@ -99,10 +99,11 @@ docker run -p 44020:44020 \
 ```
 
 <Warning>
-Do not bake the checked-in `integration/fixtures/ephemeral.secret` into your
-image. That fixture is public; any reader of the repo can forge signatures
-that look authentic to wallets. Generate your own P-256 key file per
-deployment and provision it via a secrets manager.
+Do not bake the checked-in `src/integration/fixtures/ephemeral.secret` (path
+relative to the repo root) into your image. That fixture is public; any
+reader of the repo can forge signatures that look authentic to wallets.
+Generate your own P-256 key file per deployment and provision it via a
+secrets manager.
 </Warning>
 
 ## Kubernetes deployment

--- a/docs/wallet-integration/grpc-server/getting-started.mdx
+++ b/docs/wallet-integration/grpc-server/getting-started.mdx
@@ -42,13 +42,22 @@ The parser will be available at `localhost:44020`.
 
 ### Configuration
 
-Set the `EPHEMERAL_FILE` environment variable to specify a custom signing key:
+The `EPHEMERAL_FILE` environment variable is **required**. It must point at the
+P-256 ephemeral signing key file the server should use:
 
 ```bash
 EPHEMERAL_FILE=/path/to/key.secret cargo run --bin parser_grpc_server
 ```
 
-For development, the binary defaults to `integration/fixtures/ephemeral.secret`.
+The binary refuses to start when `EPHEMERAL_FILE` is unset. There is no
+implicit default: a previous release fell back to a key fixture that ships in
+this repo, which let any reader of the repo forge `ParseResponse` signatures
+(PRS-233). Operators must provision a key path explicitly.
+
+For local development only, the `make grpc-server` target sets
+`EPHEMERAL_FILE` to the checked-in test fixture at
+`src/integration/fixtures/ephemeral.secret`. Do not reuse that fixture in any
+deployed environment.
 
 ## Building a Docker image
 
@@ -69,8 +78,10 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/src/target/release/parser_grpc_server /usr/local/bin/
-COPY --from=builder /build/src/integration/fixtures/ephemeral.secret /etc/visualsign/
 
+# EPHEMERAL_FILE must point at an operator-provisioned signing key. Mount it
+# at runtime (e.g. via a Kubernetes Secret or `docker run -v`) and set the
+# env var to its in-container path. The binary refuses to start otherwise.
 ENV EPHEMERAL_FILE=/etc/visualsign/ephemeral.secret
 
 EXPOSE 44020
@@ -78,16 +89,21 @@ EXPOSE 44020
 CMD ["parser_grpc_server"]
 ```
 
-Build and run:
+Build and run, mounting your key file into the container:
 
 ```bash
 docker build -t visualsign-grpc-server .
-docker run -p 44020:44020 visualsign-grpc-server
+docker run -p 44020:44020 \
+    -v /path/to/your/key.secret:/etc/visualsign/ephemeral.secret:ro \
+    visualsign-grpc-server
 ```
 
-<Note>
-For production, generate your own ephemeral key file rather than using the test fixture.
-</Note>
+<Warning>
+Do not bake the checked-in `integration/fixtures/ephemeral.secret` into your
+image. That fixture is public; any reader of the repo can forge signatures
+that look authentic to wallets. Generate your own P-256 key file per
+deployment and provision it via a secrets manager.
+</Warning>
 
 ## Kubernetes deployment
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -132,7 +132,11 @@ parser_host:
 
 .PHONY: grpc-server
 grpc-server:
-	cargo run --bin parser_grpc_server
+	@# The grpc-server binary refuses to start without EPHEMERAL_FILE (PRS-233).
+	@# For local development we point it at the checked-in test fixture; do NOT
+	@# reuse that fixture in any deployed/published environment.
+	EPHEMERAL_FILE=$(ROOT)/src/integration/fixtures/ephemeral.secret \
+		cargo run --bin parser_grpc_server
 
 .PHONY: parser_gateway
 parser_gateway:

--- a/src/Makefile
+++ b/src/Makefile
@@ -132,7 +132,7 @@ parser_host:
 
 .PHONY: grpc-server
 grpc-server:
-	@# The grpc-server binary refuses to start without EPHEMERAL_FILE (PRS-233).
+	@# The grpc-server binary refuses to start without EPHEMERAL_FILE.
 	@# For local development we point it at the checked-in test fixture; do NOT
 	@# reuse that fixture in any deployed/published environment.
 	EPHEMERAL_FILE=$(ROOT)/src/integration/fixtures/ephemeral.secret \

--- a/src/parser/grpc-server/src/main.rs
+++ b/src/parser/grpc-server/src/main.rs
@@ -17,6 +17,7 @@ use generated::parser::{
 use generated::tonic::{self, Request, Response, Status};
 use parser_app::routes::parse::parse;
 use qos_core::handles::EphemeralKeyHandle;
+use qos_core::protocol::ProtocolError;
 use qos_p256::P256Pair;
 use std::net::SocketAddr;
 
@@ -24,6 +25,9 @@ use std::net::SocketAddr;
 const EPHEMERAL_FILE_ENV: &str = "EPHEMERAL_FILE";
 
 /// Error returned when the operator forgot to point the server at a real key.
+///
+/// Covers all "no usable path" cases: env var unset, set to an empty string,
+/// or set to a value the OS rejects as non-unicode.
 #[derive(Debug)]
 struct MissingEphemeralFile;
 
@@ -31,14 +35,38 @@ impl std::fmt::Display for MissingEphemeralFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{EPHEMERAL_FILE_ENV} is not set; refusing to start. \
-             Point it at an operator-provisioned ephemeral key file. \
-             Do not reuse the checked-in test fixture in production."
+            "{EPHEMERAL_FILE_ENV} is unset, empty, or not valid unicode; \
+             refusing to start. Point it at an operator-provisioned \
+             ephemeral key file. Do not reuse the checked-in test fixture \
+             in production."
         )
     }
 }
 
 impl std::error::Error for MissingEphemeralFile {}
+
+/// Error returned when loading the ephemeral key file fails.
+///
+/// Preserves the underlying [`ProtocolError`] via [`std::error::Error::source`]
+/// so callers / logs can walk the chain for the root cause instead of getting
+/// a flattened string.
+#[derive(Debug)]
+struct EphemeralKeyLoadError {
+    path: String,
+    source: ProtocolError,
+}
+
+impl std::fmt::Display for EphemeralKeyLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "failed to load ephemeral key from {}", self.path)
+    }
+}
+
+impl std::error::Error for EphemeralKeyLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
 
 /// Resolve the ephemeral key file path from an environment lookup result.
 ///
@@ -63,11 +91,14 @@ struct GrpcService {
 struct HealthService;
 
 impl GrpcService {
-    fn new(ephemeral_file: &str) -> Result<Self, Box<dyn std::error::Error>> {
+    fn new(ephemeral_file: &str) -> Result<Self, EphemeralKeyLoadError> {
         let handle = EphemeralKeyHandle::new(ephemeral_file.to_string());
         let ephemeral_key = handle
             .get_ephemeral_key()
-            .map_err(|e| format!("failed to load ephemeral key from {ephemeral_file}: {e:?}"))?;
+            .map_err(|source| EphemeralKeyLoadError {
+                path: ephemeral_file.to_string(),
+                source,
+            })?;
         Ok(Self { ephemeral_key })
     }
 }
@@ -111,9 +142,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = "0.0.0.0:44020".parse()?;
 
     // Refuse to start without an explicit ephemeral key path. The repo ships a
-    // P-256 fixture under `integration/fixtures/ephemeral.secret`; falling back
-    // to it would mean every default deployment signs with a key any reader of
-    // the repo can forge (PRS-233). Operators must opt in via EPHEMERAL_FILE.
+    // P-256 fixture under `src/integration/fixtures/ephemeral.secret`; falling
+    // back to it would mean every default deployment signs with a key any
+    // reader of the repo can forge (PRS-233). Operators must opt in via
+    // EPHEMERAL_FILE.
     let ephemeral_file = resolve_ephemeral_file(std::env::var(EPHEMERAL_FILE_ENV))?;
 
     let svc = GrpcService::new(&ephemeral_file)?;

--- a/src/parser/grpc-server/src/main.rs
+++ b/src/parser/grpc-server/src/main.rs
@@ -20,6 +20,40 @@ use qos_core::handles::EphemeralKeyHandle;
 use qos_p256::P256Pair;
 use std::net::SocketAddr;
 
+/// Environment variable that must point at the ephemeral signing key file.
+const EPHEMERAL_FILE_ENV: &str = "EPHEMERAL_FILE";
+
+/// Error returned when the operator forgot to point the server at a real key.
+#[derive(Debug)]
+struct MissingEphemeralFile;
+
+impl std::fmt::Display for MissingEphemeralFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{EPHEMERAL_FILE_ENV} is not set; refusing to start. \
+             Point it at an operator-provisioned ephemeral key file. \
+             Do not reuse the checked-in test fixture in production."
+        )
+    }
+}
+
+impl std::error::Error for MissingEphemeralFile {}
+
+/// Resolve the ephemeral key file path from an environment lookup result.
+///
+/// Pure helper extracted so we can test the policy ("fail when unset") without
+/// mutating process-wide env vars (which is racy across parallel test
+/// threads).
+fn resolve_ephemeral_file(
+    env: Result<String, std::env::VarError>,
+) -> Result<String, MissingEphemeralFile> {
+    match env {
+        Ok(path) if !path.is_empty() => Ok(path),
+        _ => Err(MissingEphemeralFile),
+    }
+}
+
 /// Standalone gRPC service that calls the parser directly
 struct GrpcService {
     ephemeral_key: P256Pair,
@@ -29,12 +63,12 @@ struct GrpcService {
 struct HealthService;
 
 impl GrpcService {
-    fn new(ephemeral_file: &str) -> Self {
+    fn new(ephemeral_file: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let handle = EphemeralKeyHandle::new(ephemeral_file.to_string());
         let ephemeral_key = handle
             .get_ephemeral_key()
-            .expect("Failed to load ephemeral key");
-        Self { ephemeral_key }
+            .map_err(|e| format!("failed to load ephemeral key from {ephemeral_file}: {e:?}"))?;
+        Ok(Self { ephemeral_key })
     }
 }
 
@@ -76,11 +110,13 @@ impl Health for HealthService {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = "0.0.0.0:44020".parse()?;
 
-    // Use the test fixture for development; in production, use EPHEMERAL_KEY_FILE
-    let ephemeral_file = std::env::var("EPHEMERAL_FILE")
-        .unwrap_or_else(|_| "integration/fixtures/ephemeral.secret".to_string());
+    // Refuse to start without an explicit ephemeral key path. The repo ships a
+    // P-256 fixture under `integration/fixtures/ephemeral.secret`; falling back
+    // to it would mean every default deployment signs with a key any reader of
+    // the repo can forge (PRS-233). Operators must opt in via EPHEMERAL_FILE.
+    let ephemeral_file = resolve_ephemeral_file(std::env::var(EPHEMERAL_FILE_ENV))?;
 
-    let svc = GrpcService::new(&ephemeral_file);
+    let svc = GrpcService::new(&ephemeral_file)?;
 
     let reflection_service = generated::tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(generated::FILE_DESCRIPTOR_SET)
@@ -97,4 +133,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn resolve_ephemeral_file_errors_when_unset() {
+        let err = resolve_ephemeral_file(Err(std::env::VarError::NotPresent)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("EPHEMERAL_FILE"),
+            "error must name the env var, got: {msg}"
+        );
+        assert!(
+            msg.contains("refusing to start"),
+            "error must make the fail-closed behavior obvious, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_ephemeral_file_errors_when_empty() {
+        let err = resolve_ephemeral_file(Ok(String::new())).unwrap_err();
+        assert!(err.to_string().contains("EPHEMERAL_FILE"));
+    }
+
+    #[test]
+    fn resolve_ephemeral_file_errors_on_invalid_unicode() {
+        let err = resolve_ephemeral_file(Err(std::env::VarError::NotUnicode(
+            "bad".to_string().into(),
+        )))
+        .unwrap_err();
+        assert!(err.to_string().contains("EPHEMERAL_FILE"));
+    }
+
+    #[test]
+    fn resolve_ephemeral_file_returns_path_when_set() {
+        let path = resolve_ephemeral_file(Ok("/etc/visualsign/ephemeral.secret".to_string()))
+            .expect("non-empty path must succeed");
+        assert_eq!(path, "/etc/visualsign/ephemeral.secret");
+    }
 }

--- a/src/parser/grpc-server/src/main.rs
+++ b/src/parser/grpc-server/src/main.rs
@@ -144,7 +144,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Refuse to start without an explicit ephemeral key path. The repo ships a
     // P-256 fixture under `src/integration/fixtures/ephemeral.secret`; falling
     // back to it would mean every default deployment signs with a key any
-    // reader of the repo can forge (PRS-233). Operators must opt in via
+    // reader of the repo can forge. Operators must opt in via
     // EPHEMERAL_FILE.
     let ephemeral_file = resolve_ephemeral_file(std::env::var(EPHEMERAL_FILE_ENV))?;
 


### PR DESCRIPTION
## Summary

The `parser_grpc_server` binary defaulted to loading the checked-in fixture at `integration/fixtures/ephemeral.secret` when `EPHEMERAL_FILE` was unset. That fixture is a real P-256 keypair committed to the repo, so anyone who can read the repo can forge `ParseResponse` signatures that look authentic to wallets trusting the server's attestation. Fail closed instead.

## What changed

- `src/parser/grpc-server/src/main.rs`: refuse to start when `EPHEMERAL_FILE` is unset or empty. Returns a descriptive error pointing operators at a real key file. The previous `.expect("Failed to load ephemeral key")` is also replaced with a propagated error that includes the path. Pure helper `resolve_ephemeral_file` extracted so the policy is unit-testable without mutating process-wide env vars.
- `src/Makefile`: the `grpc-server` target now sets `EPHEMERAL_FILE` explicitly to the test fixture for local development, with a comment warning not to reuse the fixture in deployed environments.
- `docs/wallet-integration/grpc-server/getting-started.mdx`: docs reworded to say `EPHEMERAL_FILE` is required, no implicit default. Example Dockerfile no longer bakes the fixture into the image; users are shown how to mount their own key with `docker run -v`. Note upgraded to a Warning explaining the forgery risk.

## Dev workflow change (action required)

Any dev workflow that relied on the implicit fixture default must now set `EPHEMERAL_FILE` explicitly. The easiest path is to keep using `make -C src grpc-server`, which sets it for you. Direct invocations like `cargo run --bin parser_grpc_server` will refuse to start until the env var is provided.

## Rollback

Revert this commit. The previous behavior (implicit fallback to the fixture) is restored, but the underlying vulnerability returns, so this should only be done if a downstream consumer breaks unrecoverably. Operators should instead set `EPHEMERAL_FILE` in their deployment configs.

## Test plan

- [x] `cargo fmt` clean (no diff)
- [x] `cargo clippy -p parser_grpc_server --all-targets -- -D warnings` clean
- [x] `cargo test -p parser_grpc_server` — 4 new unit tests on `resolve_ephemeral_file` all pass:
  - errors when env var is unset (`VarError::NotPresent`)
  - errors when env var is empty string
  - errors on invalid unicode (`VarError::NotUnicode`)
  - returns the path when set to a non-empty string
- [ ] Smoke test locally: `make -C src grpc-server` still starts the server using the fixture.
- [ ] Smoke test locally: `cargo run --bin parser_grpc_server` (without `EPHEMERAL_FILE`) refuses to start with the expected error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
