### PR TITLE
Add OKX Router Solana preset

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/mod.rs
@@ -13,6 +13,7 @@ pub mod metadao_futarchy;
 pub mod meteora_damm_v2;
 pub mod meteora_dlmm;
 pub mod neutral_trade;
+pub mod okx_router;
 pub mod onre_app;
 pub mod orca_whirlpool;
 pub mod stakepool;

--- a/src/chain_parsers/visualsign-solana/src/presets/okx_router/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/okx_router/config.rs
@@ -1,0 +1,22 @@
+use super::OKX_ROUTER_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
+
+pub struct OkxRouterConfig;
+
+impl SolanaIntegrationConfig for OkxRouterConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(OKX_ROUTER_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/okx_router/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/okx_router/mod.rs
@@ -1,0 +1,221 @@
+//! OKX Router preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::OkxRouterConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::BTreeMap;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const OKX_ROUTER_PROGRAM_ID: &str = "proVF4pMXVaYqmy4NjniPh4pqKNfMmsihgd4wdkCX3u";
+
+const DISPLAY_NAME: &str = "OKX Router";
+
+const IDL_JSON: &str = include_str!("okx_router.json");
+
+static CONFIG: OkxRouterConfig = OkxRouterConfig;
+
+pub struct OkxRouterVisualizer;
+
+impl InstructionVisualizer for OkxRouterVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let instruction = context
+            .current_instruction()
+            .ok_or_else(|| VisualSignError::MissingData("No instruction found".into()))?;
+
+        if instruction.data.len() < 8 {
+            return Err(VisualSignError::DecodeError(
+                "Instruction data too short for Anchor discriminator".to_string(),
+            ));
+        }
+
+        let idl = load_idl()?;
+        let parsed = parse_instruction_with_idl(&instruction.data, OKX_ROUTER_PROGRAM_ID, &idl)
+            .map_err(|e| VisualSignError::DecodeError(format!("IDL parse failed: {e}")))?;
+
+        let named_accounts = build_named_accounts(&idl, &instruction.data, &instruction.accounts);
+
+        build_visualization(context, instruction, &parsed, &named_accounts)
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Dex(DISPLAY_NAME)
+    }
+}
+
+fn load_idl() -> Result<Idl, VisualSignError> {
+    decode_idl_data(IDL_JSON)
+        .map_err(|e| VisualSignError::DecodeError(format!("Failed to decode bundled IDL: {e}")))
+}
+
+fn build_named_accounts(
+    idl: &Idl,
+    instruction_data: &[u8],
+    accounts: &[solana_sdk::instruction::AccountMeta],
+) -> BTreeMap<String, String> {
+    let mut named = BTreeMap::new();
+    if instruction_data.len() < 8 {
+        return named;
+    }
+    let Some(idl_instruction) = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| &instruction_data[0..8] == disc.as_slice())
+    }) else {
+        return named;
+    };
+    for (index, account_meta) in accounts.iter().enumerate() {
+        if let Some(idl_account) = idl_instruction.accounts.get(index) {
+            named.insert(idl_account.name.clone(), account_meta.pubkey.to_string());
+        }
+    }
+    named
+}
+
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+fn build_visualization(
+    context: &VisualizerContext,
+    instruction: &solana_sdk::instruction::Instruction,
+    parsed: &SolanaParsedInstructionData,
+    named_accounts: &BTreeMap<String, String>,
+) -> Result<AnnotatedPayloadField, VisualSignError> {
+    let program_id = instruction.program_id.to_string();
+    let title = format!("{DISPLAY_NAME}: {}", parsed.instruction_name);
+
+    let condensed_fields = vec![create_text_field("Instruction", &parsed.instruction_name)?];
+
+    let mut expanded_fields = vec![
+        create_text_field("Program", DISPLAY_NAME)?,
+        create_text_field("Program ID", &program_id)?,
+        create_text_field("Instruction", &parsed.instruction_name)?,
+        create_text_field("Discriminator", &parsed.discriminator)?,
+    ];
+
+    let mut account_keys: Vec<&String> = named_accounts.keys().collect();
+    account_keys.sort();
+    for key in account_keys {
+        if let Some(addr) = named_accounts.get(key) {
+            expanded_fields.push(create_text_field(key, addr)?);
+        }
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    expanded_fields.push(create_raw_data_field(
+        &instruction.data,
+        Some(hex::encode(&instruction.data)),
+    )?);
+
+    let condensed = SignablePayloadFieldListLayout {
+        fields: condensed_fields,
+    };
+    let expanded = SignablePayloadFieldListLayout {
+        fields: expanded_fields,
+    };
+
+    let preview_layout = SignablePayloadFieldPreviewLayout {
+        title: Some(SignablePayloadFieldTextV2 {
+            text: title.clone(),
+        }),
+        subtitle: Some(SignablePayloadFieldTextV2 {
+            text: String::new(),
+        }),
+        condensed: Some(condensed),
+        expanded: Some(expanded),
+    };
+
+    let fallback_text = format!(
+        "Program ID: {program_id}\nData: {}",
+        hex::encode(&instruction.data)
+    );
+
+    Ok(AnnotatedPayloadField {
+        static_annotation: None,
+        dynamic_annotation: None,
+        signable_payload_field: SignablePayloadField::PreviewLayout {
+            common: SignablePayloadFieldCommon {
+                label: format!("Instruction {}", context.instruction_index() + 1),
+                fallback_text,
+            },
+            preview_layout,
+        },
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_okx_router_idl_loads() {
+        let idl = load_idl().expect("IDL must load");
+        assert!(
+            !idl.instructions.is_empty(),
+            "IDL should declare at least one instruction"
+        );
+    }
+
+    #[test]
+    fn test_okx_router_idl_has_discriminators() {
+        let idl = load_idl().expect("IDL must load");
+        for instruction in &idl.instructions {
+            let discriminator = instruction
+                .discriminator
+                .as_ref()
+                .expect("decode_idl_data must populate every discriminator");
+            assert_eq!(
+                discriminator.len(),
+                8,
+                "discriminator for `{}` should be 8 bytes, got {}",
+                instruction.name,
+                discriminator.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let bogus = [0xFFu8; 9];
+        let result = parse_instruction_with_idl(&bogus, OKX_ROUTER_PROGRAM_ID, &idl);
+        assert!(
+            result.is_err(),
+            "unknown discriminator should fail to parse"
+        );
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let idl = load_idl().expect("IDL must load");
+        let short = [0x01u8, 0x02, 0x03];
+        let result = parse_instruction_with_idl(&short, OKX_ROUTER_PROGRAM_ID, &idl);
+        assert!(result.is_err(), "data shorter than 8 bytes should error");
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/okx_router/okx_router.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/okx_router/okx_router.json
@@ -1,0 +1,3532 @@
+{
+  "accounts": [
+    {
+      "discriminator": [
+        156,
+        247,
+        9,
+        188,
+        54,
+        108,
+        85,
+        77
+      ],
+      "name": "TokenLedger"
+    }
+  ],
+  "address": "proVF4pMXVaYqmy4NjniPh4pqKNfMmsihgd4wdkCX3u",
+  "constants": [
+    {
+      "name": "SEED_SA",
+      "type": "bytes",
+      "value": "[111, 107, 120, 95, 115, 97]"
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "msg": "Routes cannot be empty",
+      "name": "RoutesCannotBeEmpty"
+    },
+    {
+      "code": 6001,
+      "msg": "Too many routes",
+      "name": "TooManyRoutes"
+    },
+    {
+      "code": 6002,
+      "msg": "Multiple or no output node",
+      "name": "MultipleOrNoOutputNode"
+    },
+    {
+      "code": 6003,
+      "msg": "Multiple or no input node",
+      "name": "MultipleOrNoInputNode"
+    },
+    {
+      "code": 6004,
+      "msg": "Not all nodes are processed",
+      "name": "NotAllNodesProcessed"
+    },
+    {
+      "code": 6005,
+      "msg": "Input index should start from zero",
+      "name": "InputIndexShouldStartFromZero"
+    },
+    {
+      "code": 6006,
+      "msg": "Circular dependency detected in DAG",
+      "name": "CircularDependency"
+    },
+    {
+      "code": 6007,
+      "msg": "Invalid weight",
+      "name": "InvalidWeight"
+    },
+    {
+      "code": 6008,
+      "msg": "Invalid node order",
+      "name": "InvalidNodeOrder"
+    },
+    {
+      "code": 6009,
+      "msg": "Target node not found",
+      "name": "TargetNodeNotFound"
+    },
+    {
+      "code": 6010,
+      "msg": "Min return not reached",
+      "name": "MinReturnNotReached"
+    },
+    {
+      "code": 6011,
+      "msg": "amount_in must be greater than 0",
+      "name": "AmountInMustBeGreaterThanZero"
+    },
+    {
+      "code": 6012,
+      "msg": "slippage must be less than or equal to 100%",
+      "name": "SlippageTooHigh"
+    },
+    {
+      "code": 6013,
+      "msg": "invalid expect amount out",
+      "name": "InvalidExpectAmountOut"
+    },
+    {
+      "code": 6014,
+      "msg": "weights must sum to 100%",
+      "name": "WeightsMustSumTo100"
+    },
+    {
+      "code": 6015,
+      "msg": "Invalid share amount",
+      "name": "InvalidShareAmount"
+    },
+    {
+      "code": 6016,
+      "msg": "Invalid commission rate",
+      "name": "InvalidCommissionRate"
+    },
+    {
+      "code": 6017,
+      "msg": "Invalid parent commission rate",
+      "name": "InvalidParentCommissionRate"
+    },
+    {
+      "code": 6018,
+      "msg": "Invalid trim rate",
+      "name": "InvalidTrimRate"
+    },
+    {
+      "code": 6019,
+      "msg": "Invalid charge rate",
+      "name": "InvalidChargeRate"
+    },
+    {
+      "code": 6020,
+      "msg": "Invalid commission temporary token account",
+      "name": "InvalidCommissionTemporaryTokenAccount"
+    },
+    {
+      "code": 6021,
+      "msg": "Invalid accounts length",
+      "name": "InvalidAccountsLength"
+    },
+    {
+      "code": 6022,
+      "msg": "Swap authority is not signer",
+      "name": "SwapAuthorityIsNotSigner"
+    },
+    {
+      "code": 6023,
+      "msg": "Invalid authority pda",
+      "name": "InvalidAuthorityPda"
+    },
+    {
+      "code": 6024,
+      "msg": "Invalid swap authority",
+      "name": "InvalidSwapAuthority"
+    },
+    {
+      "code": 6025,
+      "msg": "Invalid program id",
+      "name": "InvalidProgramId"
+    },
+    {
+      "code": 6026,
+      "msg": "Invalid pool",
+      "name": "InvalidPool"
+    },
+    {
+      "code": 6027,
+      "msg": "Invalid token mint",
+      "name": "InvalidTokenMint"
+    },
+    {
+      "code": 6028,
+      "msg": "Calculation error",
+      "name": "CalculationError"
+    },
+    {
+      "code": 6029,
+      "msg": "Invalid sanctum lst state list data",
+      "name": "InvalidSanctumLstStateListData"
+    },
+    {
+      "code": 6030,
+      "msg": "Invalid sanctum lst state list index",
+      "name": "InvalidSanctumLstStateListIndex"
+    },
+    {
+      "code": 6031,
+      "msg": "Invalid sanctum swap accounts",
+      "name": "InvalidSanctumSwapAccounts"
+    },
+    {
+      "code": 6032,
+      "msg": "Invalid swap authority account",
+      "name": "InvalidSwapAuthorityAccount"
+    },
+    {
+      "code": 6033,
+      "msg": "Bridge Seed Error",
+      "name": "InvalidBridgeSeed"
+    },
+    {
+      "code": 6034,
+      "msg": "Invalid accounts and instruction length",
+      "name": "InvalidBundleInput"
+    },
+    {
+      "code": 6035,
+      "msg": "Invalid platform fee rate",
+      "name": "InvalidPlatformFeeRate"
+    },
+    {
+      "code": 6036,
+      "msg": "Amount out must be greater than 0",
+      "name": "AmountOutMustBeGreaterThanZero"
+    },
+    {
+      "code": 6037,
+      "msg": "Invalid DampingTerm",
+      "name": "InvalidDampingTerm"
+    },
+    {
+      "code": 6038,
+      "msg": "Invalid mint",
+      "name": "InvalidMint"
+    },
+    {
+      "code": 6039,
+      "msg": "Invalid platform fee account",
+      "name": "InvalidPlatformFeeAccount"
+    },
+    {
+      "code": 6040,
+      "msg": "Invalid trim account",
+      "name": "InvalidTrimAccount"
+    },
+    {
+      "code": 6041,
+      "msg": "Invalid charge account",
+      "name": "InvalidChargeAccount"
+    },
+    {
+      "code": 6042,
+      "msg": "Invalid platform fee amount",
+      "name": "InvalidPlatformFeeAmount"
+    },
+    {
+      "code": 6043,
+      "msg": "Invalid fee token account",
+      "name": "InvalidFeeTokenAccount"
+    },
+    {
+      "code": 6044,
+      "msg": "Invalid sa authority",
+      "name": "InvalidSaAuthority"
+    },
+    {
+      "code": 6045,
+      "msg": "Invalid node from accounts",
+      "name": "InvalidNodeFromAccounts"
+    },
+    {
+      "code": 6046,
+      "msg": "Invalid node to accounts",
+      "name": "InvalidNodeToAccounts"
+    },
+    {
+      "code": 6047,
+      "msg": "Invalid source token account",
+      "name": "InvalidSourceTokenAccount"
+    },
+    {
+      "code": 6048,
+      "msg": "Invalid token account",
+      "name": "InvalidTokenAccount"
+    },
+    {
+      "code": 6049,
+      "msg": "Invalid destination token account",
+      "name": "InvalidDestinationTokenAccount"
+    },
+    {
+      "code": 6050,
+      "msg": "Commission account is none",
+      "name": "CommissionAccountIsNone"
+    },
+    {
+      "code": 6051,
+      "msg": "Platform fee account is none",
+      "name": "PlatformFeeAccountIsNone"
+    },
+    {
+      "code": 6052,
+      "msg": "Trim account is none",
+      "name": "TrimAccountIsNone"
+    },
+    {
+      "code": 6053,
+      "msg": "Charge account is none",
+      "name": "ChargeAccountIsNone"
+    },
+    {
+      "code": 6054,
+      "msg": "Invalid fee account",
+      "name": "InvalidFeeAccount"
+    },
+    {
+      "code": 6055,
+      "msg": "Invalid token owner",
+      "name": "InvalidTokenOwner"
+    },
+    {
+      "code": 6056,
+      "msg": "Sa authority is none",
+      "name": "SaAuthorityIsNone"
+    },
+    {
+      "code": 6057,
+      "msg": "Source token sa is none",
+      "name": "SourceTokenSaIsNone"
+    },
+    {
+      "code": 6058,
+      "msg": "Source token program is none",
+      "name": "SourceTokenProgramIsNone"
+    },
+    {
+      "code": 6059,
+      "msg": "Destination token sa is none",
+      "name": "DestinationTokenSaIsNone"
+    },
+    {
+      "code": 6060,
+      "msg": "Destination token program is none",
+      "name": "DestinationTokenProgramIsNone"
+    },
+    {
+      "code": 6061,
+      "msg": "Calculation result must be greater than zero",
+      "name": "ResultMustBeGreaterThanZero"
+    },
+    {
+      "code": 6062,
+      "msg": "Invalid account data",
+      "name": "InvalidAccountData"
+    },
+    {
+      "code": 6063,
+      "msg": "Invalid RFQ parameters",
+      "name": "InvalidRfqParameters"
+    },
+    {
+      "code": 6064,
+      "msg": "TOB mode requires authority PDA",
+      "name": "TobAuthorityPdaRequired"
+    },
+    {
+      "code": 6065,
+      "msg": "TOB mode with WSOL fees requires wsol_sa account",
+      "name": "TobWsolSaRequired"
+    },
+    {
+      "code": 6066,
+      "msg": "Invalid WSOL SA account",
+      "name": "InvalidWsolSa"
+    },
+    {
+      "code": 6067,
+      "msg": "Invalid commission account",
+      "name": "InvalidCommissionAccount"
+    },
+    {
+      "code": 6068,
+      "msg": "Invalid actual amount in",
+      "name": "InvalidActualAmountIn"
+    },
+    {
+      "code": 6069,
+      "msg": "Unexpected SA token account in CPI",
+      "name": "UnexpectedSaTokenAccount"
+    },
+    {
+      "code": 6070,
+      "msg": "Invalid source token sa mint",
+      "name": "InvalidSourceTokenSaMint"
+    },
+    {
+      "code": 6071,
+      "msg": "Invalid destination token sa mint",
+      "name": "InvalidDestinationTokenSaMint"
+    },
+    {
+      "code": 6072,
+      "msg": "Insufficient funds",
+      "name": "InsufficientFunds"
+    },
+    {
+      "code": 6073,
+      "msg": "Sa authority lamports decreased",
+      "name": "SaAuthorityLamportsDecreased"
+    },
+    {
+      "code": 6074,
+      "msg": "Invalid token program",
+      "name": "InvalidTokenProgram"
+    },
+    {
+      "code": 6075,
+      "msg": "Invalid signer",
+      "name": "InvalidSigner"
+    },
+    {
+      "code": 6076,
+      "msg": "Invalid associated token program",
+      "name": "InvalidAssociatedTokenProgram"
+    },
+    {
+      "code": 6077,
+      "msg": "Token program is none",
+      "name": "TokenProgramIsNone"
+    },
+    {
+      "code": 6078,
+      "msg": "Associated token program is none",
+      "name": "AssociatedTokenProgramIsNone"
+    },
+    {
+      "code": 6079,
+      "msg": "System program is none",
+      "name": "SystemProgramIsNone"
+    },
+    {
+      "code": 6080,
+      "msg": "Insufficient balance for transfer",
+      "name": "InsufficientBalance"
+    },
+    {
+      "code": 6081,
+      "msg": "SOL receiver must be a system account",
+      "name": "SolReceiverMustBeSystemAccount"
+    },
+    {
+      "code": 6082,
+      "msg": "SOL receiver requires acc_close_flag to be true",
+      "name": "SolReceiverRequiresAccCloseFlag"
+    },
+    {
+      "code": 6083,
+      "msg": "Destination must be wSOL when sol_receiver is specified",
+      "name": "DestinationMustBeWsolForSolReceiver"
+    },
+    {
+      "code": 6084,
+      "msg": "Invalid goonfi parameters",
+      "name": "InvalidGoonfiParameters"
+    },
+    {
+      "code": 6085,
+      "msg": "Adapter abort",
+      "name": "AdapterAbort"
+    },
+    {
+      "code": 6086,
+      "msg": "Inconsistent fee account types",
+      "name": "InconsistentFeeAccountTypes"
+    },
+    {
+      "code": 6087,
+      "msg": "Receiver must be a token account",
+      "name": "ReceiverMustBeTokenAccount"
+    },
+    {
+      "code": 6088,
+      "msg": "Receiver must be a WSOL token account",
+      "name": "ReceiverMustBeWsolAccount"
+    },
+    {
+      "code": 6089,
+      "msg": "The commission fee account and trim account are different types.",
+      "name": "InconsistentCommissionAndTrimAccountTypes"
+    },
+    {
+      "code": 6090,
+      "msg": "No available node index to support returning to START_INDEX",
+      "name": "NoAvailableNodeIndexForReturnToStart"
+    },
+    {
+      "code": 6091,
+      "msg": "Invalid token ledger token account",
+      "name": "InvalidTokenLedgerTokenAccount"
+    },
+    {
+      "code": 6092,
+      "msg": "Token ledger delta calculation failed",
+      "name": "TokenLedgerDeltaCalculationFailure"
+    }
+  ],
+  "events": [
+    {
+      "discriminator": [
+        21,
+        94,
+        224,
+        53,
+        220,
+        232,
+        193,
+        94
+      ],
+      "name": "SwapCpiEvent2"
+    },
+    {
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
+      ],
+      "name": "SwapEvent"
+    },
+    {
+      "discriminator": [
+        244,
+        105,
+        184,
+        90,
+        60,
+        165,
+        36,
+        33
+      ],
+      "name": "SwapTobV2CpiEvent2"
+    },
+    {
+      "discriminator": [
+        102,
+        16,
+        181,
+        62,
+        201,
+        71,
+        212,
+        41
+      ],
+      "name": "SwapTocV2CpiEvent2"
+    },
+    {
+      "discriminator": [
+        12,
+        134,
+        38,
+        93,
+        167,
+        151,
+        42,
+        69
+      ],
+      "name": "SwapWithFeesCpiEvent2"
+    },
+    {
+      "discriminator": [
+        84,
+        79,
+        219,
+        247,
+        218,
+        156,
+        219,
+        177
+      ],
+      "name": "SwapWithFeesCpiEventEnhanced2"
+    }
+  ],
+  "instructions": [
+    {
+      "accounts": [
+        {
+          "address": "CjoV5B96reuCfPh2rRK11G1QptG97jZdyZArTn3EN1Mj",
+          "name": "signer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "receiver",
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "ARu4n5mFdZogZAravu7CcizaojWnS6oqka37gdLT5SZn",
+          "name": "sa_authority",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        62,
+        198,
+        214,
+        193,
+        213,
+        159,
+        108,
+        210
+      ],
+      "name": "claim"
+    },
+    {
+      "accounts": [
+        {
+          "address": "CjoV5B96reuCfPh2rRK11G1QptG97jZdyZArTn3EN1Mj",
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "address": "ARu4n5mFdZogZAravu7CcizaojWnS6oqka37gdLT5SZn",
+          "docs": [
+            "PumpFun transfers claimed SOL directly to this account (account[0] in the CPI)."
+          ],
+          "name": "sa_authority",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Holds native SOL accumulated as cashback; emptied by PumpFun during claim."
+          ],
+          "name": "user_volume_accumulator",
+          "writable": true
+        },
+        {
+          "docs": [
+            "after PumpFun deposits it there."
+          ],
+          "name": "receiver",
+          "writable": true
+        },
+        {
+          "address": "Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1",
+          "name": "event_authority"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        },
+        {
+          "address": "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P",
+          "name": "pumpfun_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        83,
+        1,
+        245,
+        125,
+        201,
+        207,
+        209,
+        249
+      ],
+      "name": "claim_cashback_pumpfun"
+    },
+    {
+      "accounts": [
+        {
+          "address": "CjoV5B96reuCfPh2rRK11G1QptG97jZdyZArTn3EN1Mj",
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "address": "ARu4n5mFdZogZAravu7CcizaojWnS6oqka37gdLT5SZn",
+          "name": "sa_authority",
+          "writable": true
+        },
+        {
+          "name": "user_volume_accumulator",
+          "writable": true
+        },
+        {
+          "address": "So11111111111111111111111111111111111111112",
+          "name": "wsol_mint"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "spl_token_program"
+        },
+        {
+          "name": "uva_wsol_ata",
+          "writable": true
+        },
+        {
+          "docs": [
+            "PumpSwap requires account[5] to be a token account owned by authority_pda",
+            "(same owner as user_volume_accumulator). WSOL is deposited here by PumpSwap,",
+            "then forwarded to receiver_wsol_ata via a second SPL transfer."
+          ],
+          "name": "sa_wsol_ata",
+          "writable": true
+        },
+        {
+          "name": "receiver_wsol_ata",
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        },
+        {
+          "address": "GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR",
+          "name": "event_authority"
+        },
+        {
+          "address": "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA",
+          "name": "pumpswap_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        253,
+        242,
+        176,
+        173,
+        217,
+        78,
+        100,
+        25
+      ],
+      "name": "claim_cashback_pumpswap"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "token_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "token_mint"
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "So11111111111111111111111111111111111111112",
+          "name": "token_mint"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bump",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        147,
+        241,
+        123,
+        100,
+        244,
+        132,
+        174,
+        118
+      ],
+      "name": "create_token_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "token_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "token_mint"
+              },
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "arg",
+                "path": "seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "So11111111111111111111111111111111111111112",
+          "name": "token_mint"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bump",
+          "type": "u8"
+        },
+        {
+          "name": "seed",
+          "type": "u32"
+        }
+      ],
+      "discriminator": [
+        125,
+        191,
+        239,
+        140,
+        66,
+        8,
+        9,
+        228
+      ],
+      "name": "create_token_account_with_seed"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "token_ledger",
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        157,
+        116,
+        66,
+        59,
+        137,
+        180,
+        49,
+        157
+      ],
+      "name": "init_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  107,
+                  120,
+                  95,
+                  115,
+                  97
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        19,
+        44,
+        130,
+        148,
+        72,
+        56,
+        44,
+        238
+      ],
+      "name": "proxy_swap"
+    },
+    {
+      "accounts": [
+        {
+          "name": "token_ledger",
+          "writable": true
+        },
+        {
+          "docs": [
+            "SPL / Token-2022 token account to snapshot."
+          ],
+          "name": "token_account"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        228,
+        85,
+        185,
+        112,
+        78,
+        79,
+        77,
+        2
+      ],
+      "name": "set_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
+      "name": "swap"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        170,
+        41,
+        85,
+        177,
+        132,
+        80,
+        31,
+        53
+      ],
+      "name": "swap_tob"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        },
+        {
+          "name": "charge_rate",
+          "type": "u16"
+        }
+      ],
+      "discriminator": [
+        190,
+        156,
+        169,
+        176,
+        149,
+        154,
+        161,
+        108
+      ],
+      "name": "swap_tob_enhanced"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "parent_commission_account",
+          "writable": true
+        },
+        {
+          "name": "child_commission_account",
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "total_commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "parent_commission_rate",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        72,
+        1,
+        215,
+        242,
+        8,
+        75,
+        54,
+        216
+      ],
+      "docs": [
+        "Used to support commission distribution between parent and child nodes in TOB business"
+      ],
+      "name": "swap_tob_v2"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional SOL receiver account",
+            "- None: normal swap or SOL stays with payer",
+            "- Some: SOL receiver when converting wSOL -> SOL"
+          ],
+          "name": "sol_receiver",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        223,
+        170,
+        216,
+        234,
+        204,
+        6,
+        241,
+        25
+      ],
+      "name": "swap_tob_with_receiver"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional SOL receiver account",
+            "- None: normal swap or SOL stays with payer",
+            "- Some: SOL receiver when converting wSOL -> SOL"
+          ],
+          "name": "sol_receiver",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_ledger"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgsTokenLedger"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        239,
+        93,
+        10,
+        202,
+        161,
+        134,
+        127,
+        130
+      ],
+      "name": "swap_tob_with_receiver_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "token_ledger"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgsTokenLedger"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        },
+        {
+          "name": "trim_rate",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        36,
+        92,
+        147,
+        219,
+        26,
+        176,
+        159,
+        90
+      ],
+      "name": "swap_tob_with_token_ledger"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        }
+      ],
+      "discriminator": [
+        187,
+        201,
+        212,
+        51,
+        16,
+        155,
+        236,
+        60
+      ],
+      "name": "swap_toc"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "source_mint"
+        },
+        {
+          "name": "destination_mint"
+        },
+        {
+          "name": "parent_commission_account",
+          "writable": true
+        },
+        {
+          "name": "child_commission_account",
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "sa_authority",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "destination_token_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "source_token_program",
+          "optional": true
+        },
+        {
+          "name": "destination_token_program",
+          "optional": true
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program",
+          "optional": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "SwapArgs"
+            }
+          }
+        },
+        {
+          "name": "total_commission_info",
+          "type": "u32"
+        },
+        {
+          "name": "parent_commission_rate",
+          "type": "u32"
+        },
+        {
+          "name": "platform_fee_rate",
+          "type": "u16"
+        }
+      ],
+      "discriminator": [
+        127,
+        214,
+        107,
+        189,
+        23,
+        90,
+        47,
+        104
+      ],
+      "docs": [
+        "Used to support commission distribution between parent and child nodes in TOC business"
+      ],
+      "name": "swap_toc_v2"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "payer_wsol_account",
+          "writable": true
+        },
+        {
+          "address": "So11111111111111111111111111111111111111112",
+          "name": "wsol_mint"
+        },
+        {
+          "name": "temp_wsol_account",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  101,
+                  109,
+                  112,
+                  95,
+                  119,
+                  115,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "payer"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Used for signing fee transfers from authority_pda (SOL) or wsol_sa (WSOL)"
+          ],
+          "name": "authority_pda",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "This is the authority_pda's associated token account for WSOL"
+          ],
+          "name": "wsol_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "PlatformFeeWrapUnwrapArgs"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        220,
+        101,
+        139,
+        249,
+        41,
+        190,
+        118,
+        199
+      ],
+      "name": "wrap_unwrap"
+    },
+    {
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "payer_wsol_account",
+          "writable": true
+        },
+        {
+          "address": "So11111111111111111111111111111111111111112",
+          "name": "wsol_mint"
+        },
+        {
+          "name": "temp_wsol_account",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  101,
+                  109,
+                  112,
+                  95,
+                  119,
+                  115,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "payer"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "commission_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "platform_fee_account",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Used for signing fee transfers from authority_pda (SOL) or wsol_sa (WSOL)"
+          ],
+          "name": "authority_pda",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "This is the authority_pda's associated token account for WSOL"
+          ],
+          "name": "wsol_sa",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        },
+        {
+          "docs": [
+            "- Wrap: WSOL token account (ATA) to receive WSOL",
+            "- Unwrap: System account (EOA) to receive SOL"
+          ],
+          "name": "receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95,
+                  95,
+                  101,
+                  118,
+                  101,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "PlatformFeeWrapUnwrapArgs"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        123,
+        25,
+        47,
+        134,
+        233,
+        167,
+        171,
+        170
+      ],
+      "docs": [
+        "Wrap/Unwrap with optional specified receiver",
+        "- Wrap (SOL -> WSOL): receiver is WSOL token account (ATA)",
+        "- Unwrap (WSOL -> SOL): receiver is system account (EOA)",
+        "Transfer amount:",
+        "- From fee: amount_in",
+        "- To fee: amount_in - fees"
+      ],
+      "name": "wrap_unwrap_with_receiver"
+    }
+  ],
+  "metadata": {
+    "description": "Created with Anchor",
+    "name": "OKX Labs 2",
+    "spec": "0.1.0",
+    "version": "0.1.0"
+  },
+  "types": [
+    {
+      "name": "Dex",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SplTokenSwap"
+          },
+          {
+            "name": "StableSwap"
+          },
+          {
+            "name": "Whirlpool"
+          },
+          {
+            "name": "MeteoraDynamicpool"
+          },
+          {
+            "name": "RaydiumSwap"
+          },
+          {
+            "name": "RaydiumStableSwap"
+          },
+          {
+            "name": "RaydiumClmmSwap"
+          },
+          {
+            "name": "AldrinExchangeV1"
+          },
+          {
+            "name": "AldrinExchangeV2"
+          },
+          {
+            "name": "LifinityV1"
+          },
+          {
+            "name": "LifinityV2"
+          },
+          {
+            "name": "RaydiumClmmSwapV2"
+          },
+          {
+            "name": "FluxBeam"
+          },
+          {
+            "name": "MeteoraDlmm"
+          },
+          {
+            "name": "RaydiumCpmmSwap"
+          },
+          {
+            "name": "OpenBookV2"
+          },
+          {
+            "name": "WhirlpoolV2"
+          },
+          {
+            "name": "Phoenix"
+          },
+          {
+            "name": "ObricV2"
+          },
+          {
+            "name": "SanctumAddLiq"
+          },
+          {
+            "name": "SanctumRemoveLiq"
+          },
+          {
+            "name": "SanctumNonWsolSwap"
+          },
+          {
+            "name": "SanctumWsolSwap"
+          },
+          {
+            "name": "PumpfunBuy"
+          },
+          {
+            "name": "PumpfunSell"
+          },
+          {
+            "name": "StabbleSwap"
+          },
+          {
+            "name": "SanctumRouter"
+          },
+          {
+            "name": "MeteoraVaultDeposit"
+          },
+          {
+            "name": "MeteoraVaultWithdraw"
+          },
+          {
+            "name": "Saros"
+          },
+          {
+            "name": "MeteoraLst"
+          },
+          {
+            "name": "Solfi"
+          },
+          {
+            "name": "QualiaSwap"
+          },
+          {
+            "name": "Zerofi"
+          },
+          {
+            "name": "PumpfunammBuy"
+          },
+          {
+            "name": "PumpfunammSell"
+          },
+          {
+            "name": "Virtuals"
+          },
+          {
+            "name": "VertigoBuy"
+          },
+          {
+            "name": "VertigoSell"
+          },
+          {
+            "name": "PerpetualsAddLiq"
+          },
+          {
+            "name": "PerpetualsRemoveLiq"
+          },
+          {
+            "name": "PerpetualsSwap"
+          },
+          {
+            "name": "RaydiumLaunchpad"
+          },
+          {
+            "name": "LetsBonkFun"
+          },
+          {
+            "name": "Woofi"
+          },
+          {
+            "name": "MeteoraDbc"
+          },
+          {
+            "name": "MeteoraDlmmSwap2"
+          },
+          {
+            "name": "MeteoraDAMMV2"
+          },
+          {
+            "name": "Gavel"
+          },
+          {
+            "name": "BoopfunBuy"
+          },
+          {
+            "name": "BoopfunSell"
+          },
+          {
+            "name": "MeteoraDbc2"
+          },
+          {
+            "name": "GooseFX"
+          },
+          {
+            "name": "Dooar"
+          },
+          {
+            "name": "Numeraire"
+          },
+          {
+            "name": "SaberDecimalWrapperDeposit"
+          },
+          {
+            "name": "SaberDecimalWrapperWithdraw"
+          },
+          {
+            "name": "SarosDlmm"
+          },
+          {
+            "name": "OneDexSwap"
+          },
+          {
+            "name": "Manifest"
+          },
+          {
+            "name": "ByrealClmm"
+          },
+          {
+            "name": "PancakeSwapV3Swap"
+          },
+          {
+            "name": "PancakeSwapV3SwapV2"
+          },
+          {
+            "name": "Tessera"
+          },
+          {
+            "fields": [
+              {
+                "name": "rfq_id",
+                "type": "u64"
+              },
+              {
+                "name": "expected_maker_amount",
+                "type": "u64"
+              },
+              {
+                "name": "expected_taker_amount",
+                "type": "u64"
+              },
+              {
+                "name": "maker_send_amount",
+                "type": "u64"
+              },
+              {
+                "name": "taker_send_amount",
+                "type": "u64"
+              },
+              {
+                "name": "expiry",
+                "type": "u64"
+              },
+              {
+                "name": "maker_use_native_sol",
+                "type": "bool"
+              },
+              {
+                "name": "taker_use_native_sol",
+                "type": "bool"
+              }
+            ],
+            "name": "SolRfq"
+          },
+          {
+            "name": "Humidifi"
+          },
+          {
+            "name": "HeavenBuy"
+          },
+          {
+            "name": "HeavenSell"
+          },
+          {
+            "name": "SolfiV2"
+          },
+          {
+            "name": "Goonfi"
+          },
+          {
+            "name": "MoonitBuy"
+          },
+          {
+            "name": "MoonitSell"
+          },
+          {
+            "name": "RaydiumSwapV2"
+          },
+          {
+            "name": "Whalestreet"
+          },
+          {
+            "fields": [
+              {
+                "name": "bonding_curve_bump",
+                "type": "u8"
+              },
+              {
+                "name": "bonding_curve_sol_associated_account_bump",
+                "type": "u8"
+              }
+            ],
+            "name": "SugarMoneyBuy"
+          },
+          {
+            "fields": [
+              {
+                "name": "bonding_curve_bump",
+                "type": "u8"
+              },
+              {
+                "name": "bonding_curve_sol_associated_account_bump",
+                "type": "u8"
+              }
+            ],
+            "name": "SugarMoneySell"
+          },
+          {
+            "name": "MeteoraDAMMV2Swap2"
+          },
+          {
+            "name": "AlphaQ"
+          },
+          {
+            "name": "FutarchyAmm"
+          },
+          {
+            "name": "PumpfunBuy2"
+          },
+          {
+            "name": "PumpfunSell2"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              }
+            ],
+            "name": "HumidifiSwap2"
+          },
+          {
+            "fields": [
+              {
+                "name": "id",
+                "type": "u128"
+              }
+            ],
+            "name": "Scorch"
+          },
+          {
+            "name": "JupiterLendDeposit"
+          },
+          {
+            "name": "JupiterLendRedeem"
+          },
+          {
+            "name": "TaurusFi"
+          },
+          {
+            "name": "BisonFi"
+          },
+          {
+            "name": "GoonfiV2"
+          },
+          {
+            "name": "Quantum"
+          },
+          {
+            "name": "BoopfunBuy2"
+          },
+          {
+            "name": "BoopfunSell2"
+          },
+          {
+            "name": "ByrealClmm2"
+          },
+          {
+            "name": "Dooar2"
+          },
+          {
+            "name": "HeavenBuy2"
+          },
+          {
+            "name": "HeavenSell2"
+          },
+          {
+            "name": "MoonitBuy2"
+          },
+          {
+            "name": "MoonitSell2"
+          },
+          {
+            "name": "SaberDecimalWrapperDeposit2"
+          },
+          {
+            "name": "SaberDecimalWrapperWithdraw2"
+          },
+          {
+            "name": "ByrealPropAmm"
+          },
+          {
+            "fields": [
+              {
+                "name": "swap_id",
+                "type": "u64"
+              }
+            ],
+            "name": "SanctumPrefundSwapViaStake"
+          },
+          {
+            "name": "AbyssAmm"
+          },
+          {
+            "name": "Aquifer"
+          },
+          {
+            "fields": [
+              {
+                "name": "auth_amount_in",
+                "type": "u64"
+              },
+              {
+                "name": "auth",
+                "type": "u64"
+              }
+            ],
+            "name": "WhalestreetV2"
+          },
+          {
+            "fields": [
+              {
+                "name": "unix_timestamp",
+                "type": "u64"
+              },
+              {
+                "name": "msg_amount_in",
+                "type": "u64"
+              },
+              {
+                "name": "expect_amount_out",
+                "type": "u64"
+              },
+              {
+                "name": "slippage",
+                "type": "u16"
+              },
+              {
+                "name": "user_request_slot",
+                "type": "u64"
+              },
+              {
+                "name": "signature",
+                "type": {
+                  "array": [
+                    "u8",
+                    64
+                  ]
+                }
+              },
+              {
+                "name": "recovery_id",
+                "type": "u8"
+              }
+            ],
+            "name": "SolfiV2WithSig"
+          },
+          {
+            "name": "FusionAmm"
+          },
+          {
+            "name": "ScaleAmmBuy"
+          },
+          {
+            "name": "ScaleAmmSell"
+          },
+          {
+            "name": "ScaleVmmBuy"
+          },
+          {
+            "name": "ScaleVmmSell"
+          },
+          {
+            "name": "PumpfunBuy3"
+          },
+          {
+            "name": "PumpfunSell3"
+          },
+          {
+            "name": "PumpfunammBuy2"
+          },
+          {
+            "name": "PumpfunammSell2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlatformFeeWrapUnwrapArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "commission_info",
+            "type": "u32"
+          },
+          {
+            "name": "platform_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "tob",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Route",
+      "type": {
+        "fields": [
+          {
+            "name": "dex",
+            "type": {
+              "defined": {
+                "name": "Dex"
+              }
+            }
+          },
+          {
+            "name": "weight",
+            "type": "u16"
+          },
+          {
+            "name": "index",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapArgs",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "expect_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "slippage",
+            "type": "u16"
+          },
+          {
+            "name": "routes",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "Route"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Swap args for token-ledger swaps: no `amount_in` parameter.",
+        "`amount_in` is derived on-chain from `token_ledger` delta."
+      ],
+      "name": "SwapArgsTokenLedger",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "expect_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "slippage",
+            "type": "u16"
+          },
+          {
+            "name": "routes",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "Route"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapCpiEvent2",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "source_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "source_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "source_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "destination_token_change",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "dex",
+            "type": {
+              "defined": {
+                "name": "Dex"
+              }
+            }
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapTobV2CpiEvent2",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "source_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "source_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "source_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "destination_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "commission_direction",
+            "type": "bool"
+          },
+          {
+            "name": "total_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "parent_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "parent_commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "parent_commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "child_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "child_commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "child_commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "platform_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "trim_rate",
+            "type": "u8"
+          },
+          {
+            "name": "trim_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trim_account",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapTocV2CpiEvent2",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "source_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "source_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "source_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "destination_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "commission_direction",
+            "type": "bool"
+          },
+          {
+            "name": "total_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "parent_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "parent_commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "parent_commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "child_commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "child_commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "child_commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "platform_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_account",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapWithFeesCpiEvent2",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "source_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "source_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "source_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "destination_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "commission_direction",
+            "type": "bool"
+          },
+          {
+            "name": "commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "platform_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "trim_rate",
+            "type": "u8"
+          },
+          {
+            "name": "trim_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trim_account",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SwapWithFeesCpiEventEnhanced2",
+      "type": {
+        "fields": [
+          {
+            "name": "order_id",
+            "type": "u64"
+          },
+          {
+            "name": "source_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "source_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "destination_token_account_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "source_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "destination_token_change",
+            "type": "u64"
+          },
+          {
+            "name": "commission_direction",
+            "type": "bool"
+          },
+          {
+            "name": "commission_rate",
+            "type": "u32"
+          },
+          {
+            "name": "commission_amount",
+            "type": "u64"
+          },
+          {
+            "name": "commission_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "platform_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "trim_rate",
+            "type": "u8"
+          },
+          {
+            "name": "trim_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trim_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "charge_rate",
+            "type": "u16"
+          },
+          {
+            "name": "charge_amount",
+            "type": "u64"
+          },
+          {
+            "name": "charge_account",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Token ledger PDA used to snapshot a token account balance within a transaction.",
+        "",
+        "Seeds: `[b\"token_ledger\", [index]]`, where `index = 0..=255` (u8)."
+      ],
+      "name": "TokenLedger",
+      "type": {
+        "fields": [
+          {
+            "name": "token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 1. Why this PR exists

OKX Router (`proVF4pMXVaYqmy4NjniPh4pqKNfMmsihgd4wdkCX3u`) swaps on Solana fell through to the unknown-program catch-all visualizer. Signers saw raw instruction bytes instead of a decoded instruction name, named accounts, and arguments — making it hard to verify what they were signing.

This adds an IDL-backed preset so OKX Router instructions render as structured, human-readable fields.

## 2. What changed

- New Solana preset `presets/okx_router/` with `OkxRouterVisualizer`, following the existing IDL-preset pattern (mirrors `neutral_trade`).
- Bundles the on-chain Anchor IDL (`okx_router.json`, ~3.5k lines) via `include_str!`; the visualizer parses instructions with `parse_instruction_with_idl` against the bundled IDL.
- Decodes the 8-byte Anchor discriminator, maps account positions to IDL account names, and renders instruction name, program ID, discriminator, named accounts, and decoded args in condensed/expanded preview layouts, with a raw-hex fallback.
- `SolanaIntegrationConfig` registers the program with a `"*" -> "*"` wildcard so all OKX Router instructions route to this visualizer.
- Registered by adding `pub mod okx_router;` to `presets/mod.rs` — the `build.rs` script auto-discovers the directory and wires `OkxRouterVisualizer` into `available_visualizers()`.

## 3. Why this is safe

- **Backward compatibility:** Purely additive. No existing preset, type, or registration path is modified beyond one `pub mod` line. Before this, OKX Router txs hit the unknown-program catch-all; now they hit a dedicated visualizer. No other chain or program is affected.
- **How it was built:** Reuses the established `InstructionVisualizer` + `SolanaIntegrationConfig` + `build.rs` auto-discovery mechanism already used by every other Solana preset, so it inherits their behavior and routing.
- **Risks mitigated:** Instruction data shorter than 8 bytes and unknown discriminators return `VisualSignError` rather than panicking or mis-rendering. Decoding failures surface as errors; the field carries a raw-hex fallback so nothing is silently dropped.

### Checks run (by agent)
- `cargo test -p visualsign-solana okx` — 4 passed (IDL loads, all discriminators are 8 bytes, unknown discriminator errors, short data errors)
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean
- `cargo fmt --check -p visualsign-solana` — clean

### Manual steps needed (by human)
None — fully automated by CI.

## 4. How this is maintainable

- Follows the exact same structure as other presets (`neutral_trade`, `metadao_futarchy`), so a fresh developer recognizes the pattern immediately. The `solana-add-idl` skill documents how to add more.
- Registration is automatic via `build.rs` directory scanning — no central registry to keep in sync; the directory name (`okx_router`) deterministically maps to `OkxRouterVisualizer`.
- Tests guard the IDL contract: that it loads, that every instruction has an 8-byte discriminator, and that malformed input errors rather than panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
