### PR TITLE
ci: make auto-version.sh robust to shallow clones and forks

### DIFF
--- a/scripts/auto-version.sh
+++ b/scripts/auto-version.sh
@@ -21,6 +21,23 @@ fi
 
 SHORT_HASH=$(git rev-parse --short=12 HEAD)
 
+# A shallow clone makes the commit-distance counts below wrong (git only sees
+# the truncated history). On CI, deepen to full history and fail if we can't;
+# locally, warn loudly so a bogus version is obvious rather than silent.
+if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "Repository is shallow; fetching full history for an accurate version..." >&2
+    git fetch --unshallow 2>/dev/null || git fetch --depth=2147483647 2>/dev/null || true
+    if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+      echo "ERROR: repository is still shallow after fetch; refusing to compute a version from truncated history." >&2
+      exit 1
+    fi
+  else
+    echo "WARNING: shallow clone detected -- the computed version will be wrong." >&2
+    echo "         Run 'git fetch --unshallow' for an accurate commit distance." >&2
+  fi
+fi
+
 # Sanitized branch for semver build metadata (allowed: [0-9A-Za-z-]).
 # Trailing "-" is a separator before SHORT_HASH; omitted when branch is empty.
 if [ -n "$RAW_BRANCH" ]; then
@@ -42,14 +59,38 @@ if { [ "$RAW_BRANCH" = "main" ] || [ "$RAW_BRANCH" = "master" ]; } \
   exit 0
 fi
 
-REMOTE=$(git remote -v | awk '/[[:space:]]\(fetch\)/ && /anchorageoss\/visualsign-parser/ {print $1; exit}')
+# Find the remote that points at the canonical upstream repo. Prefer
+# $GITHUB_REPOSITORY (set in Actions) so forks/renames work without editing this
+# script; fall back to the known upstream slug, then to "origin". Override with
+# AUTO_VERSION_REMOTE if your remote layout differs.
+EXPECTED_REPO="${AUTO_VERSION_REPO:-${GITHUB_REPOSITORY:-anchorageoss/visualsign-parser}}"
+REMOTE="${AUTO_VERSION_REMOTE:-}"
+if [ -z "$REMOTE" ]; then
+  REMOTE=$(git remote -v | awk -v repo="$EXPECTED_REPO" '$0 ~ "[[:space:]]\\(fetch\\)" && index($0, repo) {print $1; exit}')
+fi
 if [ -z "$REMOTE" ]; then
   REMOTE="origin"
 fi
 
-DEFAULT_BRANCH="main"
-if ! git rev-parse --verify "$REMOTE/$DEFAULT_BRANCH" > /dev/null 2>&1; then
+# Resolve the default branch. Prefer main, then master. If neither
+# remote-tracking ref is present (e.g. a CI checkout that fetched only the
+# current ref), try to fetch both before giving up, so the merge-base below
+# doesn't fail cryptically under `set -e`.
+if git rev-parse --verify "$REMOTE/main" > /dev/null 2>&1; then
+  DEFAULT_BRANCH="main"
+elif git rev-parse --verify "$REMOTE/master" > /dev/null 2>&1; then
   DEFAULT_BRANCH="master"
+else
+  git fetch "$REMOTE" main > /dev/null 2>&1 || true
+  git fetch "$REMOTE" master > /dev/null 2>&1 || true
+  if git rev-parse --verify "$REMOTE/main" > /dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify "$REMOTE/master" > /dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  else
+    echo "ERROR: cannot resolve $REMOTE/main or $REMOTE/master to compute a merge base." >&2
+    exit 1
+  fi
 fi
 
 MERGE_BASE=$(git merge-base "$REMOTE/$DEFAULT_BRANCH" HEAD)


### PR DESCRIPTION
## What

Robustness fixes for `scripts/auto-version.sh`, found while porting it to `anchorageoss/sqisign-rs` (Copilot flagged them there; same code here). **The version string format is unchanged** — pure hardening.

- **Shallow clones**: `git rev-list --count HEAD` / `git merge-base` are wrong on a shallow clone (`actions/checkout` defaults to depth 1). Detect a shallow repo and, on CI, deepen to full history — **failing closed** if it's still shallow so a release can't mint a bogus version/tag; warn loudly locally.
- **Hard-coded repo slug**: remote detection matched only `anchorageoss/visualsign-parser`, so forks/renames silently fell back to `origin`. Derive the expected repo from `$GITHUB_REPOSITORY` (with `AUTO_VERSION_REMOTE`/`AUTO_VERSION_REPO` overrides), then the known slug, then `origin`.
- **Default-branch resolution**: the old code set `DEFAULT_BRANCH=master` whenever `main` wasn't present locally without checking `master` exists — `git merge-base` then crashes under `set -e`. Now resolve main→master, fetching both if neither remote ref is present, and error clearly otherwise.

## Test
`shellcheck` clean. Output unchanged on this branch: `0.722.0+…` (both branch and simulated-main runs), matching the existing `0.<height>.<diff>` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)