### PR TITLE
ci: harden CLA username matching and batch-PR handling

### DIFF
--- a/.github/workflows/add-cla-user.yml
+++ b/.github/workflows/add-cla-user.yml
@@ -8,6 +8,14 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize runs: this workflow pushes to the shared `cla-signers-batch` branch
+# and creates/updates a shared batch PR. Two near-simultaneous `/approve-cla`
+# comments would otherwise race on the push. Don't cancel in-progress runs --
+# each approval must complete so no signer is dropped.
+concurrency:
+  group: cla-signers-batch
+  cancel-in-progress: false
+
 jobs:
   add-user-to-cla-list:
     if: github.event.issue.pull_request
@@ -92,8 +100,10 @@ jobs:
 
           echo "Adding ${AUTHOR_USERNAME} to .cla-signed-users"
 
-          # Check if user is already in the list on main branch
-          if grep -v '^#' .cla-signed-users | grep -q -w "$AUTHOR_USERNAME"; then
+          # Check if user is already in the list on main branch.
+          # grep -Fxq: fixed-string whole-line match -- usernames like
+          # `dependabot[bot]` contain regex metacharacters that break `grep -w`.
+          if grep -v '^#' .cla-signed-users | grep -Fxq "$AUTHOR_USERNAME"; then
             echo "User is already in the list."
             gh pr comment ${{ github.event.issue.number }} --body "ℹ️ @${AUTHOR_USERNAME} is already in the CLA signers list."
             exit 0
@@ -113,8 +123,8 @@ jobs:
             git checkout -b "$BATCH_BRANCH"
           fi
 
-          # Check if user is already in the batch branch
-          if grep -v '^#' .cla-signed-users | grep -q -w "$AUTHOR_USERNAME"; then
+          # Check if user is already in the batch branch (fixed-string match).
+          if grep -v '^#' .cla-signed-users | grep -Fxq "$AUTHOR_USERNAME"; then
             echo "User is already in the batch branch."
             gh pr comment ${{ github.event.issue.number }} --body "ℹ️ @${AUTHOR_USERNAME} is already pending approval in the CLA signers batch."
             exit 0
@@ -143,6 +153,8 @@ jobs:
             gh pr comment ${{ github.event.issue.number }} --body "✅ @${AUTHOR_USERNAME} has been added to the CLA signers batch PR #${EXISTING_PR} by @${COMMENTER}. The CLA check will pass once the batch PR is merged."
           else
             echo "Creating new batch PR"
+            # `gh pr create` prints the PR URL (…/pull/<n>); take the trailing
+            # number. The old `grep '#[0-9]+'` matched nothing on a URL.
             NEW_PR=$(gh pr create \
               --title "chore: Add CLA signers batch" \
               --body "This PR adds new CLA signers in batch to comply with repository rules.
@@ -154,7 +166,7 @@ jobs:
               --head "$BATCH_BRANCH" \
               --base main \
               --label "cla" \
-              | grep -o '#[0-9]\+' | head -1 | tr -d '#')
+              | grep -oE '[0-9]+$' | head -1)
 
             echo "Created new batch PR #${NEW_PR}"
             gh pr comment ${{ github.event.issue.number }} --body "✅ @${AUTHOR_USERNAME} has been added to a new CLA signers batch PR #${NEW_PR} by @${COMMENTER}. The CLA check will pass once the batch PR is merged."

--- a/.github/workflows/cla-file-check.yml
+++ b/.github/workflows/cla-file-check.yml
@@ -33,12 +33,18 @@ jobs:
 
       - name: Check for username in .cla-signed-users
         id: check_user
+        env:
+          PR_USER: ${{ github.event.pull_request.user.login }}
         run: |
-          if grep -v '^#' .cla-signed-users | grep -q -w "${{ github.event.pull_request.user.login }}"; then
+          # Fixed-string, whole-line match (grep -Fxq): GitHub logins like
+          # `github-actions[bot]` contain regex metacharacters, so `grep -w`
+          # would misbehave. A missing file is treated as "not signed" rather
+          # than erroring the workflow.
+          if [ -f .cla-signed-users ] && grep -v '^#' .cla-signed-users | grep -Fxq "$PR_USER"; then
             echo "✅ User found in .cla-signed-users file."
             echo "is_signed=true" >> $GITHUB_OUTPUT
           else
-            echo "❌ User not found. Please acknowledge the CLA."
+            echo "❌ User not found (or CLA file missing). Please acknowledge the CLA."
             echo "is_signed=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## What

Latent robustness fixes in the CLA workflows, found while porting this flow to `anchorageoss/sqisign-rs` (Copilot flagged them there; the same code lives here).

- **Username matching** (`cla-file-check.yml`, `add-cla-user.yml` ×2): replace `grep -q -w "$user"` with `grep -Fxq "$user"` (fixed-string, whole-line). GitHub logins like `github-actions[bot]` / `dependabot[bot]` contain `[` which `grep -w` treats as a regex character class — it can error or false-negative. Also tolerate a missing `.cla-signed-users` (treat as unsigned) instead of erroring.
- **Batch-branch race** (`add-cla-user.yml`): add a `concurrency` group on `cla-signers-batch` (no cancel-in-progress) so two near-simultaneous `/approve-cla` runs don't race on the push and drop a signer.
- **Batch PR number parsing** (`add-cla-user.yml`): `gh pr create` prints the PR **URL** (`…/pull/123`), so `grep -o '#[0-9]\+'` matched nothing and left `NEW_PR` blank (broken follow-up comment). Parse the trailing number from the URL instead.

No behavior change for already-listed human signers; this only fixes bot logins, the concurrency race, and the empty PR-number bug.

## Test
`actionlint`/YAML parse clean. The matching change is verifiable: `printf 'github-actions[bot]\n' | grep -Fxq 'github-actions[bot]'` succeeds, whereas `grep -w` errors/misbehaves on the `[`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)