### PR TITLE
feat(parser_gateway): emit mock bootProof + mount v2 route for prod parity

### DIFF
--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -412,7 +412,10 @@ mod tests {
         // be present on every response, including parse errors — strict
         // consumers reject responses missing the field outright.
         let resp = error_response("oops".to_string());
-        assert_eq!(resp.boot_proof.aws_attestation_doc_b64, MOCK_BOOT_PROOF_AWS_DOC);
+        assert_eq!(
+            resp.boot_proof.aws_attestation_doc_b64,
+            MOCK_BOOT_PROOF_AWS_DOC
+        );
         assert_eq!(resp.boot_proof.enclave_app, "visualsign-parser");
         assert_eq!(resp.boot_proof.deployment_label, "local-mock");
     }
@@ -429,12 +432,14 @@ mod tests {
         let top_keys: std::collections::BTreeSet<_> =
             value.as_object().unwrap().keys().cloned().collect();
         // Top-level: bootProof, response, error (error only present when set).
-        assert!(top_keys.contains("bootProof"), "missing top-level bootProof");
+        assert!(
+            top_keys.contains("bootProof"),
+            "missing top-level bootProof"
+        );
         assert!(top_keys.contains("response"), "missing top-level response");
 
         let bp = value.get("bootProof").unwrap().as_object().unwrap();
-        let bp_keys: std::collections::BTreeSet<&str> =
-            bp.keys().map(String::as_str).collect();
+        let bp_keys: std::collections::BTreeSet<&str> = bp.keys().map(String::as_str).collect();
         let expected: std::collections::BTreeSet<&str> = [
             "awsAttestationDocB64",
             "qosManifestB64",

--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -62,10 +62,58 @@ struct TurnkeyRequest {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct TurnkeyResponseWrapper {
+    /// Top-level boot proof, matching the production Turnkey visualsign API
+    /// response shape that wallet integrators consume. parser_gateway always
+    /// emits a stable mock here — the gateway is only used in non-TEE local
+    /// dev/CI, never wrapping a real enclave, so production deployments never
+    /// see these values. Downstream consumers that perform real attestation
+    /// verification will reject the mock, which is correct: this is for
+    /// contract-shape testing (the field must be present), not for letting
+    /// signing actually succeed. See issue #337.
+    boot_proof: TurnkeyBootProof,
     response: TurnkeyResponse,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+}
+
+/// Boot proof object shape, matching the production Turnkey visualsign API
+/// that wallet integrators consume. The reference Go client uses the same
+/// field names — see [visualsign-turnkeyclient/api/types.go::TurnkeyBootProof][types].
+///
+/// [types]: https://github.com/anchorageoss/visualsign-turnkeyclient/blob/main/api/types.go#L128
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TurnkeyBootProof {
+    aws_attestation_doc_b64: String,
+    qos_manifest_b64: String,
+    qos_manifest_envelope_b64: String,
+    ephemeral_public_key_hex: String,
+    enclave_app: String,
+    deployment_label: String,
+}
+
+/// Stable mock used in every gateway response. The base64 sentinels decode to
+/// "TURNKEY_GATEWAY_MOCK_BOOT_PROOF" and "TURNKEY_GATEWAY_MOCK_QOS_MANIFEST*" —
+/// pure placeholders, not signed attestation. Real attestation verifiers will
+/// reject them. Kept stable so downstream test fixtures can pin against them.
+const MOCK_BOOT_PROOF_AWS_DOC: &str = "VFVSTktFWV9HQVRFV0FZX01PQ0tfQk9PVF9QUk9PRg==";
+const MOCK_BOOT_PROOF_QOS_MANIFEST: &str = "VFVSTktFWV9HQVRFV0FZX01PQ0tfUU9TX01BTklGRVNU";
+const MOCK_BOOT_PROOF_QOS_MANIFEST_ENV: &str =
+    "VFVSTktFWV9HQVRFV0FZX01PQ0tfUU9TX01BTklGRVNUX0VOVkVMT1BF";
+const MOCK_BOOT_PROOF_EPHEMERAL_PK: &str =
+    "020000000000000000000000000000000000000000000000000000000000000001";
+
+fn mock_boot_proof() -> TurnkeyBootProof {
+    TurnkeyBootProof {
+        aws_attestation_doc_b64: MOCK_BOOT_PROOF_AWS_DOC.to_string(),
+        qos_manifest_b64: MOCK_BOOT_PROOF_QOS_MANIFEST.to_string(),
+        qos_manifest_envelope_b64: MOCK_BOOT_PROOF_QOS_MANIFEST_ENV.to_string(),
+        ephemeral_public_key_hex: MOCK_BOOT_PROOF_EPHEMERAL_PK.to_string(),
+        enclave_app: "visualsign-parser".to_string(),
+        deployment_label: "local-mock".to_string(),
+    }
 }
 
 #[derive(Serialize)]
@@ -242,6 +290,7 @@ async fn parse_handler(
     (
         StatusCode::OK,
         Json(TurnkeyResponseWrapper {
+            boot_proof: mock_boot_proof(),
             response: TurnkeyResponse {
                 parsed_transaction: TurnkeyParsedTransaction {
                     payload: TurnkeyPayload {
@@ -262,6 +311,7 @@ const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495
 
 fn error_response(msg: String) -> TurnkeyResponseWrapper {
     TurnkeyResponseWrapper {
+        boot_proof: mock_boot_proof(),
         response: TurnkeyResponse {
             parsed_transaction: TurnkeyParsedTransaction {
                 payload: TurnkeyPayload {
@@ -348,6 +398,51 @@ mod tests {
         assert_eq!(payload.input_payload_digest, EMPTY_SHA256);
         assert!(payload.signable_payload.is_empty());
         assert_eq!(resp.error.as_deref(), Some("something broke"));
+    }
+
+    #[test]
+    fn error_response_carries_mock_boot_proof() {
+        // The wallet-integration contract (see issue #337) requires bootProof
+        // be present on every response, including parse errors — strict
+        // consumers reject responses missing the field outright.
+        let resp = error_response("oops".to_string());
+        assert_eq!(resp.boot_proof.aws_attestation_doc_b64, MOCK_BOOT_PROOF_AWS_DOC);
+        assert_eq!(resp.boot_proof.enclave_app, "visualsign-parser");
+        assert_eq!(resp.boot_proof.deployment_label, "local-mock");
+    }
+
+    #[test]
+    fn mock_boot_proof_matches_production_wire_shape() {
+        // Wire-shape parity with the production response that wallet
+        // integrators consume. Field set and JSON keys mirror
+        // visualsign-turnkeyclient/api/types.go: TurnkeyVisualSignResponse
+        // (bootProof at top level) and TurnkeyBootProof (six camelCase keys).
+        let resp = error_response("x".to_string());
+        let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
+
+        let top_keys: std::collections::BTreeSet<_> =
+            value.as_object().unwrap().keys().cloned().collect();
+        // Top-level: bootProof, response, error (error only present when set).
+        assert!(top_keys.contains("bootProof"), "missing top-level bootProof");
+        assert!(top_keys.contains("response"), "missing top-level response");
+
+        let bp = value.get("bootProof").unwrap().as_object().unwrap();
+        let bp_keys: std::collections::BTreeSet<&str> =
+            bp.keys().map(String::as_str).collect();
+        let expected: std::collections::BTreeSet<&str> = [
+            "awsAttestationDocB64",
+            "qosManifestB64",
+            "qosManifestEnvelopeB64",
+            "ephemeralPublicKeyHex",
+            "enclaveApp",
+            "deploymentLabel",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            bp_keys, expected,
+            "bootProof field set must match production wire shape exactly"
+        );
     }
 
     #[test]

--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -352,9 +352,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         health_client,
     };
 
+    // Mount the same handler under both v1 and v2 URLs for local parity with
+    // the production Turnkey visualsign API, which serves /api/v1/parse and
+    // /api/v2/parse from the same backend. The response shape already carries
+    // both v1 fields (signablePayload) and v2 fields (metadataDigest,
+    // inputPayloadDigest) since #287, so a single handler covers both.
     let app = Router::new()
         .route("/health", get(health_handler))
         .route("/visualsign/api/v1/parse", post(parse_handler))
+        .route("/visualsign/api/v2/parse", post(parse_handler))
         .layer(DefaultBodyLimit::max(GRPC_MAX_RECV_MSG_SIZE))
         .with_state(state);
 


### PR DESCRIPTION
## Summary

Closes #337.

Brings the local parser_gateway into wire-shape parity with the production Turnkey visualsign API so wallet integrators don't have to special-case the local environment.

Two changes on the same branch:

1. **`feat(parser_gateway): emit mock bootProof in every response`** — adds a stable, deterministic mock `bootProof` at the top level of every gateway response with the six camelCase fields integrators expect (`awsAttestationDocB64`, `qosManifestB64`, `qosManifestEnvelopeB64`, `ephemeralPublicKeyHex`, `enclaveApp`, `deploymentLabel`). The gateway only runs in non-TEE local dev/CI (production wraps `parser_app` directly inside the Nitro enclave), so emitting a stable placeholder is always safe. Real attestation verifiers will reject the mock — that's correct; this is for shape conformance, not for letting signing succeed.

2. **`feat(parser_gateway): mount /visualsign/api/v2/parse for local/prod parity`** — production Turnkey serves both `/api/v1/parse` and `/api/v2/parse` from the same backend. After #287 the response shape already carries v2 fields (`metadataDigest`, `inputPayloadDigest`), so a single handler covers both routes. Local previously only mounted v1 and 404'd on v2 clients.

## Test plan

- [x] `cargo test -p parser_gateway` — 7 tests pass, including `mock_boot_proof_matches_production_wire_shape` (strict field-set check against the production wire shape).
- [x] `cargo clippy -p parser_gateway --all-targets -- -D warnings` clean.
- [x] End-to-end against a downstream integrator (Anchorage's parsersmoke selfContainedTest hitting the locally-built image): the consumer's `BootProof` is now populated, where previously it was always `nil`.
- [x] `curl POST http://localhost:1997/visualsign/api/v1/parse` returns the expected shape; same for `/api/v2/parse`.

## Notes for reviewers

- The mock values are fixed sentinels (decode to `TURNKEY_GATEWAY_MOCK_BOOT_PROOF` etc.) so downstream test fixtures can pin against them.
- The PR-event-derived stagex tags (`pr-N` / SHA) will be used downstream to pin the consumer's wrapper Dockerfile during integration testing before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)