### PR TITLE
refactor(ethereum): collapse duplicate network_id->chain_id mapping

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/CLAUDE.md
+++ b/src/chain_parsers/visualsign-ethereum/CLAUDE.md
@@ -77,10 +77,12 @@ All amount and number fields validate the input using a regex pattern:
 The `token_metadata` module provides canonical wallet format for token data:
 
 ```rust
-use crate::token_metadata::{ChainMetadata, TokenMetadata, ErcStandard, parse_network_id};
+use crate::networks::network_id_to_chain_id;
+use crate::token_metadata::{ChainMetadata, TokenMetadata, ErcStandard};
 
-// Parse network identifier to chain ID
-let chain_id = parse_network_id("ETHEREUM_MAINNET")?; // Returns 1
+// Parse network identifier to chain ID (canonical mapping in networks.rs).
+// Returns Option<u64>; callers handle the None (unknown-network) case.
+let chain_id = network_id_to_chain_id("ETHEREUM_MAINNET"); // Some(1)
 
 // Create token metadata
 let token = TokenMetadata {
@@ -97,11 +99,14 @@ let hash = compute_metadata_hash(protobuf_bytes);
 
 ### Supported Networks
 
-- `ETHEREUM_MAINNET` → chain_id: 1
-- `POLYGON_MAINNET` → chain_id: 137
-- `ARBITRUM_MAINNET` → chain_id: 42161
-- `OPTIMISM_MAINNET` → chain_id: 10
-- `BASE_MAINNET` → chain_id: 8453
+The canonical `network_id -> chain_id` mapping lives in `networks.rs` (the `networks!`
+table) and covers all supported networks (case-insensitive). Examples:
+
+- `ETHEREUM_MAINNET` -> chain_id: 1
+- `POLYGON_MAINNET` -> chain_id: 137
+- `ARBITRUM_MAINNET` -> chain_id: 42161
+- `OPTIMISM_MAINNET` -> chain_id: 10
+- `BASE_MAINNET` -> chain_id: 8453
 
 ## Registry
 
@@ -152,7 +157,7 @@ let nested = context.for_nested_call(nested_contract, nested_calldata);
 2. **Handle errors** - All field builders return `Result` types
 3. **Prefer canonical types** - Use `TokenMetadata` from `token_metadata` module
 4. **Use registry for lookups** - Don't duplicate token metadata storage
-5. **Network ID mapping** - Always use `parse_network_id()` to convert string IDs to chain IDs
+5. **Network ID mapping** - Always use `networks::network_id_to_chain_id()` to convert string IDs to chain IDs
 6. **Validate amounts** - Field builders validate number formats automatically
 7. **Chain ID + Address as key** - Always use (chain_id, Address) tuple for token lookups
 
@@ -175,7 +180,7 @@ src/
 
 - `TokenMetadata`: canonical wallet token format with symbol, name, erc_standard, contract_address, decimals
 - `ChainMetadata`: grouping of tokens by network, sent from wallets as protobuf
-- `parse_network_id()`: maps network identifiers to chain IDs
+- `networks::network_id_to_chain_id()`: maps network identifiers to chain IDs
 - `compute_metadata_hash()`: SHA256 hashing of protobuf metadata bytes
 - `ContractRegistry`: (chain_id, Address) → TokenMetadata mapping for efficient lookups
 - Field builders from visualsign: reusable field construction utilities

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -1,8 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::abi_metadata::sign_abi_for_cli;
-use crate::networks::parse_network;
-use crate::token_metadata::parse_network_id;
+use crate::networks::{network_id_to_chain_id, parse_network};
 use clap::Args as ClapArgs;
 use generated::parser::{Abi, AbiType, ChainMetadata, EthereumMetadata, chain_metadata::Metadata};
 use visualsign::registry::{Chain, TransactionConverterRegistry};
@@ -294,15 +293,16 @@ pub(crate) fn create_chain_metadata(
 
     // The ABI signature binds the chain id, so the numeric chain id is only needed
     // when there is at least one ABI to sign. Derive it lazily inside each branch so
-    // the no-ABI path still works for networks `parse_network_id` does not number
-    // (it only knows the canonical mainnets). The double lookup when both lists are
-    // non-empty is cheap and avoids sharing an `Option` across the lint-restricted
-    // borrow.
+    // the no-ABI path stays decoupled from the numeric lookup. The double lookup when
+    // both lists are non-empty is cheap and avoids sharing an `Option` across the
+    // lint-restricted borrow. `network_id` is already a canonical id from
+    // `parse_network`, so `network_id_to_chain_id` resolves it for every known network.
     let mut abi_mappings = if abi_json_mappings.is_empty() {
         BTreeMap::new()
     } else {
-        let chain_id = parse_network_id(&network_id)
-            .map_err(|e| format!("cannot sign ABI mappings for network '{network_id}': {e}"))?;
+        let chain_id = network_id_to_chain_id(&network_id).ok_or_else(|| {
+            format!("cannot sign ABI mappings for network '{network_id}': unknown network ID")
+        })?;
         eprintln!("Loading custom ABIs:");
         let (mappings, valid_count) = build_abi_mappings_from_files(abi_json_mappings, chain_id);
         eprintln!(
@@ -314,8 +314,8 @@ pub(crate) fn create_chain_metadata(
     };
 
     if !abi_proxy_mappings.is_empty() {
-        let chain_id = parse_network_id(&network_id).map_err(|e| {
-            format!("cannot sign proxy ABI mappings for network '{network_id}': {e}")
+        let chain_id = network_id_to_chain_id(&network_id).ok_or_else(|| {
+            format!("cannot sign proxy ABI mappings for network '{network_id}': unknown network ID")
         })?;
         eprintln!("Applying proxy mappings:");
         apply_proxy_mappings(

--- a/src/chain_parsers/visualsign-ethereum/src/registry.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/registry.rs
@@ -1,4 +1,5 @@
-use crate::token_metadata::{ChainMetadata, TokenMetadata, parse_network_id};
+use crate::networks::network_id_to_chain_id;
+use crate::token_metadata::{ChainMetadata, TokenMetadata};
 use alloy_primitives::{Address, U256, utils::format_units};
 use std::collections::BTreeMap;
 
@@ -406,7 +407,8 @@ impl ContractRegistry {
     /// # Returns
     /// `Ok(())` on success, `Err(String)` if network_id is unknown or any token registration fails
     pub fn load_chain_metadata(&mut self, chain_metadata: &ChainMetadata) -> Result<(), String> {
-        let chain_id = parse_network_id(&chain_metadata.network_id).map_err(|e| e.to_string())?;
+        let chain_id = network_id_to_chain_id(&chain_metadata.network_id)
+            .ok_or_else(|| format!("Unknown network ID: {}", chain_metadata.network_id))?;
 
         let errors: Vec<String> = chain_metadata
             .assets

--- a/src/chain_parsers/visualsign-ethereum/src/token_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/token_metadata.rs
@@ -50,66 +50,13 @@ pub struct TokenMetadata {
 ///
 /// This is the canonical format for wallets to send token metadata.
 /// Network ID is sent as a string (e.g., "ETHEREUM_MAINNET") and is converted
-/// to a numeric chain ID by parse_network_id().
+/// to a numeric chain ID by `networks::network_id_to_chain_id`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChainMetadata {
     /// Network identifier as string (e.g., "ETHEREUM_MAINNET")
     pub network_id: String,
     /// Map of token symbol to token metadata
     pub assets: BTreeMap<String, TokenMetadata>,
-}
-
-/// Error type for token metadata operations
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TokenMetadataError {
-    /// Unknown network ID
-    UnknownNetworkId(String),
-    /// Hash computation error
-    HashError(String),
-}
-
-impl std::fmt::Display for TokenMetadataError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TokenMetadataError::UnknownNetworkId(id) => write!(f, "Unknown network ID: {id}"),
-            TokenMetadataError::HashError(msg) => write!(f, "Hash error: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for TokenMetadataError {}
-
-/// Parses a network ID string to its corresponding chain ID
-///
-/// # Arguments
-/// * `network_id` - The network identifier string (e.g., "ETHEREUM_MAINNET")
-///
-/// # Returns
-/// `Ok(chain_id)` for known networks, `Err(TokenMetadataError)` otherwise
-///
-/// # Supported Networks
-/// - "ETHEREUM_MAINNET" -> 1
-/// - "POLYGON_MAINNET" -> 137
-/// - "ARBITRUM_MAINNET" -> 42161
-/// - "OPTIMISM_MAINNET" -> 10
-/// - "BASE_MAINNET" -> 8453
-///
-/// # Examples
-/// ```
-/// use visualsign_ethereum::token_metadata::parse_network_id;
-///
-/// assert_eq!(parse_network_id("ETHEREUM_MAINNET"), Ok(1));
-/// assert_eq!(parse_network_id("POLYGON_MAINNET"), Ok(137));
-/// ```
-pub fn parse_network_id(network_id: &str) -> Result<u64, TokenMetadataError> {
-    match network_id {
-        "ETHEREUM_MAINNET" => Ok(1),
-        "POLYGON_MAINNET" => Ok(137),
-        "ARBITRUM_MAINNET" => Ok(42161),
-        "OPTIMISM_MAINNET" => Ok(10),
-        "BASE_MAINNET" => Ok(8453),
-        _ => Err(TokenMetadataError::UnknownNetworkId(network_id.to_string())),
-    }
 }
 
 /// Computes a deterministic SHA256 hash of protobuf bytes
