### PR TITLE
chore: gitignore private .claude/ working paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@
 out
 docs/superpowers/
 .surfpool/
+
+# Claude Code private/working files. The shared team config under .claude/
+# (settings.json, hooks/, skills/) IS tracked and intentionally not matched
+# here; everything below is per-user/agent scratch that must never be committed
+# (a plan doc slipped into a PR once -- see the trust-model PR).
+.claude/plans/
+.claude/projects/
+.claude/todos/
+.claude/shell-snapshots/
+.claude/statsig/
+.claude/settings.local.json


### PR DESCRIPTION
## Why

`.claude/` is not gitignored, and while the shared team config under it (`settings.json`, `hooks/`, `skills/`) is intentionally tracked, the **private** working paths are not — so a `.claude/plans/` design doc slipped into a PR (#355). Private/agent scratch files shouldn't land in a public repo.

## What

Ignore the per-user/agent scratch paths, while leaving the tracked shared config untouched:
- `.claude/plans/`, `.claude/projects/`, `.claude/todos/`, `.claude/shell-snapshots/`, `.claude/statsig/`, `.claude/settings.local.json`

Verified with `git check-ignore`: the private paths are now ignored, and `.claude/settings.json` / `.claude/hooks/` / `.claude/skills/` remain tracked.

## Follow-up

#355 still needs its already-committed `.claude/plans/...` file removed (`git rm --cached`); a `.gitignore` only stops *new* additions, it doesn't untrack an already-committed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)