### PR TITLE
fix(ethereum): update test to assert chain_id mismatch is rejected

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -1090,11 +1090,11 @@ mod tests {
         );
     }
 
-    /// The canonical-token short-circuit must key off the transaction's own
-    /// chain id, not the resolved `chain_id` (which gives priority to
-    /// caller-controlled metadata). Otherwise a malicious dApp could supply a
-    /// mismatched `network_id` so the global registry lookup misses USDC and
-    /// the dynamic-ABI path runs again.
+    /// A mismatched `network_id` vs tx chain_id is rejected outright by
+    /// `resolve_chain_id`, so a malicious dApp that supplies `network_id`
+    /// pointing at a chain where a canonical token is not registered can never
+    /// reach the ABI dispatch layer — the payload is rejected before the
+    /// known-token short-circuit even runs.
     #[test]
     fn test_known_token_short_circuit_uses_tx_chain_id_not_metadata() {
         let usdc_address: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
@@ -1170,19 +1170,19 @@ mod tests {
         };
 
         let wrapper = EthereumTransactionWrapper::new(tx);
-        let payload = converter.to_visual_sign_payload(wrapper, options).unwrap();
-
-        let preview = payload
-            .fields
-            .iter()
-            .find(|f| matches!(f, SignablePayloadField::PreviewLayout { .. }))
-            .expect("expected a PreviewLayout from the built-in ERC20 visualizer");
-        let SignablePayloadField::PreviewLayout { common, .. } = preview else {
-            panic!("matched discriminant changed");
+        let err = converter
+            .to_visual_sign_payload(wrapper, options)
+            .unwrap_err();
+        assert!(
+            matches!(err, VisualSignError::ValidationError(_)),
+            "mismatched tx/metadata chain_id must be rejected: {err:?}",
+        );
+        let VisualSignError::ValidationError(msg) = err else {
+            unreachable!()
         };
-        assert_eq!(
-            common.label, "ERC20 Transfer",
-            "tx chain_id must win over caller metadata for the canonical-token lookup",
+        assert!(
+            msg.contains("chain_id mismatch"),
+            "error message must describe the mismatch: {msg}",
         );
     }
 


### PR DESCRIPTION
## Why am I making this PR?

CI was failing with a `ValidationError` panic in `test_known_token_short_circuit_uses_tx_chain_id_not_metadata`. PR #329 (`fix(ethereum): treat signed chain_id as authoritative over network_id`) introduced a hard rejection in `resolve_chain_id` when the transaction's `chain_id` and `metadata.network_id` disagree. The test was asserting the old, weaker behavior (accept the mismatch and use the tx's chain_id for the token lookup); it now needs to assert the new, stronger behavior (reject the payload outright).

## What am I changing?

Single test function update in `src/chain_parsers/visualsign-ethereum/src/lib.rs`:

- `test_known_token_short_circuit_uses_tx_chain_id_not_metadata`: replaces `.unwrap()` + ERC20 Transfer assertion with `.unwrap_err()` + assertion that the error is a `ValidationError` containing `"chain_id mismatch"`.
- Updates the doc comment to describe the invariant now being tested: a mismatched `network_id` vs tx `chain_id` is rejected by `resolve_chain_id` before the known-token short-circuit or ABI dispatch runs.

No production code is touched.

## What is the Linear ticket?

N/A

## What are the rollback steps?

Revert this PR. The only change is a test assertion; reverting restores the failing test and the CI failure from PR #329 reappears.

## Is this change backwards compatible?

Yes — test-only change with no production surface.

## Does this require cross-team/service coordination?

No.

## How do I know it works as designed? Which tests exercise this code?

```
cargo test -p visualsign-ethereum test_known_token_short_circuit_uses_tx_chain_id_not_metadata
```

Before this PR: panics with `ValidationError("chain_id mismatch: ...")`.
After this PR: passes — the test asserts exactly that `ValidationError`.

The companion test `test_known_token_short_circuit_handles_chain_id_less_legacy_tx` (pre-EIP-155 tx with no chain_id + mismatched metadata) is unaffected and continues to pass, since `resolve_chain_id` only errors when *both* sides are present and disagree.