@@ -143,49 +90,6 @@ pub fn compute_metadata_hash(protobuf_bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_network_id_ethereum() {
-        assert_eq!(parse_network_id("ETHEREUM_MAINNET"), Ok(1));
-    }
-
-    #[test]
-    fn test_parse_network_id_polygon() {
-        assert_eq!(parse_network_id("POLYGON_MAINNET"), Ok(137));
-    }
-
-    #[test]
-    fn test_parse_network_id_arbitrum() {
-        assert_eq!(parse_network_id("ARBITRUM_MAINNET"), Ok(42161));
-    }
-
-    #[test]
-    fn test_parse_network_id_optimism() {
-        assert_eq!(parse_network_id("OPTIMISM_MAINNET"), Ok(10));
-    }
-
-    #[test]
-    fn test_parse_network_id_base() {
-        assert_eq!(parse_network_id("BASE_MAINNET"), Ok(8453));
-    }
-
-    #[test]
-    fn test_parse_network_id_unknown() {
-        let result = parse_network_id("UNKNOWN_NETWORK");
-        assert!(result.is_err());
-        assert_eq!(
-            result,
-            Err(TokenMetadataError::UnknownNetworkId(
-                "UNKNOWN_NETWORK".to_string()
-            ))
-        );
-    }
-
-    #[test]
-    fn test_parse_network_id_empty() {
-        let result = parse_network_id("");
-        assert!(result.is_err());
-    }
 
     #[test]
     fn test_compute_metadata_hash_deterministic() {


### PR DESCRIPTION
## Why am I making this PR?

The `visualsign-ethereum` crate had two separate `network_id -> chain_id` mappings that could silently drift apart.

`networks::network_id_to_chain_id` is macro-generated from the `networks!` table: 28 networks, case-insensitive. `token_metadata::parse_network_id` was a hand-written match on 5 mainnets (ETHEREUM / POLYGON / ARBITRUM / OPTIMISM / BASE), case-sensitive.

Two sources of truth for the same mapping is the smell. No live divergence today (the registry caller is gated behind a commented-out TODO), but if wallet-token loading is ever re-enabled, a wallet declaring a valid network handled by `networks!` would be silently rejected by `parse_network_id`. The case-sensitivity gap is its own foot-gun.

## What am I changing?

- Delete `parse_network_id` from `token_metadata.rs`, plus the now-dead `TokenMetadataError` enum (its only consumer, including the unused `HashError` variant) and the 7 tests that only covered the 5 hardcoded networks. `networks.rs` already has full coverage of all 28.
- Route `registry::ContractRegistry::load_chain_metadata` through `networks::network_id_to_chain_id`, mapping the `Option<u64>` into the registry's existing `String` error.
- Migrate both live `cli_plugin.rs` ABI-signing call sites (ABI mappings + proxy ABI mappings) to `network_id_to_chain_id`, and rewrite the stale comment that defended the old narrow 5-mainnet behavior.
- Update the crate's `CLAUDE.md` doc references to point at the canonical `networks.rs` table.

Files: `token_metadata.rs`, `registry.rs`, `cli_plugin.rs`, `CLAUDE.md` (all under `src/chain_parsers/visualsign-ethereum/`).

## What is the Linear ticket?

N/A. Small internal refactor (single source of truth for the network mapping).

## What are the rollback steps?

Revert the single commit on this branch. No migrations, no data changes, no config changes, no new dependencies.

## Is this change backwards compatible?

Production gRPC path: yes, unchanged. The only registry caller (`load_chain_metadata`) is reached from a commented-out TODO block in `lib.rs`, so it is effectively dead and its behavior does not change in production.

One intentional behavior change in the CLI (called out deliberately, since the original task scope did not anticipate the `cli_plugin.rs` callers): ABI signing now resolves chain ids for all 28 networks instead of only the 5 mainnets. So `--abi-json-mappings` / `--abi-proxy-mappings` with a valid non-mainnet network (e.g. a testnet) now succeeds instead of erroring out. This is strictly more permissive; the no-ABI CLI path was already unaffected.

The chain_id <-> ABI-signature binding is preserved (the security audit confirmed the resolved chain_id is identical for the 5 prior mainnets and that cross-network signature replay remains impossible).

## Does this require cross-team/service coordination?

No. No proto changes, no shared API changes, no deployment config touched. The deleted symbols (`parse_network_id`, `TokenMetadataError`) have no references outside this crate.

## How do I know it works as designed? Which tests exercise this code?

- `cargo +1.88.0 fmt --check` (from `src/`): clean.
- `cargo +1.88.0 clippy -p visualsign-ethereum --all-targets -- -D warnings`: clean.
- `cargo +1.88.0 test -p visualsign-ethereum`: green. 265 unit + 9 integration + 2 doc-tests, 0 failed.
- `grep -rn "parse_network_id\|TokenMetadataError"` across `src/`: no references remain.
- The 28-network coverage (including the 5 previously hardcoded mainnets, case-insensitivity, and unknown-network rejection) is already exercised by the existing `network_id_to_chain_id` tests in `networks.rs`.

> Opened as a draft by /draft. CI / Sonar / Copilot gates are handled by /finish; mark ready for review once they are green.
