### PR TITLE
feat(cli): strip internal whitespace from @file / @- transaction input

### DIFF
--- a/src/parser/cli-core/src/tx_input.rs
+++ b/src/parser/cli-core/src/tx_input.rs
@@ -4,8 +4,13 @@
 //! - `@-` reads it from stdin.
 //! - Anything else is returned unchanged.
 //!
-//! In all `@` cases, leading and trailing whitespace is trimmed since the
-//! transaction string itself (hex / base64) cannot legitimately contain it.
+//! In all `@` cases, ASCII whitespace (space, tab, line feed, form feed,
+//! carriage return) is stripped from
+//! the buffer since the transaction string itself (hex / base64) cannot
+//! legitimately contain it — this lets users paste line-wrapped hex from
+//! block explorers or terminal emulators without manual cleanup. The 10 MB
+//! size limit is applied to the raw read so a whitespace-padded file can't
+//! bypass it.
 
 use std::io::Read;
 
@@ -32,7 +37,15 @@ pub fn resolve_transaction_input(input: &str) -> Result<String, String> {
         }
     };
 
-    Ok(raw.trim().to_string())
+    Ok(strip_ascii_whitespace(&raw))
+}
+
+/// Remove every ASCII-whitespace byte from `input`. We intentionally use the
+/// ASCII variant (not `split_whitespace`) so exotic Unicode-whitespace
+/// characters such as NBSP (`\u{00A0}`) stay in the buffer and surface as
+/// decode errors rather than being silently swallowed.
+fn strip_ascii_whitespace(input: &str) -> String {
+    input.split_ascii_whitespace().collect()
 }
 
 fn read_bounded<R: Read>(reader: R, source: &str) -> Result<String, String> {
@@ -67,6 +80,31 @@ mod tests {
         let path = write_temp_json("vsp_tx_input_tests", "tx.hex", "  0xdeadbeef\n\n");
         let arg = format!("@{}", path.display());
         assert_eq!(resolve_transaction_input(&arg).unwrap(), "0xdeadbeef");
+    }
+
+    #[test]
+    fn reads_from_file_and_strips_internal_whitespace() {
+        // Line-wrapped hex (with stray internal space and tab) as a user
+        // might paste from a block explorer or wrapped terminal output.
+        let wrapped = "0a8a010a020793\n2208e4e3a4d46f74\td763\r\n   ";
+        let path = write_temp_json("vsp_tx_input_tests", "tx_wrapped.hex", wrapped);
+        let arg = format!("@{}", path.display());
+        assert_eq!(
+            resolve_transaction_input(&arg).unwrap(),
+            "0a8a010a0207932208e4e3a4d46f74d763",
+        );
+    }
+
+    #[test]
+    fn strip_ascii_whitespace_preserves_non_ascii() {
+        // Non-ASCII whitespace (e.g. NBSP) must pass through unchanged so we
+        // never silently corrupt input that happens to land in `@file` mode.
+        // Using NBSP (which `split_whitespace` *would* strip) guards against
+        // accidentally switching to Unicode-aware whitespace splitting.
+        assert_eq!(
+            strip_ascii_whitespace("a b\tc\nd \u{00A0}e"),
+            "abcd\u{00A0}e"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `--transaction @file` and `--transaction @-` now strip every ASCII whitespace byte from the buffer, not just leading/trailing edges.
- Lets users paste line-wrapped hex (or base64) straight out of a block explorer or wrapped terminal without manual cleanup.
- The 10 MB raw-read limit still applies, so a whitespace-padded file cannot bypass it. Non-ASCII whitespace (NBSP and friends) is intentionally preserved so it surfaces as a decode error instead of being silently swallowed.
- Uses `str::split_ascii_whitespace().collect()` — built-in, no extra allocation per chunk.

## Test Plan
- [x] `cargo test -p parser_cli tx_input::` (9 unit tests, including new `reads_from_file_and_strips_internal_whitespace` and `strip_ascii_whitespace_preserves_non_ascii`)
- [x] Manually decoded a wrapped Tron VoteWitness tx via `-t @tx.hex` and confirmed identical output to the inline form