### PR TITLE
draft: route external Custom chains from the --chain string

### DIFF
--- a/src/parser/cli-core/src/chains.rs
+++ b/src/parser/cli-core/src/chains.rs
@@ -13,18 +13,40 @@ fn chain_string_mapping() -> BTreeMap<&'static str, Chain> {
     mapping
 }
 
-/// Parses a chain string into a Chain enum value.
-/// Returns `Chain::Unspecified` if the chain string is not recognized.
+/// Parses a chain string into a `Chain`.
+///
+/// Built-in chains map to their dedicated variant. Any other string maps to
+/// `Chain::Custom`, so a chain contributed by an external [`ChainPlugin`] is
+/// selected by the plugin that registered under the matching `Chain::Custom`.
 #[must_use]
 pub fn parse_chain(chain_str: &str) -> Chain {
     chain_string_mapping()
         .get(chain_str)
         .cloned()
-        .unwrap_or(Chain::Unspecified)
+        .unwrap_or_else(|| Chain::Custom(chain_str.to_string()))
 }
 
 /// Returns a vector of all available chain names as string slices.
 #[must_use]
 pub fn available_chains() -> Vec<&'static str> {
     chain_string_mapping().keys().copied().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_chain_maps_builtins() {
+        assert_eq!(parse_chain("ethereum"), Chain::Ethereum);
+        assert_eq!(parse_chain("solana"), Chain::Solana);
+    }
+
+    #[test]
+    fn parse_chain_maps_unknown_to_custom() {
+        // A chain contributed by an external ChainPlugin (e.g. NEAR) is not a
+        // built-in, but must still resolve so the plugin registered under the
+        // matching Chain::Custom is selected by `run`.
+        assert_eq!(parse_chain("near"), Chain::Custom("near".to_string()));
+    }
 }


### PR DESCRIPTION
## Problem

`parser_cli_core` exists so external workspaces can compose their own
`parser_cli` binary with a custom set of chain plugins (see the crate docs).
A plugin registers its converter under a `Chain`; a chain without a dedicated
enum variant uses `Chain::Custom("name")`.

But `chains::parse_chain` maps any unrecognized string to
`Chain::Unspecified`, and both code paths that turn `--chain <string>` into a
`Chain` go through it:

- plugin selection in `run` (`plugins.iter().find(|p| p.chain() == chain)`)
- registry lookup in `output::parse_and_display` (`convert_transaction(&parse_chain(chain), ...)`)

So a plugin registered under `Chain::Custom("foo")` can never be selected:
`parse_chain("foo")` yields `Unspecified`, which matches neither the plugin
nor its registry entry. The CLI even lists the chain as supported (that list
is built from the plugins) while rejecting it — a confusing contradiction.

## Fix

Map unrecognized chain strings to `Chain::Custom(string)` instead of
`Chain::Unspecified`, mirroring the existing `impl FromStr for Chain`
contract. Built-in chains are unaffected (matched first). The plugin that
registered under that `Custom` chain is now selected, so an external
workspace can add a chain purely by depending on its chain crate — no edit to
upstream chain-string parsing.

## Test plan

- [x] New unit tests in `chains.rs`: built-ins still map to their variant; an
      unknown string (`"near"`) maps to `Chain::Custom("near")`.
- [x] `cargo test -p parser_cli_core` — 28 passed.
- [x] `cargo test -p parser_cli` — 8 passed (no existing behavior regressed).
- [x] `make -C src fmt` + `make -C src lint` — clean across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)