### PR TITLE
feat(solana): core::arg_rendering + Marginfi preset; bootstrap-only solana-add-idl skill

### DIFF
--- a/.claude/skills/solana-add-idl/SKILL.md
+++ b/.claude/skills/solana-add-idl/SKILL.md
@@ -6,7 +6,24 @@ user-invocable: true
 
 # Add Solana IDL Visualizer Preset
 
-You are scaffolding a new Solana program visualizer preset from an Anchor IDL.
+You are orchestrating the scaffolding of a new Solana program visualizer preset.
+
+## Scope: bootstrap only
+
+This skill scaffolds a **new** preset from zero to a working, registered, charset-safe
+baseline. It is a one-time bootstrap, not a repeatable regenerator: once a preset exists,
+it is owned by humans/PRs and may diverge from this skill's output through hand
+customization (e.g. program-specific nested rendering). Do **not** re-run this skill over a
+preset that already exists — regeneration is destructive to that customization. If the
+target `presets/<snake_name>/` directory is already present, stop and tell the user rather
+than overwriting it. Program-agnostic improvements belong in `crate::core` (e.g.
+`core::arg_rendering`) so every future scaffold inherits them; program-specific work stays
+in the individual preset.
+
+## Mode Selection
+
+- **Standard** (`/solana-add-idl`): gather inputs, dispatch one Sonnet subagent to scaffold the preset
+- **Compare** (`/solana-add-idl compare`): gather inputs, dispatch Sonnet and Opus subagents in parallel to separate temp dirs, then diff their outputs to surface capability gaps
 
 ## Step 1: Gather Information
 
@@ -14,68 +31,108 @@ Ask the user for:
 1. **Program address** (base58 Solana program ID)
 2. **Human-readable name** (e.g. "Squads Multisig", "Marinade Finance", "Jupiter Swap")
 3. **VisualizerKind** — one of: `Dex`, `Lending`, `StakingPools`, `Payments`
+4. **Subtitle** (optional) — the short label shown under the instruction title in the preview layout. Default is empty (corpus-wide convention for IDL presets); ask the user if they want a custom string.
 
-Derive these from the human name:
+Derive from the human name:
 - `snake_name`: lowercase with underscores (e.g. `marinade_finance`)
 - `PascalName`: PascalCase (e.g. `MarinadeFinance`)
 - `SCREAMING_SNAKE`: uppercase with underscores (e.g. `MARINADE_FINANCE`)
-- `display_name`: the human name as-is for display strings
+- `display_name`: human name as-is
+- `subtitle_text`: the user-provided subtitle, or `String::new()` if none given
 
-## Step 2: Fetch the IDL
+## Step 2: Dispatch
 
-Try these in order:
+### Standard mode
+
+Dispatch one Agent with **`model: "sonnet"`**, substituting gathered values into the implementation prompt below.
+
+### Compare mode
+
+Dispatch two Agents **in parallel** — one with `model: "sonnet"`, one with `model: "opus"`. Give each a different output directory:
+
+- Sonnet writes to: `/tmp/solana-add-idl-compare/sonnet/`
+- Opus writes to: `/tmp/solana-add-idl-compare/opus/`
+
+Both receive the same implementation prompt (below), with only the output directory differing.
+
+After both complete, diff the two output directories:
+
+```bash
+diff -ru /tmp/solana-add-idl-compare/sonnet/ /tmp/solana-add-idl-compare/opus/
+```
+
+Present the diff to the user and summarize: what did Opus add or do differently? Are any of those patterns general enough to encode in this skill's instructions?
+
+## Step 3: Live-fuzz validation (surfpool)
+
+After the scaffolding subagent finishes and the PR is open, add the `surfpool` label to trigger the `surfpool_fuzz_all_idls.sh` CI job. This runs the `surfpool_fuzz` integration suite against every bundled IDL — including the new preset — using real mainnet transactions (32 proptest cases per IDL). It exercises the full parse pipeline with live tx data that synthetic unit tests can't replicate. If any IDL fails, CI adds a `surfpool-failure` label. The job only fires on non-fork PRs (secrets required for `HELIUS_API_KEY`).
+
+```bash
+gh pr edit <PR_NUMBER> --add-label surfpool
+```
+
+If adding the label requires repo permissions you don't have, request it via comment instead:
+
+```bash
+gh pr comment <PR_NUMBER> --body "Please add the \`surfpool\` label to trigger the live fuzz CI job for the new preset."
+```
+
+---
+
+## Implementation Prompt (for subagents)
+
+```
+You are scaffolding a Solana program visualizer preset from an Anchor IDL.
+
+## Inputs
+
+- Program address: {PROGRAM_ID}
+- snake_name: {snake_name}
+- PascalName: {PascalName}
+- SCREAMING_SNAKE: {SCREAMING_SNAKE}
+- display_name: {display_name}
+- VisualizerKind: {VisualizerKind}
+- subtitle_text: {subtitle_text}   ← custom subtitle string, or empty for the corpus default
+- Output directory: {OUTPUT_DIR}   ← for compare mode; omit in standard mode (write to repo)
+
+## Step A: Fetch the IDL
 
 ### Option A: Local Anchor CLI
 ```bash
-anchor idl fetch <PROGRAM_ID> --provider.cluster mainnet
+anchor idl fetch {PROGRAM_ID} --provider.cluster mainnet
 ```
 
 ### Option B: Docker container
-If `anchor` is not installed locally, use the project's Anchor CLI container:
-
 ```bash
-# Build the image if it doesn't exist
 docker images -q anchor-cli | grep -q . || \
   docker build -t anchor-cli -f images/anchor-cli/Containerfile .
-
-# Fetch the IDL
-docker run --rm anchor-cli idl fetch <PROGRAM_ID> --provider.cluster mainnet
+docker run --rm anchor-cli idl fetch {PROGRAM_ID} --provider.cluster mainnet
 ```
 
-### Option C: User-provided IDL
-If both methods fail, ask the user to provide the IDL via:
-- A local file path
-- A URL to fetch
-- Pasted JSON
+### Option C: User-provided
+If both fail, ask the user for the IDL (file path, URL, or pasted JSON).
 
-Save the IDL to: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
+Save to: `{OUTPUT_DIR}src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
 
-### Validation
-The IDL JSON **must** have an `instructions` array. Verify this before proceeding. If it's missing, tell the user the IDL is invalid.
+The IDL **must** have an `instructions` array. Stop and report if missing.
 
-## Step 3: Scaffold the Preset
-
-Create directory: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/`
-
-### File: `config.rs`
+## Step B: Scaffold config.rs
 
 ```rust
 use super::{SCREAMING_SNAKE}_PROGRAM_ID;
 use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub struct {PascalName}Config;
 
 impl SolanaIntegrationConfig for {PascalName}Config {
-    fn new() -> Self {
-        Self
-    }
+    fn new() -> Self { Self }
 
     fn data(&self) -> &SolanaIntegrationConfigData {
         static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
         DATA.get_or_init(|| {
-            let mut programs = HashMap::new();
-            let mut instructions = HashMap::new();
+            let mut programs = BTreeMap::new();
+            let mut instructions = BTreeMap::new();
             instructions.insert("*", vec!["*"]);
             programs.insert({SCREAMING_SNAKE}_PROGRAM_ID, instructions);
             SolanaIntegrationConfigData { programs }
@@ -84,44 +141,49 @@ impl SolanaIntegrationConfig for {PascalName}Config {
 }
 ```
 
-### File: `mod.rs`
+## Step C: Scaffold mod.rs
 
-Use the dflow_aggregator preset as a template: `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs`
+Use `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs` as the
+structural template. Make these substitutions:
+- `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` → appropriate casing
+- Program ID string → {PROGRAM_ID}
+- `"DFlow Aggregator"` display strings → the constant `{SCREAMING_SNAKE}_DISPLAY_NAME` (define it once as `const {SCREAMING_SNAKE}_DISPLAY_NAME: &str = "{display_name}";`)
+- `include_str!("dflow_aggregator.json")` → `include_str!("{snake_name}.json")`
+- `kind()` → returns `{VisualizerKind}("{display_name}")`
 
-Read that file for the exact structure, then generate a generic version with these substitutions:
-- Replace `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` with the appropriate casing of the new program name
-- Replace the program ID string with the new program address
-- Replace `"DFlow Aggregator"` display strings with `{display_name}`
-- Replace IDL file reference: `include_str!("{snake_name}.json")`
-- Keep the `kind()` method returning the user's chosen `VisualizerKind` variant with `display_name` as the `&'static str` argument
-
-**Generic IDL pattern only:**
-- The generic scaffold uses the three helpers `dflow_aggregator` defines: `build_named_accounts`, `build_parsed_fields`, and `build_fallback_fields`. All three work with any IDL.
-- Two additional helpers — `append_raw_data` (for byte-blob args) and `format_arg_value` (for custom scalar rendering) — are not present in `dflow_aggregator`. Add them when the target IDL needs them, copying the pattern from another preset such as `kamino_vault` or `jupiter_earn`.
-- The parse function should: check `data.len() < 8`, load IDL, call `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with parsed data + named accounts
-
-**Visualizer body must use the wire-data context API.** At the top of `visualize_tx_commands`:
+**Account resolution** — use `InstructionView`, not `resolve_accounts()`:
 ```rust
-let program_id = context.resolve_program_id()?.to_string();
-let accounts = context.resolve_accounts()?;
+let view = InstructionView::from_context(context);
 let data = context.data();
 ```
 
-These three accessors replace the old `context.current_instruction()`. They surface
-unresolved indices as `Err(VisualSignError::DecodeError(...))` with the bad index
-named, instead of returning a generic "no instruction found" failure. Use
-`context.instruction_index()` for any "Instruction N" labels.
+`InstructionView::from_context` is infallible and degrades gracefully on v0+ALT
+transactions (unresolvable account indices become empty strings rather than
+aborting). `context.resolve_accounts()?` aborts on those — do not use it for IDL
+presets. Use `view.program_id` for the program ID string and `view.accounts` (a
+`Vec<String>`) wherever account pubkeys are needed. Inner helpers take
+`accounts: &[String]`.
+
+**Subtitle** — in the `preview_layout` construction, set the subtitle field from
+`subtitle_text`. The default is the empty corpus convention; a custom string is used only
+if the user supplied one:
+```rust
+// custom subtitle:
+subtitle: Some(SignablePayloadFieldTextV2 { text: "{subtitle_text}".to_string() }),
+// default (no subtitle given):
+subtitle: Some(SignablePayloadFieldTextV2 { text: String::new() }),
+```
 
 **Required imports** (at top of module, NOT inside functions):
 ```rust
 use crate::core::{
-    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+    format_arg_value, InstructionView, InstructionVisualizer, SolanaIntegrationConfig,
+    VisualizerContext, VisualizerKind,
 };
 use config::{PascalName}Config;
 use solana_parser::{
     Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
 };
-use solana_sdk::instruction::AccountMeta;
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 use visualsign::errors::VisualSignError;
@@ -132,35 +194,79 @@ use visualsign::{
 };
 ```
 
-`BTreeMap` (not `HashMap`) keeps the rendered named-accounts order deterministic.
+`BTreeMap` (not `HashMap`) — keeps named-account order deterministic.
 
-**Required tests** (in `#[cfg(test)] mod tests`):
-- `test_{snake_name}_idl_loads` — IDL loads and has instructions
-- `test_{snake_name}_idl_has_discriminators` — every instruction has an 8-byte discriminator
-- `test_unknown_discriminator_returns_error` — garbage 9-byte data returns error
-- `test_short_data_returns_error` — 3-byte data returns error
+### Arg rendering: import from crate::core
 
-## Step 4: Register in presets/mod.rs
+`format_arg_value` is already included via the import above. Do **not** copy the
+function body into the preset — the implementation lives in
+`src/chain_parsers/visualsign-solana/src/core/arg_rendering.rs`.
 
-Add `pub mod {snake_name};` to `src/chain_parsers/visualsign-solana/src/presets/mod.rs`.
+It enforces two constraints that apply to every program:
 
-**Keep entries in alphabetical order.** The existing entries are sorted — insert the new module in the correct position.
+**Constraint 1 — charset safety.** `SignablePayload::validate_charset` rejects `"`
+and `\`. Compact JSON of any object emits `\"` for keys and fails validation.
+`format_arg_value` never emits `"` or `\`.
 
-No other registration is needed. `build.rs` auto-discovers `{PascalName}Visualizer` from any directory under `src/presets/`.
+**Constraint 2 — field explosion.** A `[u8; 32]` seed or 76-byte opaque ID would
+produce 32 or 76 per-byte fields if recursed into. `format_arg_value` collapses
+all-byte arrays into a single `0x`-prefixed hex string.
 
-## Step 5: Code Quality
+Use it in `build_parsed_fields` for every program-call arg:
+```rust
+for (key, value) in &parsed.program_call_args {
+    condensed_fields.push(create_text_field(key, &format_arg_value(value))?);
+}
+// same in expanded_fields
+```
 
-Follow these rules in all generated code:
+For raw-data fields, pass `None` as the second arg of `create_raw_data_field`
+unless you already have a precomputed hex string to reuse.
+
+### Required tests
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_{snake_name}_idl_loads() { /* IDL loads and has instructions */ }
+
+    #[test]
+    fn test_{snake_name}_idl_has_discriminators() {
+        // IdlInstruction.discriminator is Option<Vec<u8>>
+        let idl_json = include_str!("{snake_name}.json");
+        let idl: Idl = serde_json::from_str(idl_json).unwrap();
+        for ix in &idl.instructions {
+            let len = ix.discriminator.as_ref().map(Vec::len).unwrap_or(0);
+            assert_eq!(len, 8, "instruction {} missing 8-byte discriminator", ix.name);
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() { /* garbage 9-byte data returns error */ }
+
+    #[test]
+    fn test_short_data_returns_error() { /* 3-byte data returns error */ }
+}
+```
+
+## Step D: Registration
+
+No manual registration needed. `build.rs` auto-discovers `{PascalName}Visualizer`
+from any directory under `src/presets/` — do not edit `presets/mod.rs`, it is
+generated.
+
+## Step E: Code Quality
+
 - `use` statements at top of module, never inside functions
 - Inline format strings: `format!("{variable}")` not `format!("{}", variable)`
-- Use `create_text_field` and `create_raw_data_field` from `visualsign::field_builders` — never construct field structs directly
-- For raw-data fields, pass `None` as the second arg of `create_raw_data_field` unless you already have a precomputed hex string to reuse (e.g. one you built for `fallback_text`). Do not call `hex::encode(data)` solely to populate this arg — the helper falls back to the same lowercase byte-by-byte hex on `None`.
 - ASCII only in user-visible strings: `>=` not `≥`, `->` not `→`
 - Rust edition 2024 on nightly
 
-## Step 6: Verify
-
-Run these commands and fix any issues:
+## Step F: Verify
 
 ```bash
 cargo fmt -p visualsign-solana
@@ -171,6 +277,41 @@ cargo test -p visualsign-solana --features diagnostics
 make -C src test
 ```
 
-All must pass before the task is complete. Both feature configurations
-(diagnostics on and off) need to compile and test cleanly because parser_app
-builds without `diagnostics` while parser_cli builds with it.
+Both feature configurations must pass. Report any failures before marking done.
+```
+
+---
+
+## Improving this skill
+
+The skill file is the artifact; generated preset files are only evidence it works. Two non-destructive loops surface where the skill needs work — both regenerate into a scratch directory and **never overwrite a committed preset** (see Scope: bootstrap only).
+
+### Loop 1 — corpus diff (does the skill still reproduce known-good presets?)
+
+Regenerate an existing preset into a scratch dir (the same way compare mode writes to `/tmp`), then diff against the committed version:
+
+```bash
+git diff --no-index \
+  src/chain_parsers/visualsign-solana/src/presets/{snake_name}/mod.rs \
+  /tmp/solana-add-idl-regen/{snake_name}/mod.rs
+```
+
+Look for:
+
+- **Structural regressions**: fields missing from condensed or expanded, fallback path removed, IDL caching changed from `OnceLock` to per-call
+- **Behaviour changes**: field labels renamed, subtitle content changed, extra accounts dropped or added
+- **Improvements**: the generated output may be strictly better than the committed version (e.g. added `Remaining Account N` handling) — call these out; they validate the skill is producing higher-quality output than the predecessor
+
+It is an iterative loop, not a one-shot pass:
+
+```
+regenerate to scratch -> diff vs committed
+  -> finding? -> fix the SKILL (not the preset) -> repeat
+    -> clean -> done
+```
+
+Per finding, name the specific step or template section affected (e.g. "Step C", "config.rs template", "Required imports"), fix it in the skill, and re-regenerate to confirm clean output. **The skill is the artifact**: if regenerated output needed a manual tweak to compile or pass tests, that tweak belongs in the skill, not in a committed preset. Do not commit the regenerated preset over the existing one.
+
+### Loop 2 — model compare
+
+Compare mode (above) regenerates with Sonnet and Opus into separate scratch dirs and diffs them to surface model capability gaps. Encode any general pattern Opus produces back into this skill so Sonnet reproduces it.

--- a/src/chain_parsers/visualsign-solana/src/core/arg_rendering.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/arg_rendering.rs
@@ -1,0 +1,113 @@
+pub fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => charset_safe(s),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Array(items) => {
+            if let Some(hex) = bytes_as_hex(items) {
+                hex
+            } else {
+                let inner: Vec<String> = items.iter().map(format_arg_value).collect();
+                format!("[{}]", inner.join(","))
+            }
+        }
+        serde_json::Value::Object(map) => {
+            let inner: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}:{}", charset_safe(k), format_arg_value(v)))
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        }
+    }
+}
+
+fn charset_safe(text: &str) -> String {
+    text.chars()
+        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\'))
+        .collect()
+}
+
+fn bytes_as_hex(items: &[serde_json::Value]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(items.len());
+    for item in items {
+        let byte = item.as_u64().filter(|n| *n <= u8::MAX as u64)? as u8;
+        bytes.push(byte);
+    }
+    Some(format!("0x{}", hex::encode(bytes)))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_scalars() {
+        assert_eq!(format_arg_value(&json!("hello")), "hello");
+        assert_eq!(format_arg_value(&json!(42)), "42");
+        assert_eq!(format_arg_value(&json!(true)), "true");
+        assert_eq!(format_arg_value(&serde_json::Value::Null), "null");
+    }
+
+    #[test]
+    fn test_byte_array_renders_as_hex() {
+        assert_eq!(format_arg_value(&json!([1u8, 2, 3])), "0x010203");
+        assert_eq!(format_arg_value(&json!([0u8, 255u8])), "0x00ff");
+    }
+
+    #[test]
+    fn test_non_byte_array_renders_as_bracketed_list() {
+        assert_eq!(format_arg_value(&json!([1, 2, 256])), "[1,2,256]");
+        assert_eq!(format_arg_value(&json!(["a", "b"])), "[a,b]");
+    }
+
+    #[test]
+    fn test_empty_array_renders_as_brackets() {
+        assert_eq!(format_arg_value(&json!([])), "[]");
+    }
+
+    #[test]
+    fn test_object_renders_quote_free() {
+        let result = format_arg_value(&json!({"side": "buy", "amount": 100}));
+        assert!(
+            result == "{amount:100,side:buy}" || result == "{side:buy,amount:100}",
+            "unexpected: {result}"
+        );
+    }
+
+    #[test]
+    fn test_empty_object_renders_as_braces() {
+        assert_eq!(format_arg_value(&json!({})), "{}");
+    }
+
+    #[test]
+    fn test_charset_safe_no_quotes_or_backslashes() {
+        let result = format_arg_value(&json!({"k\"ey": "val\\ue"}));
+        assert!(!result.contains('"'), "must not contain quote: {result}");
+        assert!(
+            !result.contains('\\'),
+            "must not contain backslash: {result}"
+        );
+    }
+
+    #[test]
+    fn test_string_with_forbidden_chars_is_stripped() {
+        assert_eq!(format_arg_value(&json!("a\"b\\c d")), "abc d");
+        assert_eq!(format_arg_value(&json!("a\tb\rc")), "abc");
+    }
+
+    #[test]
+    fn test_nested_object_does_not_emit_quotes() {
+        let nested = json!({"outer": {"inner": "value"}});
+        let result = format_arg_value(&nested);
+        assert!(
+            !result.contains('"'),
+            "nested object must be quote-free: {result}"
+        );
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/core/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/mod.rs
@@ -6,11 +6,13 @@ use solana_parser::solana::structs::SolanaAccount;
 use solana_sdk::pubkey::Pubkey;
 
 mod accounts;
+mod arg_rendering;
 mod instructions;
 mod txtypes;
 mod visualsign;
 
 pub use accounts::*;
+pub use arg_rendering::format_arg_value;
 pub use instructions::*;
 pub use txtypes::*;
 pub use visualsign::*;

--- a/src/chain_parsers/visualsign-solana/src/presets/marginfi/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/marginfi/config.rs
@@ -1,0 +1,22 @@
+use super::MARGINFI_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::BTreeMap;
+
+pub struct MarginfiConfig;
+
+impl SolanaIntegrationConfig for MarginfiConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = BTreeMap::new();
+            let mut instructions = BTreeMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(MARGINFI_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/marginfi/marginfi.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/marginfi/marginfi.json
@@ -1,0 +1,10932 @@
+{
+  "address": "",
+  "metadata": {
+    "name": "marginfi",
+    "version": "0.1.7",
+    "spec": "0.1.0",
+    "description": "Borrow Lending Prime Broker"
+  },
+  "instructions": [
+    {
+      "name": "config_group_fee",
+      "docs": [
+        "(global fee admin only) Enable or disable program fees for any group. Does not require the",
+        "group admin to sign: the global fee state admin can turn program fees on or off for any",
+        "group"
+      ],
+      "discriminator": [231, 205, 66, 242, 220, 87, 145, 38],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "global_fee_admin",
+          "docs": ["`global_fee_admin` of the FeeState"],
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "enable_program_fee",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "configure_deleverage_withdrawal_limit",
+      "docs": ["(group admin only) Set the daily withdrawal limit for deleverages per group."],
+      "discriminator": [28, 132, 205, 158, 67, 77, 177, 63],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        }
+      ],
+      "args": [
+        {
+          "name": "limit",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "drift_deposit",
+      "docs": [
+        "(user) Deposit into a Drift spot market through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "discriminator": [252, 63, 250, 201, 98, 55, 130, 12],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "drift_oracle",
+          "docs": ["The oracle account for the asset (not needed if using oracle type QuoteAsset)"],
+          "optional": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The bank's liquidity vault authority, which owns the Drift user account"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit tokens into Drift"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "signer_token_account",
+          "docs": ["Owned by authority, the source account for the token deposit"],
+          "writable": true
+        },
+        {
+          "name": "drift_state",
+          "docs": ["The Drift state account"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["The Drift user account owned by liquidity_vault_authority"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_3",
+          "docs": ["The Drift user stats account owned by liquidity_vault_authority"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Drift spot market for this asset"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_spot_market_vault",
+          "docs": ["The Drift spot market vault that will receive tokens"],
+          "writable": true
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint"],
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_program",
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "drift_harvest_reward",
+      "docs": [
+        "(fee admin only) Harvest rewards from admin deposits in Drift spot markets",
+        "The harvest spot market must be different from the bank's main drift spot market"
+      ],
+      "discriminator": [167, 161, 240, 194, 138, 54, 87, 189],
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "name": "fee_state",
+          "docs": ["Global fee state that contains the global_fee_wallet"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The bank's liquidity vault authority"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "intermediary_token_account",
+          "docs": [
+            "To create this manually just send some of the reward token",
+            "to the liquidity vault authority address before claiming"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153, 218, 255, 16,
+                132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "destination_token_account",
+          "docs": ["Destination token account must be owned by the global fee wallet"],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "fee_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153, 218, 255, 16,
+                132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "drift_state",
+          "docs": ["Drift accounts"]
+        },
+        {
+          "name": "integration_acc_2",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_3",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "harvest_drift_spot_market",
+          "docs": [
+            "The harvest spot market - MUST be different from bank's Drift spot market (integration_acc_1)",
+            "This is the market that contains admin deposits to harvest"
+          ],
+          "writable": true
+        },
+        {
+          "name": "harvest_drift_spot_market_vault",
+          "docs": ["The harvest spot market vault - derived from harvest_drift_spot_market"],
+          "writable": true
+        },
+        {
+          "name": "drift_signer",
+          "docs": ["The Drift signer PDA"]
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "drift_program",
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "drift_init_user",
+      "docs": [
+        "(permissionless) Initialize a Drift user and user stats for a marginfi bank",
+        "Creates user with sub_account_id = 0 and empty name",
+        "Requires a minimum deposit to ensure the account remains active",
+        "* amount - minimum deposit amount (at least 10 units) in native decimals"
+      ],
+      "discriminator": [29, 18, 236, 190, 29, 254, 114, 169],
+      "accounts": [
+        {
+          "name": "fee_payer",
+          "docs": ["Pays to init the drift user and user stats accounts and provides initial deposit"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "signer_token_account",
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the account is not empty.",
+            "This amount is irrecoverable and will prevent the account from being closed."
+          ],
+          "writable": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The liquidity vault authority (PDA that will own the Drift user)"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit a nominal amount of token into Drift."],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC)"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_3",
+          "docs": ["The user stats account to be created"],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [117, 115, 101, 114, 95, 115, 116, 97, 116, 115]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                9, 84, 219, 190, 158, 201, 96, 201, 138, 122, 41, 63, 226, 19, 54, 150, 111, 225, 128, 209, 81, 174, 75,
+                129, 121, 86, 31, 137, 133, 74, 83, 246
+              ]
+            }
+          },
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["The user account to be created (sub_account_id = 0)"],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [117, 115, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "const",
+                "value": [0, 0]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                9, 84, 219, 190, 158, 201, 96, 201, 138, 122, 41, 63, 226, 19, 54, 150, 111, 225, 128, 209, 81, 174, 75,
+                129, 121, 86, 31, 137, 133, 74, 83, 246
+              ]
+            }
+          },
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_state",
+          "writable": true
+        },
+        {
+          "name": "integration_acc_1",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_spot_market_vault",
+          "docs": ["The Drift spot market vault where tokens will be deposited"],
+          "writable": true
+        },
+        {
+          "name": "drift_oracle",
+          "docs": ["Oracle for the asset (can be null for USDC/market 0)"],
+          "optional": true
+        },
+        {
+          "name": "drift_program",
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "drift_withdraw",
+      "docs": [
+        "(user) Withdraw from a Drift spot market through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals",
+        "* withdraw_all - if true, withdraws entire position"
+      ],
+      "discriminator": [86, 59, 186, 123, 183, 181, 234, 137],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true,
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "drift_oracle",
+          "docs": ["The oracle account for the asset (not needed if using oracle type QuoteAsset)"],
+          "optional": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The bank's liquidity vault authority, which owns the Drift user account"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Receives tokens from Drift withdrawal"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "destination_token_account",
+          "docs": ["Token account that will receive the withdrawn tokens"],
+          "writable": true
+        },
+        {
+          "name": "drift_state",
+          "docs": ["The Drift state account"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["The Drift user account owned by liquidity_vault_authority"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_3",
+          "docs": ["The Drift user stats account owned by liquidity_vault_authority"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Drift spot market for this asset"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_spot_market_vault",
+          "docs": ["The Drift spot market vault that holds tokens"],
+          "writable": true
+        },
+        {
+          "name": "drift_reward_oracle",
+          "docs": ["Optional: Oracle for first reward asset (only needed if rewards exist)"],
+          "optional": true
+        },
+        {
+          "name": "drift_reward_spot_market",
+          "docs": ["Optional: Spot market for first reward asset (only needed if rewards exist)"],
+          "optional": true
+        },
+        {
+          "name": "drift_reward_mint",
+          "docs": ["Optional: Mint for first reward asset (only needed if rewards exist)"],
+          "optional": true
+        },
+        {
+          "name": "drift_reward_oracle_2",
+          "docs": ["Optional: Oracle for second reward asset (backup in case multiple rewards)"],
+          "optional": true
+        },
+        {
+          "name": "drift_reward_spot_market_2",
+          "docs": ["Optional: Spot market for second reward asset (backup in case multiple rewards)"],
+          "optional": true
+        },
+        {
+          "name": "drift_reward_mint_2",
+          "docs": ["Optional: Mint for second reward asset (backup in case multiple rewards)"],
+          "optional": true
+        },
+        {
+          "name": "drift_signer",
+          "docs": ["The Drift signer PDA"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint"],
+          "relations": ["bank"]
+        },
+        {
+          "name": "drift_program",
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "edit_global_fee_state",
+      "docs": ["(global fee admin only) Adjust fees, admin, or the destination wallet"],
+      "discriminator": [52, 62, 35, 129, 93, 69, 165, 202],
+      "accounts": [
+        {
+          "name": "global_fee_admin",
+          "docs": ["Admin of the global FeeState"],
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "liquidation_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "liquidation_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "edit_staked_settings",
+      "discriminator": [11, 108, 215, 87, 240, 9, 66, 241],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "relations": ["staked_settings"]
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        },
+        {
+          "name": "staked_settings",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "settings",
+          "type": {
+            "defined": {
+              "name": "StakedSettingsEditConfig"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "end_deleverage",
+      "discriminator": [114, 14, 250, 143, 252, 104, 214, 209],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "writable": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "group",
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "risk_admin",
+          "signer": true,
+          "relations": ["group"]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "end_liquidation",
+      "discriminator": [110, 11, 244, 54, 229, 181, 22, 184],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "docs": ["Account under liquidation"],
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "docs": ["The associated liquidation record PDA for the given `marginfi_account`"],
+          "writable": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "liquidation_receiver",
+          "writable": true,
+          "signer": true,
+          "relations": ["liquidation_record"]
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "init_bank_metadata",
+      "docs": ["(permissionless) pay the rent to open a bank's metadata."],
+      "discriminator": [94, 239, 50, 136, 137, 204, 254, 213],
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "name": "fee_payer",
+          "docs": ["Pays the init fee"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "metadata",
+          "docs": ["Note: unique per-bank."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 101, 116, 97, 100, 97, 116, 97]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "init_global_fee_state",
+      "docs": [
+        "(Runs once per program) Configures the fee state account, where the global admin sets fees",
+        "that are assessed to the protocol"
+      ],
+      "discriminator": [82, 48, 247, 59, 220, 109, 231, 44],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": ["Pays the init fee"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "liquidation_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "liquidation_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_staked_settings",
+      "docs": [
+        "(group admin only) Init the Staked Settings account, which is used to create staked",
+        "collateral banks, and must run before any staked collateral bank can be created with",
+        "`add_pool_permissionless`. Running this ix effectively opts the group into the staked",
+        "collateral feature."
+      ],
+      "discriminator": [52, 35, 149, 44, 69, 86, 69, 80],
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        },
+        {
+          "name": "fee_payer",
+          "docs": ["Pays the init fee"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "staked_settings",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 116, 97, 107, 101, 100, 95, 115, 101, 116, 116, 105, 110, 103, 115]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "settings",
+          "type": {
+            "defined": {
+              "name": "StakedSettingsConfig"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "kamino_deposit",
+      "docs": [
+        "(user) Deposit into a Kamino pool through a marginfi account",
+        "* amount - in the liquidity token (e.g. if there is a Kamino USDC bank, pass the amount of",
+        "USDC desired), in native decimals."
+      ],
+      "discriminator": [237, 8, 188, 187, 115, 99, 49, 85],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "docs": ["Owned by authority, the source account for the token deposit."],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Kamino obligation. Note: Kamino needs",
+            "this to be mut because `deposit` might return the rent here"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit token into Kamino"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority"
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Kamino reserve that holds liquidity"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC). Kamino calls this the `reserve_liquidity_mint`"],
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's mint for tokenized representations of Kamino deposits."],
+          "writable": true
+        },
+        {
+          "name": "reserve_destination_deposit_collateral",
+          "docs": [
+            "The reserve's destination for tokenized representations of deposits. Note: the",
+            "`reserve_collateral_mint` will mint tokens directly to this account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "obligation_farm_user_state",
+          "docs": ["Required if the Kamino reserve has an active farm."],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_farm_state",
+          "docs": ["Required if the Kamino reserve has an active farm."],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "kamino_program",
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+        },
+        {
+          "name": "farms_program",
+          "docs": ["Farms program for Kamino staking functionality"],
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+        },
+        {
+          "name": "collateral_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "liquidity_token_program"
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "kamino_harvest_reward",
+      "docs": [
+        "(fee admin only) Harvest the specified reward index from the Kamino Farm attached to this bank.",
+        "",
+        "* `reward_index` — index of the reward token in the Kamino Farm's reward list"
+      ],
+      "discriminator": [163, 202, 248, 141, 106, 20, 116, 5],
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "name": "fee_state",
+          "docs": ["Global fee state that contains the global_fee_admin"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "destination_token_account",
+          "docs": ["Destination token account must be owned by the global fee admin"],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "fee_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153, 218, 255, 16,
+                132, 4, 142, 123, 216, 219, 233, 248, 89
+              ]
+            }
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The bank's liquidity vault authority, which owns the Kamino obligation."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_state",
+          "writable": true
+        },
+        {
+          "name": "farm_state",
+          "writable": true
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_reward_ata",
+          "docs": ["An initialized ATA of type reward mint owned by liquidity vault"],
+          "writable": true
+        },
+        {
+          "name": "rewards_vault",
+          "writable": true
+        },
+        {
+          "name": "rewards_treasury_vault",
+          "writable": true
+        },
+        {
+          "name": "farm_vaults_authority"
+        },
+        {
+          "name": "scope_prices",
+          "optional": true
+        },
+        {
+          "name": "farms_program",
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "kamino_init_obligation",
+      "docs": [
+        "(permissionless) Initialize a Kamino obligation for a marginfi bank",
+        "* amount - In token, in native decimals. Must be >10 (i.e. 10 lamports, not 10 tokens). Lost",
+        "forever. Generally, try to make this the equivalent of around $1, in case Kamino ever",
+        "rounds small balances down to zero."
+      ],
+      "discriminator": [253, 177, 160, 225, 70, 156, 217, 109],
+      "accounts": [
+        {
+          "name": "fee_payer",
+          "docs": [
+            "Pays to init the obligation and pays a nominal amount to ensure the obligation has a",
+            "non-zero balance."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "signer_token_account",
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the obligation is not empty.",
+            "This amount is irrecoverable and and will prevent the obligation from ever being closed,",
+            "even if the bank is otherwise empty (Kamino normally closes empty obligations automatically)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": [
+            "The liquidity vault authority (PDA that will own the Kamino obligation). Note: Kamino needs",
+            "this to be mut because `deposit` might return the rent here"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit a nominal amount of token into the obligation."],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": [
+            "The obligation account to be created. Note that the key was already derived when",
+            "initializing the bank, and this must match the obligation recorded at that time."
+          ],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "user_metadata",
+          "writable": true
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority"
+        },
+        {
+          "name": "integration_acc_1",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC). Kamino calls this the `reserve_liquidity_mint`"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's mint for tokenized representations of Kamino deposits."],
+          "writable": true
+        },
+        {
+          "name": "reserve_destination_deposit_collateral",
+          "docs": [
+            "The reserve's destination for tokenized representations of deposits. Note: the",
+            "`reserve_collateral_mint` will mint tokens directly to this account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "pyth_oracle",
+          "optional": true
+        },
+        {
+          "name": "switchboard_price_oracle",
+          "optional": true
+        },
+        {
+          "name": "switchboard_twap_oracle",
+          "optional": true
+        },
+        {
+          "name": "scope_prices",
+          "optional": true
+        },
+        {
+          "name": "obligation_farm_user_state",
+          "docs": ["Required if the Kamino reserve has an active farm."],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_farm_state",
+          "docs": ["Required if the Kamino reserve has an active farm."],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "kamino_program",
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+        },
+        {
+          "name": "farms_program",
+          "docs": ["Farms program for Kamino staking functionality"],
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+        },
+        {
+          "name": "collateral_token_program",
+          "docs": ["Note: the collateral token always uses Token classic, never Token22."],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "liquidity_token_program",
+          "docs": [
+            "Note: Kamino does not have full Token22 support, certain Token22 features are disallowed.",
+            "Expect this to update over time. Check with the Kamino source."
+          ]
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "kamino_withdraw",
+      "docs": [
+        "(user) Withdraw from a Kamino pool through a marginfi account",
+        "* amount - in the collateral token (NOT liquidity token), in native decimals. Must convert",
+        "from collateral to liquidity token amounts using the current exchange rate.",
+        "* withdraw_all - if true, withdraw the entire mrgn balance (Note: due to rounding down, a",
+        "deposit and withdraw back to back may result in several lamports less)"
+      ],
+      "discriminator": [199, 101, 41, 45, 213, 98, 224, 200],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true,
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "docs": ["Token account that will get tokens back", "WARN: Completely unchecked!"],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "lending_market",
+          "docs": ["The Kamino lending market"]
+        },
+        {
+          "name": "lending_market_authority",
+          "docs": ["The Kamino lending market authority"]
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Kamino reserve that holds liquidity"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_mint",
+          "docs": [
+            "The liquidity token mint (e.g., USDC)",
+            "Needs serde to get the mint decimals for transfer checked"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "docs": ["The reserve's liquidity supply account"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's collateral mint"],
+          "writable": true
+        },
+        {
+          "name": "reserve_source_collateral",
+          "docs": ["The reserve's source for collateral tokens"],
+          "writable": true
+        },
+        {
+          "name": "obligation_farm_user_state",
+          "docs": ["Optional farms accounts for Kamino staking functionality"],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_farm_state",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "kamino_program",
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+        },
+        {
+          "name": "farms_program",
+          "docs": ["Farms program for Kamino staking functionality"],
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+        },
+        {
+          "name": "collateral_token_program",
+          "docs": ["The token program for the collateral token"],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "liquidity_token_program",
+          "docs": ["The token program for the liquidity token"]
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "docs": ["Used by kamino validate CPI calls"],
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_account_borrow",
+      "discriminator": [4, 126, 116, 53, 48, 5, 212, 31],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_account_close_balance",
+      "discriminator": [245, 54, 41, 4, 243, 202, 31, 17],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_account_deposit",
+      "discriminator": [171, 94, 235, 103, 82, 64, 212, 140],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "deposit_up_to_limit",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_account_end_flashloan",
+      "discriminator": [105, 124, 201, 106, 153, 2, 8, 156],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["marginfi_account"]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_account_liquidate",
+      "docs": ["Liquidate a lending account balance of an unhealthy marginfi account"],
+      "discriminator": [214, 169, 151, 213, 251, 167, 86, 219],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["asset_bank", "liab_bank", "liquidator_marginfi_account", "liquidatee_marginfi_account"]
+        },
+        {
+          "name": "asset_bank",
+          "writable": true
+        },
+        {
+          "name": "liab_bank",
+          "writable": true
+        },
+        {
+          "name": "liquidator_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "liquidatee_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bank_liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bank_insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "asset_amount",
+          "type": "u64"
+        },
+        {
+          "name": "liquidatee_accounts",
+          "type": "u8"
+        },
+        {
+          "name": "liquidator_accounts",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "lending_account_pulse_health",
+      "docs": [
+        "(Permissionless) Refresh the internal risk engine health cache. Useful for liquidators and",
+        "other consumers that want to see the internal risk state of a user account. This cache is",
+        "read-only and serves no purpose except being populated by this ix.",
+        "* remaining accounts expected in the same order as borrow, etc. I.e., for each balance the",
+        "user has, pass bank and oracle: <bank1, oracle1, bank2, oracle2>"
+      ],
+      "discriminator": [186, 52, 117, 97, 34, 74, 39, 253],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_account_repay",
+      "discriminator": [79, 209, 172, 177, 222, 51, 173, 151],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Must be marginfi_account's authority, unless in liquidation/deleverage receivership",
+            "",
+            "Note: during receivership, there are no signer checks whatsoever: any key can repay as",
+            "long as the invariants checked at the end of receivership are met."
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "repay_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_account_settle_emissions",
+      "discriminator": [161, 58, 136, 174, 242, 223, 156, 176],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_account_start_flashloan",
+      "discriminator": [14, 131, 33, 220, 81, 186, 180, 107],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "ixs_sysvar",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "end_index",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_account_withdraw",
+      "discriminator": [36, 72, 74, 19, 210, 210, 192, 192],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true,
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Must be marginfi_account's authority, unless in liquidation/deleverage receivership",
+            "",
+            "Note: during receivership, there are no signer checks whatsoever: any key can repay as",
+            "long as the invariants checked at the end of receivership are met."
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_account_withdraw_emissions",
+      "discriminator": [234, 22, 84, 214, 118, 176, 140, 170],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "emissions_mint",
+          "relations": ["bank"]
+        },
+        {
+          "name": "emissions_auth",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "destination_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_account_withdraw_emissions_permissionless",
+      "discriminator": [4, 174, 124, 203, 44, 49, 145, 150],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "emissions_mint",
+          "relations": ["bank"]
+        },
+        {
+          "name": "emissions_auth",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "destination_account",
+          "docs": ["registered on `marginfi_account`"],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_accrue_bank_interest",
+      "discriminator": [108, 201, 30, 87, 47, 65, 97, 188],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_add_bank",
+      "discriminator": [215, 68, 72, 78, 208, 218, 103, 182],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        },
+        {
+          "name": "fee_payer",
+          "docs": ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "BankConfigCompact"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_add_bank_drift",
+      "docs": ["(group admin only) Add a Drift bank to the group."],
+      "discriminator": [62, 63, 49, 48, 76, 55, 108, 155],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank_mint",
+          "docs": ["Must match the mint used by `integration_acc_1`"]
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["Drift spot market account that must match the bank mint"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["Drift user account for the marginfi program (derived from liquidity_vault_authority)"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [117, 115, 101, 114]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "const",
+                "value": [0, 0]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                9, 84, 219, 190, 158, 201, 96, 201, 138, 122, 41, 63, 226, 19, 54, 150, 111, 225, 128, 209, 81, 174, 75,
+                129, 121, 86, 31, 137, 133, 74, 83, 246
+              ]
+            }
+          }
+        },
+        {
+          "name": "integration_acc_3",
+          "docs": ["Drift user stats account for the marginfi program (derived from liquidity_vault_authority)"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [117, 115, 101, 114, 95, 115, 116, 97, 116, 115]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                9, 84, 219, 190, 158, 201, 96, 201, 138, 122, 41, 63, 226, 19, 54, 150, 111, 225, 128, 209, 81, 174, 75,
+                129, 121, 86, 31, 137, 133, 74, 83, 246
+              ]
+            }
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["Will be authority of the bank's liquidity vault. Used as intermediary for deposits/withdraws"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": [
+            "For Drift banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Drift -> here ->",
+            "the user's token account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "DriftConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_add_bank_kamino",
+      "docs": [
+        "(group admin only) Add a Kamino bank to the group. Pass the oracle and reserve in remaining",
+        "accounts 0 and 1 respectively."
+      ],
+      "discriminator": [118, 53, 16, 243, 255, 245, 149, 241],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank_mint",
+          "docs": [
+            "Must match the mint used by the Kamino reserve (integration_acc_1), Kamino calls this the",
+            "`reserve_liquidity_mint` aka `liquidity.mint_pubkey`"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "integration_acc_1"
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["Note: not yet initialized in this instruction, run `init_obligation` after."]
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": [
+            "Will be authority of the bank's Kamino obligation (integration_acc_2). Note: When",
+            "depositing/withdrawing Kamino assets, the source/destination must also be owned by the",
+            "obligation authority.",
+            "Kamino assets, the source/destination must also be owned by the obligation authority. This",
+            "account owns the `liquidity_vault`, and thus acts as intermediary for deposits/withdraws"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": [
+            "For Kamino banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Kamino -> here ->",
+            "the user's token account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "KaminoConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_add_bank_permissionless",
+      "discriminator": [127, 187, 121, 34, 187, 167, 238, 102],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true,
+          "relations": ["staked_settings"]
+        },
+        {
+          "name": "staked_settings"
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank_mint",
+          "docs": [
+            "Mint of the spl-single-pool LST (a PDA derived from `stake_pool`)",
+            "",
+            "because the sol_pool and stake_pool will not derive to a valid PDA which is also owned by",
+            "the staking program and spl-single-pool program."
+          ]
+        },
+        {
+          "name": "sol_pool"
+        },
+        {
+          "name": "stake_pool",
+          "docs": [
+            "this key.",
+            "",
+            "If derives the same `bank_mint`, then this must be the correct stake pool for that mint, and",
+            "we can subsequently use it to validate the `sol_pool`"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_add_bank_solend",
+      "docs": ["(admin) Add a Solend bank to the marginfi group"],
+      "discriminator": [81, 233, 203, 199, 47, 226, 0, 68],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank_mint",
+          "docs": ["Must match the mint used by `integration_acc_1`, Solend calls this the `liquidity.mint_pubkey`"]
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["Solend reserve account that must match the bank mint"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": [
+            "Obligation PDA for this bank in Solend",
+            "Will be initialized and transferred to Solend in init_obligation instruction"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 101, 110, 100, 95, 111, 98, 108, 105, 103, 97, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["Will be authority of the bank's liquidity vault. Used as intermediary for deposits/withdraws"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": [
+            "For Solend banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Solend -> here ->",
+            "the user's token account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "docs": ["Note: Currently does nothing."],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "docs": ["Note: Currently does nothing."],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "SolendConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_add_bank_with_seed",
+      "docs": [
+        "A copy of lending_pool_add_bank with an additional bank seed.",
+        "This seed is used to create a PDA for the bank's signature.",
+        "lending_pool_add_bank is preserved for backwards compatibility."
+      ],
+      "discriminator": [76, 211, 213, 171, 117, 78, 158, 76],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        },
+        {
+          "name": "fee_payer",
+          "docs": ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "BankConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_clone_bank",
+      "docs": ["Staging or localnet only, panics on mainnet"],
+      "discriminator": [214, 93, 17, 236, 177, 228, 78, 17],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "relations": ["marginfi_group"]
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "name": "source_bank",
+          "docs": ["Source bank to clone from mainnet program", ""]
+        },
+        {
+          "name": "bank",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_clone_emode",
+      "docs": [
+        "(admin or emode_admin) Copies emode settings from one bank to another. Useful when applying",
+        "emode settings from e.g. one LST to another."
+      ],
+      "discriminator": [146, 167, 94, 106, 184, 202, 15, 10],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["copy_from_bank", "copy_to_bank"]
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "copy_from_bank"
+        },
+        {
+          "name": "copy_to_bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_close_bank",
+      "discriminator": [22, 115, 7, 130, 227, 85, 0, 47],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "relations": ["group"]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_collect_bank_fees",
+      "discriminator": [201, 5, 215, 116, 230, 92, 75, 150],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_ata",
+          "docs": [
+            "(validated in handler). Must already exist, may require initializing the ATA if it does not",
+            "already exist prior to this ix."
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_configure_bank",
+      "docs": ["(admin only)"],
+      "discriminator": [121, 173, 156, 40, 93, 148, 56, 237],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config_opt",
+          "type": {
+            "defined": {
+              "name": "BankConfigOpt"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_configure_bank_emode",
+      "docs": ["(emode_admin only)"],
+      "discriminator": [17, 175, 91, 57, 239, 86, 49, 71],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "emode_admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "emode_tag",
+          "type": "u16"
+        },
+        {
+          "name": "entries",
+          "type": {
+            "array": [
+              {
+                "defined": {
+                  "name": "EmodeEntry"
+                }
+              },
+              10
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_configure_bank_interest_only",
+      "docs": ["(delegate_curve_admin only)"],
+      "discriminator": [245, 107, 83, 38, 103, 219, 163, 241],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "delegate_curve_admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "interest_rate_config",
+          "type": {
+            "defined": {
+              "name": "InterestRateConfigOpt"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_configure_bank_limits_only",
+      "docs": ["(delegate_limits_admin only)"],
+      "discriminator": [157, 196, 221, 200, 202, 62, 84, 21],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "delegate_limit_admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "deposit_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "borrow_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "total_asset_value_init_limit",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_configure_bank_oracle",
+      "docs": ["(admin only)"],
+      "discriminator": [209, 82, 255, 171, 124, 21, 71, 81],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "setup",
+          "type": "u8"
+        },
+        {
+          "name": "oracle",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_force_tokenless_repay_complete",
+      "docs": [
+        "(risk_admin only) - Signals all of a bank's liability have been deleveraged. Used if a bank",
+        "still has liability dust after the risk admin has completed deleveraging all debts. The",
+        "risk admin is trusted not to execute this until all non-dust debts have been deleveraged."
+      ],
+      "discriminator": [15, 203, 147, 232, 199, 14, 231, 37],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "risk_admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_handle_bankruptcy",
+      "docs": ["Handle bad debt of a bankrupt marginfi account for a given bank."],
+      "discriminator": [162, 11, 56, 139, 90, 128, 70, 173],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank", "marginfi_account"]
+        },
+        {
+          "name": "signer",
+          "docs": ["PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG is not set"],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_pulse_bank_price_cache",
+      "docs": ["(Permissionless) Refresh the cached oracle price for a bank."],
+      "discriminator": [192, 19, 201, 135, 105, 203, 32, 222],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_set_fixed_oracle_price",
+      "docs": ["(admin only)"],
+      "discriminator": [28, 126, 127, 127, 60, 37, 211, 125],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "price",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_setup_emissions",
+      "docs": ["(delegate_emissions_admin only)"],
+      "discriminator": [206, 97, 120, 172, 113, 204, 169, 70],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "delegate_emissions_admin",
+          "writable": true,
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "emissions_mint"
+        },
+        {
+          "name": "emissions_auth",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_funding_account",
+          "docs": ["NOTE: This is a TokenAccount, spl transfer will validate it.", ""],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "flags",
+          "type": "u64"
+        },
+        {
+          "name": "rate",
+          "type": "u64"
+        },
+        {
+          "name": "total_emissions",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_update_emissions_parameters",
+      "docs": ["(delegate_emissions_admin only)"],
+      "discriminator": [55, 213, 224, 168, 153, 53, 197, 40],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "delegate_emissions_admin",
+          "writable": true,
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "emissions_mint"
+        },
+        {
+          "name": "emissions_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_funding_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "emissions_flags",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "emissions_rate",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "additional_emissions",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_update_fees_destination_account",
+      "discriminator": [102, 4, 121, 243, 237, 110, 95, 13],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "destination_account",
+          "docs": ["Bank fees will be sent to this account which must be an ATA of the bank's mint."]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "lending_pool_withdraw_fees",
+      "discriminator": [92, 140, 215, 254, 170, 0, 83, 174],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dst_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_withdraw_fees_permissionless",
+      "discriminator": [57, 245, 1, 208, 130, 18, 145, 113],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fees_destination_account",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "lending_pool_withdraw_insurance",
+      "discriminator": [108, 60, 60, 246, 104, 79, 159, 243],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "insurance_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dst_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "marginfi_account_close",
+      "discriminator": [186, 221, 93, 34, 50, 97, 194, 241],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "marginfi_account_init_liq_record",
+      "discriminator": [236, 213, 238, 126, 147, 251, 164, 8],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "liquidation_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [108, 105, 113, 95, 114, 101, 99, 111, 114, 100]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "marginfi_account_initialize",
+      "docs": [
+        "Initialize a marginfi account for a given group. The account is a fresh keypair, and must",
+        "sign. If you are a CPI caller, consider using `marginfi_account_initialize_pda` instead, or",
+        "create the account manually and use `transfer_to_new_account` to gift it to the owner you",
+        "wish."
+      ],
+      "discriminator": [43, 78, 61, 255, 148, 52, 249, 154],
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "marginfi_account_initialize_pda",
+      "docs": [
+        "The same as `marginfi_account_initialize`, except the created marginfi account uses a PDA",
+        "(Program Derived Address)",
+        "",
+        "seeds:",
+        "- marginfi_group",
+        "- authority: The account authority (owner)",
+        "- account_index: A u16 value to allow multiple accounts per authority",
+        "- third_party_id: Optional u16 for third-party tagging. Seeds < PDA_FREE_THRESHOLD can be",
+        "used freely. For a dedicated seed used by just your program (via CPI), contact us."
+      ],
+      "discriminator": [87, 177, 91, 80, 218, 119, 245, 31],
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 97, 114, 103, 105, 110, 102, 105, 95, 97, 99, 99, 111, 117, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "arg",
+                "path": "account_index"
+              },
+              {
+                "kind": "arg",
+                "path": "third_party_id.unwrap_or(0)"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "instructions_sysvar",
+          "docs": ["Instructions sysvar for CPI validation", ""],
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "account_index",
+          "type": "u16"
+        },
+        {
+          "name": "third_party_id",
+          "type": {
+            "option": "u16"
+          }
+        }
+      ]
+    },
+    {
+      "name": "marginfi_account_set_freeze",
+      "discriminator": [199, 179, 231, 30, 138, 247, 110, 227],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "frozen",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "marginfi_account_update_emissions_destination_account",
+      "discriminator": [73, 185, 162, 201, 111, 24, 116, 185],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "destination_account",
+          "docs": ["User's earned emissions will be sent to the canonical ATA of this wallet.", ""]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "marginfi_group_configure",
+      "discriminator": [62, 199, 81, 78, 33, 13, 236, 61],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "relations": ["marginfi_group"]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_emode_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_curve_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_limit_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_emissions_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_metadata_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "new_risk_admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "emode_max_init_leverage",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        },
+        {
+          "name": "emode_max_maint_leverage",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "marginfi_group_initialize",
+      "discriminator": [255, 67, 67, 26, 94, 31, 34, 20],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_curve",
+      "docs": [
+        "(Permissionless) Convert a bank from the legacy curve setup to the new setup, with no effect",
+        "on how interest accrues."
+      ],
+      "discriminator": [151, 254, 50, 13, 112, 235, 152, 72],
+      "accounts": [
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "panic_pause",
+      "discriminator": [76, 164, 123, 25, 4, 43, 79, 165],
+      "accounts": [
+        {
+          "name": "global_fee_admin",
+          "docs": ["Admin of the global FeeState (can trigger panic pause)"],
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "docs": ["Global fee state account containing the panic state"],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "panic_unpause",
+      "discriminator": [236, 107, 194, 242, 99, 51, 121, 128],
+      "accounts": [
+        {
+          "name": "global_fee_admin",
+          "docs": ["Admin of the global FeeState (can manually unpause)"],
+          "writable": true,
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "panic_unpause_permissionless",
+      "docs": ["(permissionless) Unpause the protocol when pause time has expired"],
+      "discriminator": [245, 139, 50, 159, 213, 62, 91, 248],
+      "accounts": [
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "propagate_fee_state",
+      "docs": ["(Permissionless) Force any group to adopt the current FeeState settings"],
+      "discriminator": [64, 3, 166, 194, 129, 21, 101, 155],
+      "accounts": [
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "marginfi_group",
+          "docs": ["Any group, this ix is permisionless and can propagate the fee to any group"],
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "propagate_staked_settings",
+      "discriminator": [210, 30, 152, 69, 130, 99, 222, 170],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "relations": ["staked_settings"]
+        },
+        {
+          "name": "staked_settings"
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "purge_deleverage_balance",
+      "docs": [
+        "(risk admin only) Purge a user's lending balance without withdrawing anything. Only usable",
+        "after all the debt has been settled on a bank in deleveraging mode, e.g. when",
+        "`TOKENLESS_REPAYMENTS_ALLOWED` and `TOKENLESS_REPAYMENTS_COMPLETE`. used to purge remaining",
+        "lending assets in a now-worthless bank before it is fully sunset."
+      ],
+      "discriminator": [132, 187, 25, 149, 181, 59, 253, 136],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "risk_admin",
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "solend_deposit",
+      "docs": [
+        "(user) Deposit into a Solend reserve through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "discriminator": [56, 127, 176, 148, 12, 25, 3, 24],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "docs": ["Owned by authority, the source account for the token deposit."],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The bank's liquidity vault authority, which owns the Solend obligation"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit tokens into Solend"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["The Solend obligation account"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority",
+          "docs": ["Derived from the lending market"]
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Solend reserve that holds liquidity"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC)"],
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "docs": ["Reserve's liquidity supply SPL Token account"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's mint for cTokens"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_supply",
+          "docs": ["The reserve's collateral supply account (where cTokens are stored)"],
+          "writable": true
+        },
+        {
+          "name": "user_collateral",
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that will hold cTokens between deposit and obligation update."
+          ],
+          "writable": true
+        },
+        {
+          "name": "pyth_price",
+          "docs": ["Oracle accounts - required by Solend even if not actively used"]
+        },
+        {
+          "name": "switchboard_feed"
+        },
+        {
+          "name": "solend_program",
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "solend_init_obligation",
+      "docs": [
+        "(permissionless) Initialize a Solend obligation for a marginfi bank",
+        "Requires a minimum deposit to ensure the obligation remains active",
+        "* amount - minimum deposit amount (at least 10 units) in native decimals"
+      ],
+      "discriminator": [81, 96, 123, 149, 218, 116, 235, 196],
+      "accounts": [
+        {
+          "name": "fee_payer",
+          "docs": [
+            "Pays to init the obligation and pays a nominal amount to ensure the obligation has a",
+            "non-zero balance."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "signer_token_account",
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the obligation is not empty.",
+            "This amount is irrecoverable and will prevent the obligation from ever being closed."
+          ],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "docs": ["The liquidity vault authority (PDA that will own the Solend obligation)"],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "docs": ["Used as an intermediary to deposit a nominal amount of token into the obligation."],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [115, 111, 108, 101, 110, 100, 95, 111, 98, 108, 105, 103, 97, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "relations": ["bank"]
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority",
+          "docs": ["Derived from the lending market"]
+        },
+        {
+          "name": "integration_acc_1",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC)"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's mint for cTokens"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_supply",
+          "docs": ["The reserve's collateral supply account (where cTokens are stored)"],
+          "writable": true
+        },
+        {
+          "name": "user_collateral",
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that will hold cTokens between deposit and obligation update."
+          ],
+          "writable": true
+        },
+        {
+          "name": "pyth_price",
+          "docs": ["Oracle accounts - required by Solend even if not actively used"]
+        },
+        {
+          "name": "switchboard_feed"
+        },
+        {
+          "name": "solend_program",
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "solend_withdraw",
+      "docs": [
+        "(user) Withdraw from a Solend reserve through a marginfi account",
+        "* amount - in collateral tokens (cTokens), in native decimals",
+        "* withdraw_all - withdraw entire position if true"
+      ],
+      "discriminator": [238, 144, 170, 199, 21, 72, 155, 36],
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true,
+          "relations": ["marginfi_account", "bank"]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "docs": ["Token account that will get tokens back", "WARN: Completely unchecked!"],
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "integration_acc_2",
+          "docs": ["The Solend obligation account"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "lending_market",
+          "writable": true
+        },
+        {
+          "name": "lending_market_authority",
+          "docs": ["Derived from the lending market"]
+        },
+        {
+          "name": "integration_acc_1",
+          "docs": ["The Solend reserve that holds liquidity"],
+          "writable": true,
+          "relations": ["bank"]
+        },
+        {
+          "name": "mint",
+          "docs": ["Bank's liquidity token mint (e.g., USDC)"],
+          "relations": ["bank"]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "docs": ["Reserve's liquidity supply SPL Token account"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_mint",
+          "docs": ["The reserve's mint for cTokens"],
+          "writable": true
+        },
+        {
+          "name": "reserve_collateral_supply",
+          "docs": ["The reserve's collateral supply account (where cTokens are stored)"],
+          "writable": true
+        },
+        {
+          "name": "user_collateral",
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that holds cTokens."
+          ],
+          "writable": true
+        },
+        {
+          "name": "solend_program",
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "start_deleverage",
+      "discriminator": [10, 138, 10, 57, 40, 232, 182, 193],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "docs": ["Account to deleverage"],
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "docs": ["The associated liquidation record PDA for the given `marginfi_account`"],
+          "writable": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "group",
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "risk_admin",
+          "docs": [
+            "The risk admin will have the authority to withdraw/repay as if they are the user authority",
+            "until the end of the tx."
+          ],
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "instruction_sysvar",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "start_liquidation",
+      "discriminator": [244, 93, 90, 214, 192, 166, 191, 21],
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "docs": ["Account under liquidation"],
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "docs": ["The associated liquidation record PDA for the given `marginfi_account`"],
+          "writable": true,
+          "relations": ["marginfi_account"]
+        },
+        {
+          "name": "liquidation_receiver",
+          "docs": [
+            "This account will have the authority to withdraw/repay as if they are the user authority",
+            "until the end of the tx.",
+            ""
+          ]
+        },
+        {
+          "name": "instruction_sysvar",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_to_new_account",
+      "discriminator": [28, 79, 129, 231, 169, 69, 69, 65],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["old_marginfi_account"]
+        },
+        {
+          "name": "old_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "new_marginfi_account",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "new_authority"
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_to_new_account_pda",
+      "docs": [
+        "Same as `transfer_to_new_account` except the resulting account is a PDA",
+        "",
+        "seeds:",
+        "- marginfi_group",
+        "- authority: The account authority (owner)",
+        "- account_index: A u32 value to allow multiple accounts per authority",
+        "- third_party_id: Optional u32 for third-party tagging. Seeds < PDA_FREE_THRESHOLD can be",
+        "used freely. For a dedicated seed used by just your program (via CPI), contact us."
+      ],
+      "discriminator": [172, 210, 224, 220, 146, 212, 253, 49],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["old_marginfi_account"]
+        },
+        {
+          "name": "old_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "new_marginfi_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [109, 97, 114, 103, 105, 110, 102, 105, 95, 97, 99, 99, 111, 117, 110, 116]
+              },
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "new_authority"
+              },
+              {
+                "kind": "arg",
+                "path": "account_index"
+              },
+              {
+                "kind": "arg",
+                "path": "third_party_id.unwrap_or(0)"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "new_authority"
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true
+        },
+        {
+          "name": "instructions_sysvar",
+          "docs": ["Instructions sysvar for CPI validation"],
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "account_index",
+          "type": "u16"
+        },
+        {
+          "name": "third_party_id",
+          "type": {
+            "option": "u16"
+          }
+        }
+      ]
+    },
+    {
+      "name": "write_bank_metadata",
+      "docs": [
+        "(metadata admin only) Write ticker/descrption information for a bank on-chain. Optional, not",
+        "all Banks are guranteed to have metadata."
+      ],
+      "discriminator": [147, 78, 81, 133, 129, 138, 233, 59],
+      "accounts": [
+        {
+          "name": "group",
+          "relations": ["bank"]
+        },
+        {
+          "name": "bank",
+          "relations": ["metadata"]
+        },
+        {
+          "name": "metadata_admin",
+          "writable": true,
+          "signer": true,
+          "relations": ["group"]
+        },
+        {
+          "name": "metadata",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "ticker",
+          "type": {
+            "option": "bytes"
+          }
+        },
+        {
+          "name": "description",
+          "type": {
+            "option": "bytes"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Bank",
+      "discriminator": [142, 49, 166, 242, 50, 66, 97, 188]
+    },
+    {
+      "name": "BankMetadata",
+      "discriminator": [49, 207, 31, 34, 67, 225, 169, 186]
+    },
+    {
+      "name": "FeeState",
+      "discriminator": [63, 224, 16, 85, 193, 36, 235, 220]
+    },
+    {
+      "name": "LiquidationRecord",
+      "discriminator": [95, 116, 23, 132, 89, 210, 245, 162]
+    },
+    {
+      "name": "MarginfiAccount",
+      "discriminator": [67, 178, 130, 109, 126, 114, 28, 42]
+    },
+    {
+      "name": "MarginfiGroup",
+      "discriminator": [182, 23, 173, 240, 151, 206, 182, 67]
+    },
+    {
+      "name": "MinimalObligation",
+      "discriminator": [168, 206, 141, 106, 88, 76, 172, 167]
+    },
+    {
+      "name": "MinimalReserve",
+      "discriminator": [43, 242, 204, 202, 26, 247, 59, 127]
+    },
+    {
+      "name": "MinimalSpotMarket",
+      "discriminator": [100, 177, 8, 107, 168, 65, 65, 39]
+    },
+    {
+      "name": "MinimalUser",
+      "discriminator": [159, 117, 95, 227, 239, 151, 58, 236]
+    },
+    {
+      "name": "SolendMinimalReserve",
+      "discriminator": [1]
+    },
+    {
+      "name": "StakedSettings",
+      "discriminator": [157, 140, 6, 77, 89, 173, 173, 125]
+    }
+  ],
+  "events": [
+    {
+      "name": "DeleverageEvent",
+      "discriminator": [161, 8, 108, 204, 209, 198, 12, 30]
+    },
+    {
+      "name": "EditStakedSettingsEvent",
+      "discriminator": [29, 58, 155, 191, 75, 220, 145, 206]
+    },
+    {
+      "name": "HealthPulseEvent",
+      "discriminator": [183, 159, 218, 110, 61, 220, 65, 1]
+    },
+    {
+      "name": "LendingAccountBorrowEvent",
+      "discriminator": [223, 96, 81, 10, 156, 99, 26, 59]
+    },
+    {
+      "name": "LendingAccountDepositEvent",
+      "discriminator": [161, 54, 237, 217, 105, 248, 122, 151]
+    },
+    {
+      "name": "LendingAccountLiquidateEvent",
+      "discriminator": [166, 160, 249, 154, 183, 39, 23, 242]
+    },
+    {
+      "name": "LendingAccountRepayEvent",
+      "discriminator": [16, 220, 55, 111, 7, 80, 16, 25]
+    },
+    {
+      "name": "LendingAccountWithdrawEvent",
+      "discriminator": [3, 220, 148, 243, 33, 249, 54, 88]
+    },
+    {
+      "name": "LendingPoolBankAccrueInterestEvent",
+      "discriminator": [104, 117, 187, 156, 111, 154, 106, 186]
+    },
+    {
+      "name": "LendingPoolBankCollectFeesEvent",
+      "discriminator": [101, 119, 97, 250, 169, 175, 156, 253]
+    },
+    {
+      "name": "LendingPoolBankConfigureEvent",
+      "discriminator": [246, 35, 233, 110, 93, 152, 235, 40]
+    },
+    {
+      "name": "LendingPoolBankConfigureFrozenEvent",
+      "discriminator": [24, 10, 55, 18, 49, 150, 157, 179]
+    },
+    {
+      "name": "LendingPoolBankConfigureOracleEvent",
+      "discriminator": [119, 140, 110, 253, 150, 64, 210, 62]
+    },
+    {
+      "name": "LendingPoolBankCreateEvent",
+      "discriminator": [236, 220, 201, 63, 239, 126, 136, 249]
+    },
+    {
+      "name": "LendingPoolBankHandleBankruptcyEvent",
+      "discriminator": [166, 77, 41, 140, 36, 94, 10, 57]
+    },
+    {
+      "name": "LendingPoolBankSetFixedOraclePriceEvent",
+      "discriminator": [65, 72, 8, 85, 229, 20, 90, 26]
+    },
+    {
+      "name": "LiquidationReceiverEvent",
+      "discriminator": [40, 131, 224, 220, 151, 83, 24, 230]
+    },
+    {
+      "name": "MarginfiAccountCreateEvent",
+      "discriminator": [183, 5, 117, 104, 122, 199, 68, 51]
+    },
+    {
+      "name": "MarginfiAccountFreezeEvent",
+      "discriminator": [219, 219, 57, 178, 75, 86, 146, 122]
+    },
+    {
+      "name": "MarginfiAccountTransferToNewAccount",
+      "discriminator": [59, 105, 171, 110, 223, 136, 80, 89]
+    },
+    {
+      "name": "MarginfiGroupConfigureEvent",
+      "discriminator": [241, 104, 172, 167, 41, 195, 199, 170]
+    },
+    {
+      "name": "MarginfiGroupCreateEvent",
+      "discriminator": [233, 125, 61, 14, 98, 240, 136, 253]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InternalLogicError",
+      "msg": "Internal Marginfi logic error"
+    },
+    {
+      "code": 6001,
+      "name": "BankNotFound",
+      "msg": "Invalid bank index"
+    },
+    {
+      "code": 6002,
+      "name": "LendingAccountBalanceNotFound",
+      "msg": "Lending account balance not found"
+    },
+    {
+      "code": 6003,
+      "name": "BankAssetCapacityExceeded",
+      "msg": "Bank deposit capacity exceeded"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidTransfer",
+      "msg": "Invalid transfer"
+    },
+    {
+      "code": 6005,
+      "name": "MissingPythOrBankAccount",
+      "msg": "Missing Oracle, Bank, LST mint, or Sol Pool"
+    },
+    {
+      "code": 6006,
+      "name": "MissingPythAccount",
+      "msg": "Missing Pyth account"
+    },
+    {
+      "code": 6007,
+      "name": "MissingBankAccount",
+      "msg": "Missing Bank account"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidBankAccount",
+      "msg": "Invalid Bank account"
+    },
+    {
+      "code": 6009,
+      "name": "RiskEngineInitRejected",
+      "msg": "RiskEngine rejected due to either bad health or stale oracles"
+    },
+    {
+      "code": 6010,
+      "name": "LendingAccountBalanceSlotsFull",
+      "msg": "Lending account balance slots are full"
+    },
+    {
+      "code": 6011,
+      "name": "BankAlreadyExists",
+      "msg": "Bank already exists"
+    },
+    {
+      "code": 6012,
+      "name": "ZeroLiquidationAmount",
+      "msg": "Amount to liquidate must be positive"
+    },
+    {
+      "code": 6013,
+      "name": "AccountNotBankrupt",
+      "msg": "Account is not bankrupt"
+    },
+    {
+      "code": 6014,
+      "name": "BalanceNotBadDebt",
+      "msg": "Account balance is not bad debt"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidConfig",
+      "msg": "Invalid group config"
+    },
+    {
+      "code": 6016,
+      "name": "BankPaused",
+      "msg": "Bank paused"
+    },
+    {
+      "code": 6017,
+      "name": "BankReduceOnly",
+      "msg": "Bank is ReduceOnly mode"
+    },
+    {
+      "code": 6018,
+      "name": "BankAccountNotFound",
+      "msg": "Bank is missing"
+    },
+    {
+      "code": 6019,
+      "name": "OperationDepositOnly",
+      "msg": "Operation is deposit-only"
+    },
+    {
+      "code": 6020,
+      "name": "OperationWithdrawOnly",
+      "msg": "Operation is withdraw-only"
+    },
+    {
+      "code": 6021,
+      "name": "OperationBorrowOnly",
+      "msg": "Operation is borrow-only"
+    },
+    {
+      "code": 6022,
+      "name": "OperationRepayOnly",
+      "msg": "Operation is repay-only"
+    },
+    {
+      "code": 6023,
+      "name": "NoAssetFound",
+      "msg": "No asset found"
+    },
+    {
+      "code": 6024,
+      "name": "NoLiabilityFound",
+      "msg": "No liability found"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidOracleSetup",
+      "msg": "Invalid oracle setup"
+    },
+    {
+      "code": 6026,
+      "name": "IllegalUtilizationRatio",
+      "msg": "Invalid bank utilization ratio"
+    },
+    {
+      "code": 6027,
+      "name": "BankLiabilityCapacityExceeded",
+      "msg": "Bank borrow cap exceeded"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidPrice",
+      "msg": "Invalid Price"
+    },
+    {
+      "code": 6029,
+      "name": "IsolatedAccountIllegalState",
+      "msg": "Account can have only one liability when account is under isolated risk"
+    },
+    {
+      "code": 6030,
+      "name": "EmissionsAlreadySetup",
+      "msg": "Emissions already setup"
+    },
+    {
+      "code": 6031,
+      "name": "OracleNotSetup",
+      "msg": "Oracle is not set"
+    },
+    {
+      "code": 6032,
+      "name": "InvalidSwitchboardDecimalConversion",
+      "msg": "Invalid switchboard decimal conversion"
+    },
+    {
+      "code": 6033,
+      "name": "CannotCloseOutstandingEmissions",
+      "msg": "Cannot close balance because of outstanding emissions"
+    },
+    {
+      "code": 6034,
+      "name": "EmissionsUpdateError",
+      "msg": "Update emissions error"
+    },
+    {
+      "code": 6035,
+      "name": "AccountDisabled",
+      "msg": "Account disabled"
+    },
+    {
+      "code": 6036,
+      "name": "AccountTempActiveBalanceLimitExceeded",
+      "msg": "Account can't temporarily open 3 balances, please close a balance first"
+    },
+    {
+      "code": 6037,
+      "name": "AccountInFlashloan",
+      "msg": "Illegal action during flashloan"
+    },
+    {
+      "code": 6038,
+      "name": "IllegalFlashloan",
+      "msg": "Illegal flashloan"
+    },
+    {
+      "code": 6039,
+      "name": "IllegalFlag",
+      "msg": "Illegal flag"
+    },
+    {
+      "code": 6040,
+      "name": "IllegalBalanceState",
+      "msg": "Illegal balance state"
+    },
+    {
+      "code": 6041,
+      "name": "IllegalAccountAuthorityTransfer",
+      "msg": "Illegal account authority transfer"
+    },
+    {
+      "code": 6042,
+      "name": "Unauthorized",
+      "msg": "Unauthorized"
+    },
+    {
+      "code": 6043,
+      "name": "IllegalAction",
+      "msg": "Invalid account authority"
+    },
+    {
+      "code": 6044,
+      "name": "T22MintRequired",
+      "msg": "Token22 Banks require mint account as first remaining account"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidFeeAta",
+      "msg": "Invalid ATA for global fee account"
+    },
+    {
+      "code": 6046,
+      "name": "AddedStakedPoolManually",
+      "msg": "Use add pool permissionless instead"
+    },
+    {
+      "code": 6047,
+      "name": "AssetTagMismatch",
+      "msg": "Staked SOL accounts can only deposit staked assets and borrow SOL"
+    },
+    {
+      "code": 6048,
+      "name": "StakePoolValidationFailed",
+      "msg": "Stake pool validation failed: check the stake pool, mint, or sol pool"
+    },
+    {
+      "code": 6049,
+      "name": "SwitchboardStalePrice",
+      "msg": "Switchboard oracle: stale price"
+    },
+    {
+      "code": 6050,
+      "name": "PythPushStalePrice",
+      "msg": "Pyth Push oracle: stale price"
+    },
+    {
+      "code": 6051,
+      "name": "WrongNumberOfOracleAccounts",
+      "msg": "Oracle error: wrong number of accounts"
+    },
+    {
+      "code": 6052,
+      "name": "WrongOracleAccountKeys",
+      "msg": "Oracle error: wrong account keys"
+    },
+    {
+      "code": 6053,
+      "name": "PythPushWrongAccountOwner",
+      "msg": "Pyth Push oracle: wrong account owner"
+    },
+    {
+      "code": 6054,
+      "name": "StakedPythPushWrongAccountOwner",
+      "msg": "Staked Pyth Push oracle: wrong account owner"
+    },
+    {
+      "code": 6055,
+      "name": "OracleMaxConfidenceExceeded",
+      "msg": "Oracle max confidence exceeded: try again later"
+    },
+    {
+      "code": 6056,
+      "name": "PythPushInsufficientVerificationLevel",
+      "msg": "Pyth Push oracle: insufficient verification level"
+    },
+    {
+      "code": 6057,
+      "name": "ZeroAssetPrice",
+      "msg": "Zero asset price"
+    },
+    {
+      "code": 6058,
+      "name": "ZeroLiabilityPrice",
+      "msg": "Zero liability price"
+    },
+    {
+      "code": 6059,
+      "name": "SwitchboardWrongAccountOwner",
+      "msg": "Switchboard oracle: wrong account owner"
+    },
+    {
+      "code": 6060,
+      "name": "PythPushInvalidAccount",
+      "msg": "Pyth Push oracle: invalid account"
+    },
+    {
+      "code": 6061,
+      "name": "SwitchboardInvalidAccount",
+      "msg": "Switchboard oracle: invalid account"
+    },
+    {
+      "code": 6062,
+      "name": "MathError",
+      "msg": "Math error"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidEmissionsDestinationAccount",
+      "msg": "Invalid emissions destination account"
+    },
+    {
+      "code": 6064,
+      "name": "SameAssetAndLiabilityBanks",
+      "msg": "Asset and liability bank cannot be the same"
+    },
+    {
+      "code": 6065,
+      "name": "OverliquidationAttempt",
+      "msg": "Trying to withdraw more assets than available"
+    },
+    {
+      "code": 6066,
+      "name": "NoLiabilitiesInLiabilityBank",
+      "msg": "Liability bank has no liabilities"
+    },
+    {
+      "code": 6067,
+      "name": "AssetsInLiabilityBank",
+      "msg": "Liability bank has assets"
+    },
+    {
+      "code": 6068,
+      "name": "HealthyAccount",
+      "msg": "Account is healthy and cannot be liquidated"
+    },
+    {
+      "code": 6069,
+      "name": "ExhaustedLiability",
+      "msg": "Liability payoff too severe, exhausted liability"
+    },
+    {
+      "code": 6070,
+      "name": "TooSeverePayoff",
+      "msg": "Liability payoff too severe, liability balance has assets"
+    },
+    {
+      "code": 6071,
+      "name": "TooSevereLiquidation",
+      "msg": "Liquidation too severe, account above maintenance requirement"
+    },
+    {
+      "code": 6072,
+      "name": "WorseHealthPostLiquidation",
+      "msg": "Liquidation would worsen account health"
+    },
+    {
+      "code": 6073,
+      "name": "Vacated0",
+      "msg": "Vacated0"
+    },
+    {
+      "code": 6074,
+      "name": "Vacated1",
+      "msg": "Vacated1"
+    },
+    {
+      "code": 6075,
+      "name": "BadEmodeConfig",
+      "msg": "The Emode config was invalid"
+    },
+    {
+      "code": 6076,
+      "name": "PythPushInvalidWindowSize",
+      "msg": "TWAP window size does not match expected duration"
+    },
+    {
+      "code": 6077,
+      "name": "InvalidFeesDestinationAccount",
+      "msg": "Invalid fees destination account"
+    },
+    {
+      "code": 6078,
+      "name": "BankCannotClose",
+      "msg": "Banks cannot close when they have open positions or emissions outstanding"
+    },
+    {
+      "code": 6079,
+      "name": "AccountAlreadyMigrated",
+      "msg": "Account already migrated"
+    },
+    {
+      "code": 6080,
+      "name": "ProtocolPaused",
+      "msg": "Protocol is paused"
+    },
+    {
+      "code": 6081,
+      "name": "MetadataTooLong",
+      "msg": "Metadata is too long"
+    },
+    {
+      "code": 6082,
+      "name": "PauseLimitExceeded",
+      "msg": "Pause limit exceeded"
+    },
+    {
+      "code": 6083,
+      "name": "ProtocolNotPaused",
+      "msg": "Protocol is not paused"
+    },
+    {
+      "code": 6084,
+      "name": "BankKilledByBankruptcy",
+      "msg": "Bank killed by bankruptcy: bank shutdown and value of all holdings is zero"
+    },
+    {
+      "code": 6085,
+      "name": "UnexpectedLiquidationState",
+      "msg": "Liquidation state issue. Check start before end, end last, and both unique"
+    },
+    {
+      "code": 6086,
+      "name": "StartNotFirst",
+      "msg": "Liquidation start must be first instruction (other than compute program ixes)"
+    },
+    {
+      "code": 6087,
+      "name": "StartRepeats",
+      "msg": "Only one liquidation event allowed per tx"
+    },
+    {
+      "code": 6088,
+      "name": "EndNotLast",
+      "msg": "The end instruction must be the last ix in the tx"
+    },
+    {
+      "code": 6089,
+      "name": "ForbiddenIx",
+      "msg": "Tried to call an instruction that is forbidden during liquidation"
+    },
+    {
+      "code": 6090,
+      "name": "LiquidationPremiumTooHigh",
+      "msg": "Seized too much of the asset relative to liability repaid"
+    },
+    {
+      "code": 6091,
+      "name": "NotAllowedInCPI",
+      "msg": "Start and end liquidation and flashloan must be top-level instructions"
+    },
+    {
+      "code": 6092,
+      "name": "ZeroSupplyInStakePool",
+      "msg": "Stake pool supply is zero: cannot compute price"
+    },
+    {
+      "code": 6093,
+      "name": "InvalidGroup",
+      "msg": "Invalid group: account constraint violated"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidLiquidityVault",
+      "msg": "Invalid liquidity vault: account constraint violated"
+    },
+    {
+      "code": 6095,
+      "name": "InvalidLiquidationRecord",
+      "msg": "Invalid liquidation record: account constraint violated"
+    },
+    {
+      "code": 6096,
+      "name": "InvalidLiquidationReceiver",
+      "msg": "Invalid liquidation receiver: account constraint violated"
+    },
+    {
+      "code": 6097,
+      "name": "InvalidEmissionsMint",
+      "msg": "Invalid emissions mint: account constraint violated"
+    },
+    {
+      "code": 6098,
+      "name": "InvalidMint",
+      "msg": "Invalid mint: account constraint violated"
+    },
+    {
+      "code": 6099,
+      "name": "InvalidFeeWallet",
+      "msg": "Invalid fee wallet: account constraint violated"
+    },
+    {
+      "code": 6100,
+      "name": "FixedOraclePriceNegative",
+      "msg": "Fixed oracle price must be zero or greater"
+    },
+    {
+      "code": 6101,
+      "name": "DailyWithdrawalLimitExceeded",
+      "msg": "Daily withdrawal limit exceeded: try again later"
+    },
+    {
+      "code": 6102,
+      "name": "ZeroWithdrawalLimit",
+      "msg": "Cannot set daily withdrawal limit to zero"
+    },
+    {
+      "code": 6103,
+      "name": "AccountFrozen",
+      "msg": "Account is frozen by the group admin"
+    },
+    {
+      "code": 6200,
+      "name": "WrongAssetTagForStandardInstructions",
+      "msg": "Wrong asset tag for standard instructions, expected DEFAULT, SOL, or STAKED asset tag"
+    },
+    {
+      "code": 6201,
+      "name": "WrongAssetTagForKaminoInstructions",
+      "msg": "Wrong asset tag for Kamino instructions, expected KAMINO asset tag"
+    },
+    {
+      "code": 6202,
+      "name": "CantAddPool",
+      "msg": "Cannot create a kamino bank with this instruction, use add_bank_kamino"
+    },
+    {
+      "code": 6203,
+      "name": "KaminoReserveMintAddressMismatch",
+      "msg": "Kamino reserve mint address doesn't match the bank mint address"
+    },
+    {
+      "code": 6204,
+      "name": "KaminoDepositFailed",
+      "msg": "Deposit failed: obligation deposit amount increase did not match the expected increase, left - actual, right - expected"
+    },
+    {
+      "code": 6205,
+      "name": "KaminoWithdrawFailed",
+      "msg": "Withdraw failed: token vault increase did not match the expected increase, left - actual, right - expected"
+    },
+    {
+      "code": 6206,
+      "name": "ReserveStale",
+      "msg": "Kamino Reserve data is stale - run refresh_reserve on kamino program first"
+    },
+    {
+      "code": 6207,
+      "name": "InvalidObligationDepositCount",
+      "msg": "Kamino obligation must have exactly one active deposit, at index 0"
+    },
+    {
+      "code": 6208,
+      "name": "ObligationDepositReserveMismatch",
+      "msg": "Kamino obligation deposit doesn't match the expected reserve"
+    },
+    {
+      "code": 6209,
+      "name": "ObligationInitDepositInsufficient",
+      "msg": "Failed to meet minimum deposit amount requirement for init obligation"
+    },
+    {
+      "code": 6210,
+      "name": "KaminoReserveValidationFailed",
+      "msg": "Kamino reserve validation failed"
+    },
+    {
+      "code": 6211,
+      "name": "KaminoInvalidOracleSetup",
+      "msg": "Invalid oracle setup: only KaminoPythPush and KaminoSwitchboardPull are supported"
+    },
+    {
+      "code": 6212,
+      "name": "IntegrationPositionLimitExceeded",
+      "msg": "Maximum integration positions limit exceeded (max 8 Kamino/Drift/Solend positions per account)"
+    },
+    {
+      "code": 6213,
+      "name": "InvalidKaminoReserve",
+      "msg": "Invalid Kamino reserve: account constraint violated"
+    },
+    {
+      "code": 6214,
+      "name": "InvalidKaminoObligation",
+      "msg": "Invalid Kamino obligation: account constraint violated"
+    },
+    {
+      "code": 6300,
+      "name": "DriftInvalidOracleSetup",
+      "msg": "Invalid oracle setup: only DriftPythPull and DriftSwitchboardPull are supported"
+    },
+    {
+      "code": 6301,
+      "name": "DriftSpotMarketMintMismatch",
+      "msg": "Drift spot market mint does not match bank mint"
+    },
+    {
+      "code": 6302,
+      "name": "WrongBankAssetTagForDriftOperation",
+      "msg": "Wrong bank asset tag for Drift operation"
+    },
+    {
+      "code": 6303,
+      "name": "CantUseStandardOperationsOnDriftAssets",
+      "msg": "Cannot use standard operations on Drift assets"
+    },
+    {
+      "code": 6304,
+      "name": "DriftSpotMarketValidationFailed",
+      "msg": "Drift spot market validation failed"
+    },
+    {
+      "code": 6305,
+      "name": "DriftInvalidSpotPositions",
+      "msg": "Drift user has invalid spot positions (only first position can have balance)"
+    },
+    {
+      "code": 6306,
+      "name": "DriftSpotPositionMarketMismatch",
+      "msg": "Drift spot position market does not match bank's configured market"
+    },
+    {
+      "code": 6307,
+      "name": "DriftInvalidPositionType",
+      "msg": "Drift position has invalid balance type (must be deposit)"
+    },
+    {
+      "code": 6308,
+      "name": "DriftScaledBalanceMismatch",
+      "msg": "Drift scaled balance change does not match expected amount"
+    },
+    {
+      "code": 6309,
+      "name": "DriftWithdrawFailed",
+      "msg": "Drift withdrawal failed - token amount mismatch"
+    },
+    {
+      "code": 6310,
+      "name": "DriftUserInitDepositInsufficient",
+      "msg": "Drift user initial deposit insufficient (minimum 10 units required)"
+    },
+    {
+      "code": 6311,
+      "name": "InvalidDriftAccount",
+      "msg": "Invalid drift account"
+    },
+    {
+      "code": 6312,
+      "name": "DriftAuthorityMismatch",
+      "msg": "Drift authority mismatch"
+    },
+    {
+      "code": 6313,
+      "name": "DriftInvalidHarvestPositionIndex",
+      "msg": "Invalid harvest position index - must be between 2 and 7"
+    },
+    {
+      "code": 6314,
+      "name": "DriftPositionEmpty",
+      "msg": "Drift position is empty"
+    },
+    {
+      "code": 6315,
+      "name": "DriftInvalidBalanceType",
+      "msg": "Drift position has invalid balance type"
+    },
+    {
+      "code": 6316,
+      "name": "DriftNoAdminDeposit",
+      "msg": "No admin deposits found in Drift positions 2-7 for this market"
+    },
+    {
+      "code": 6317,
+      "name": "DriftHarvestSameMarket",
+      "msg": "Cannot harvest from the same market as the bank's main drift spot market"
+    },
+    {
+      "code": 6318,
+      "name": "DriftBrickedAccount",
+      "msg": "Drift account bricked: too many active deposits from admin operations"
+    },
+    {
+      "code": 6319,
+      "name": "DriftMissingRewardOracle",
+      "msg": "Drift reward oracle required when 2+ active deposits exist"
+    },
+    {
+      "code": 6320,
+      "name": "DriftMissingRewardSpotMarket",
+      "msg": "Drift reward spot market required when 2+ active deposits exist"
+    },
+    {
+      "code": 6321,
+      "name": "DriftMissingRewardAccounts",
+      "msg": "Drift account has admin deposits that require reward accounts to be provided"
+    },
+    {
+      "code": 6322,
+      "name": "DriftSpotMarketStale",
+      "msg": "Drift spot market is stale, interest needs to be updated"
+    },
+    {
+      "code": 6323,
+      "name": "InvalidDriftSpotMarket",
+      "msg": "Invalid Drift spot market: account constraint violated"
+    },
+    {
+      "code": 6324,
+      "name": "InvalidDriftUser",
+      "msg": "Invalid Drift user: account constraint violated"
+    },
+    {
+      "code": 6325,
+      "name": "InvalidDriftUserStats",
+      "msg": "Invalid Drift user stats: account constraint violated"
+    },
+    {
+      "code": 6326,
+      "name": "DriftUnsupportedTokenDecimals",
+      "msg": "Drift cannot support tokens with more than 19 decimals"
+    },
+    {
+      "code": 6400,
+      "name": "SolendInvalidOracleSetup",
+      "msg": "Invalid oracle setup: only SolendPythPull and SolendSwitchboardPull are supported"
+    },
+    {
+      "code": 6401,
+      "name": "SolendReserveValidationFailed",
+      "msg": "Solend reserve validation failed"
+    },
+    {
+      "code": 6402,
+      "name": "SolendObligationOwnerMismatch",
+      "msg": "Solend obligation owner mismatch"
+    },
+    {
+      "code": 6403,
+      "name": "WrongBankAssetTagForSolendOperation",
+      "msg": "Wrong bank asset tag for Solend operation"
+    },
+    {
+      "code": 6404,
+      "name": "CantUseStandardOperationsOnSolendAssets",
+      "msg": "Cannot use standard operations on Solend assets"
+    },
+    {
+      "code": 6405,
+      "name": "SolendReserveMismatch",
+      "msg": "Solend reserve mismatch"
+    },
+    {
+      "code": 6406,
+      "name": "SolendReserveMintMismatch",
+      "msg": "Solend reserve mint mismatch"
+    },
+    {
+      "code": 6407,
+      "name": "SolendInvalidDepositPositions",
+      "msg": "Solend obligation has invalid deposits (only first position can have balance)"
+    },
+    {
+      "code": 6408,
+      "name": "SolendDepositPositionReserveMismatch",
+      "msg": "Solend deposit position reserve does not match bank's configured reserve"
+    },
+    {
+      "code": 6409,
+      "name": "SolendCTokenBalanceMismatch",
+      "msg": "Solend cToken balance change does not match expected amount"
+    },
+    {
+      "code": 6410,
+      "name": "SolendWithdrawFailed",
+      "msg": "Solend withdrawal failed - token amount mismatch"
+    },
+    {
+      "code": 6411,
+      "name": "SolendReserveStale",
+      "msg": "Solend reserve is stale"
+    },
+    {
+      "code": 6412,
+      "name": "SolendDepositFailed",
+      "msg": "Solend deposit failed - collateral amount mismatch"
+    },
+    {
+      "code": 6413,
+      "name": "InvalidSolendAccount",
+      "msg": "Invalid Solend account owner"
+    },
+    {
+      "code": 6414,
+      "name": "InvalidSolendAccountVersion",
+      "msg": "Invalid Solend account version"
+    },
+    {
+      "code": 6415,
+      "name": "InvalidSolendReserve",
+      "msg": "Invalid Solend reserve: account constraint violated"
+    },
+    {
+      "code": 6416,
+      "name": "InvalidSolendObligation",
+      "msg": "Invalid Solend obligation: account constraint violated"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountEventHeader",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_group",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Balance",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active",
+            "type": "u8"
+          },
+          {
+            "name": "bank_pk",
+            "type": "pubkey"
+          },
+          {
+            "name": "bank_asset_tag",
+            "docs": [
+              "Inherited from the bank when the position is first created and CANNOT BE CHANGED after that.",
+              "Note that all balances created before the addition of this feature use `ASSET_TAG_DEFAULT`"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "asset_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "emissions_outstanding",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "last_update",
+            "type": "u64"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": ["u64", 1]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bank",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "asset_share_value",
+            "docs": [
+              "Monotonically increases as interest rate accumulates. For typical banks, a user's asset",
+              "value in token = (number of shares the user has * asset_share_value).",
+              "* A float (arbitrary decimals)",
+              "* Initially 1"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_share_value",
+            "docs": [
+              "Monotonically increases as interest rate accumulates. For typical banks, a user's liabilty",
+              "value in token = (number of shares the user has * liability_share_value)",
+              "* A float (arbitrary decimals)",
+              "* Initially 1"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liquidity_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_vault_bump",
+            "type": "u8"
+          },
+          {
+            "name": "liquidity_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "insurance_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "insurance_vault_bump",
+            "type": "u8"
+          },
+          {
+            "name": "insurance_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad1",
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "collected_insurance_fees_outstanding",
+            "docs": ["Fees collected and pending withdraw for the `insurance_vault`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "fee_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_vault_bump",
+            "type": "u8"
+          },
+          {
+            "name": "fee_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad2",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "collected_group_fees_outstanding",
+            "docs": ["Fees collected and pending withdraw for the `fee_vault`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "total_liability_shares",
+            "docs": ["Sum of all liability shares held by all borrowers in this bank.", "* Uses `mint_decimals`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "total_asset_shares",
+            "docs": [
+              "Sum of all asset shares held by all depositors in this bank.",
+              "* Uses `mint_decimals`",
+              "* For Kamino banks, this is the quantity of collateral tokens (NOT liquidity tokens) in the",
+              "bank, and also uses `mint_decimals`, though the mint itself will always show (6) decimals",
+              "exactly (i.e Kamino ignores this and treats it as if it was using `mint_decimals`)"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "last_update",
+            "type": "i64"
+          },
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "BankConfig"
+              }
+            }
+          },
+          {
+            "name": "flags",
+            "docs": [
+              "Bank Config Flags",
+              "",
+              "- EMISSIONS_FLAG_BORROW_ACTIVE: 1",
+              "- EMISSIONS_FLAG_LENDING_ACTIVE: 2",
+              "- PERMISSIONLESS_BAD_DEBT_SETTLEMENT: 4",
+              "- FREEZE_SETTINGS: 8",
+              "- CLOSE_ENABLED_FLAG: 16",
+              "- TOKENLESS_REPAYMENTS_ACTIVE: 32",
+              ""
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_rate",
+            "docs": [
+              "Emissions APR. Number of emitted tokens (emissions_mint) per 1e(bank.mint_decimal) tokens",
+              "(bank mint) (native amount) per 1 YEAR."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_remaining",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "emissions_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "collected_program_fees_outstanding",
+            "docs": [
+              "Fees collected and pending withdraw for the `FeeState.global_fee_wallet`'s canonical ATA for `mint`"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "emode",
+            "docs": [
+              "Controls this bank's emode configuration, which enables some banks to treat the assets of",
+              "certain other banks more preferentially as collateral."
+            ],
+            "type": {
+              "defined": {
+                "name": "EmodeSettings"
+              }
+            }
+          },
+          {
+            "name": "fees_destination_account",
+            "docs": [
+              "Set with `update_fees_destination_account`. Fees can be withdrawn to the canonical ATA of",
+              "this wallet without the admin's input (withdraw_fees_permissionless). If pubkey default, the",
+              "bank doesn't support this feature, and the fees must be collected manually (withdraw_fees)."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "cache",
+            "type": {
+              "defined": {
+                "name": "BankCache"
+              }
+            }
+          },
+          {
+            "name": "lending_position_count",
+            "docs": [
+              "Number of user lending positions currently open in this bank",
+              "* For banks created prior to 0.1.4, this is the number of positions opened/closed after",
+              "0.1.4 goes live, and may be negative.",
+              "* For banks created in 0.1.4 or later, this is the number of positions open in total, and",
+              "the bank may safely be closed if this is zero. Will never go negative."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "borrowing_position_count",
+            "docs": [
+              "Number of user borrowing positions currently open in this bank",
+              "* For banks created prior to 0.1.4, this is the number of positions opened/closed after",
+              "0.1.4 goes live, and may be negative.",
+              "* For banks created in 0.1.4 or later, this is the number of positions open in total, and",
+              "the bank may safely be closed if this is zero. Will never go negative."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "integration_acc_1",
+            "docs": [
+              "Integration account slot 1 (default Pubkey for non-integrations).",
+              "- Kamino: reserve",
+              "- Drift: spot market",
+              "- Solend: reserve"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "integration_acc_2",
+            "docs": [
+              "Integration account slot 2 (default Pubkey for non-integrations).",
+              "- Kamino: obligation",
+              "- Drift: user",
+              "- Solend: obligation"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "integration_acc_3",
+            "docs": ["Integration account slot 3 (default Pubkey for non-integrations).", "- Drift: user stats"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 2]
+                },
+                13
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankCache",
+      "docs": ["A read-only cache of the bank's key metrics, e.g. spot interest/fee rates."],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_rate",
+            "docs": [
+              "Actual (spot) interest/fee rates of the bank, based on utilization",
+              "* APR (annual percentage rate) values",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u:32::MAX/2 = 500%, etc"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "lending_rate",
+            "docs": [
+              "Equivalent to `base_rate` * utilization",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u:32::MAX/2 = 500%, etc"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "borrowing_rate",
+            "docs": [
+              "Equivalent to `base_rate` * (1 + ir_fees) + fixed_fees",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u:32::MAX/2 = 500%, etc"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "interest_accumulated_for",
+            "docs": ["* in seconds"],
+            "type": "u32"
+          },
+          {
+            "name": "accumulated_since_last_update",
+            "docs": [
+              "equivalent to (share value increase in the last `interest_accumulated_for` seconds *",
+              "shares), i.e. the delta in `asset_share_value`, in token.",
+              "* Note: if the tx that triggered this cache update increased or decreased the net shares,",
+              "this value still reports using the PRE-CHANGE share amount, since interest is always",
+              "earned on that amount.",
+              "* in token, in native decimals, as I80F48"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "last_oracle_price",
+            "docs": [
+              "Oracle price used in the last instruction that consumed an oracle price",
+              "* Only updated when instruction uses an oracle price, not updated for operations that don't",
+              "require prices (e.g., deposit, repay)",
+              "* Price in USD, with no price bias",
+              "* Zero if never updated"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "last_oracle_price_timestamp",
+            "docs": [
+              "Unix timestamp (seconds) when last_oracle_price was last updated",
+              "* Used to determine staleness of cached price",
+              "* Zero if never updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_price_confidence",
+            "docs": [
+              "Confidence interval reported by the oracle when last_oracle_price was fetched",
+              "* Always non-negative",
+              "* Zero if never updated",
+              "* Note: this value is the confidence reported by oracles, multiplied by `STD_DEV_MULTIPLE`"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": ["u8", 24]
+            }
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankConfig",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_weight_init",
+            "docs": ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "interest_rate_config",
+            "type": {
+              "defined": {
+                "name": "InterestRateConfig"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "name": "oracle_keys",
+            "type": {
+              "array": ["pubkey", 5]
+            }
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "borrow_limit",
+            "type": "u64"
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "asset_tag",
+            "docs": [
+              "Determines what kinds of assets users of this bank can interact with.",
+              "Options:",
+              "* ASSET_TAG_DEFAULT (0) - A regular asset that can be comingled with any other regular asset",
+              "or with `ASSET_TAG_SOL`",
+              "* ASSET_TAG_SOL (1) - Accounts with a SOL position can comingle with **either**",
+              "`ASSET_TAG_DEFAULT` or `ASSET_TAG_STAKED` positions, but not both",
+              "* ASSET_TAG_STAKED (2) - Staked SOL assets. Accounts with a STAKED position can only deposit",
+              "other STAKED assets or SOL (`ASSET_TAG_SOL`) and can only borrow SOL"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "config_flags",
+            "docs": [
+              "Flags for various config options",
+              "* 1 - Always set if bank created in 0.1.4 or later, or if migrated to the new pyth",
+              "oracle setup from a prior version. Not set in 0.1.3 or earlier banks using pyth that have",
+              "not yet migrated. Does nothing for banks that use switchboard.",
+              "* 2, 4, 8, 16, etc - reserved for future use."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_pad1",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "docs": [
+              "USD denominated limit for calculating asset value for initialization margin requirements.",
+              "Example, if total SOL deposits are equal to $1M and the limit it set to $500K,",
+              "then SOL assets will be discounted by 50%.",
+              "",
+              "In other words the max value of liabilities that can be backed by the asset is $500K.",
+              "This is useful for limiting the damage of orcale attacks.",
+              "",
+              "Value is UI USD value, for example value 100 -> $100"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "docs": ["Time window in seconds for the oracle price feed to be considered live."],
+            "type": "u16"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "oracle_max_confidence",
+            "docs": [
+              "From 0-100%, if the confidence exceeds this value, the oracle is considered invalid. Note:",
+              "the confidence adjustment is capped at 5% regardless of this value.",
+              "* 0 falls back to using the default 10% instead, i.e., U32_MAX_DIV_10",
+              "* A %, as u32, e.g. 100% = u32::MAX, 50% = u32::MAX/2, etc."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fixed_price",
+            "docs": ["Stored oracle price for `OracleSetup::Fixed`, otherwise does nothing"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankConfigCompact",
+      "docs": ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "interest_rate_config",
+            "type": {
+              "defined": {
+                "name": "InterestRateConfigCompact"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "borrow_limit",
+            "type": "u64"
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "asset_tag",
+            "docs": [
+              "Determines what kinds of assets users of this bank can interact with.",
+              "Options:",
+              "* ASSET_TAG_DEFAULT (0) - A regular asset that can be comingled with any other regular asset",
+              "or with `ASSET_TAG_SOL`",
+              "* ASSET_TAG_SOL (1) - Accounts with a SOL position can comingle with **either**",
+              "`ASSET_TAG_DEFAULT` or `ASSET_TAG_STAKED` positions, but not both",
+              "* ASSET_TAG_STAKED (2) - Staked SOL assets. Accounts with a STAKED position can only deposit",
+              "other STAKED assets or SOL (`ASSET_TAG_SOL`) and can only borrow SOL"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "config_flags",
+            "docs": [
+              "Flags for various config options",
+              "* 1 - Always set if bank created in 0.1.4 or later, or if migrated to the new oracle",
+              "setup from a prior version. Not set in 0.1.3 or earlier banks that have not yet migrated.",
+              "* 2, 4, 8, 16, etc - reserved for future use."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "docs": [
+              "USD denominated limit for calculating asset value for initialization margin requirements.",
+              "Example, if total SOL deposits are equal to $1M and the limit it set to $500K,",
+              "then SOL assets will be discounted by 50%.",
+              "",
+              "In other words the max value of liabilities that can be backed by the asset is $500K.",
+              "This is useful for limiting the damage of orcale attacks.",
+              "",
+              "Value is UI USD value, for example value 100 -> $100"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "docs": ["Time window in seconds for the oracle price feed to be considered live."],
+            "type": "u16"
+          },
+          {
+            "name": "oracle_max_confidence",
+            "docs": [
+              "From 0-100%, if the confidence exceeds this value, the oracle is considered invalid. Note:",
+              "the confidence adjustment is capped at 5% regardless of this value.",
+              "* 0% = use the default (10%)",
+              "* A %, as u32, e.g. 100% = u32::MAX, 50% = u32::MAX/2, etc."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankConfigOpt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "liability_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "liability_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "borrow_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "operational_state",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "BankOperationalState"
+                }
+              }
+            }
+          },
+          {
+            "name": "interest_rate_config",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "InterestRateConfigOpt"
+                }
+              }
+            }
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RiskTier"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_tag",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracle_max_confidence",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "oracle_max_age",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "permissionless_bad_debt_settlement",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "freeze_settings",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "tokenless_repayments_allowed",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankMetadata",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bank",
+            "docs": ["Bank this metadata corresponds to"],
+            "type": "pubkey"
+          },
+          {
+            "name": "placeholder",
+            "type": "u64"
+          },
+          {
+            "name": "ticker",
+            "docs": ["The token's ticker name, e.g. USDC", "* utf-8"],
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "description",
+            "docs": ["The token's plain english descripion, e.g US Dollar Coin", "* utf-8"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          },
+          {
+            "name": "data_blob",
+            "docs": ["Reserved for future use. Room for a very small icon or something else cool"],
+            "type": {
+              "array": ["u8", 256]
+            }
+          },
+          {
+            "name": "end_description_byte",
+            "docs": ["The last data byte in description (padding follows)"],
+            "type": "u16"
+          },
+          {
+            "name": "end_data_blob",
+            "docs": ["The last data byte in data_blob (padding follows)"],
+            "type": "u16"
+          },
+          {
+            "name": "end_ticker_byte",
+            "docs": ["The last data byte in ticker (padding follows)"],
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BankOperationalState",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Paused"
+          },
+          {
+            "name": "Operational"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "KilledByBankruptcy"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeleverageEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "risk_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "deleveragee_assets_seized",
+            "type": "f64"
+          },
+          {
+            "name": "deleveragee_liability_repaid",
+            "type": "f64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DriftConfigCompact",
+      "docs": [
+        "Used to configure Drift banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Drift banks cannot earn interest or be borrowed against."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_setup",
+            "docs": ["Either `DriftPythPull` or `DriftSwitchboardPull`"],
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "docs": ["Bank operational state - allows starting banks in paused state"],
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "risk_tier",
+            "docs": ["Risk tier - determines if assets can be borrowed in isolation"],
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "config_flags",
+            "docs": ["Config flags for future-proofing"],
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "oracle_max_confidence",
+            "docs": ["Oracle confidence threshold (0 = use default 10%)"],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EditStakedSettingsEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "settings",
+            "type": {
+              "defined": {
+                "name": "StakedSettingsEditConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EmodeConfig",
+      "docs": [
+        "An emode configuration. Each bank has one such configuration, but this may also be the",
+        "intersection of many configurations (see `reconcile_emode_configs`). For example, the risk",
+        "engine creates such an intersection from all the emode config of all banks the user is borrowing",
+        "from."
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "entries",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "EmodeEntry"
+                  }
+                },
+                10
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EmodeEntry",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collateral_bank_emode_tag",
+            "docs": ["emode_tag of the bank(s) whose collateral you wish to treat preferentially."],
+            "type": "u16"
+          },
+          {
+            "name": "flags",
+            "docs": [
+              "* APPLIES_TO_ISOLATED (1) - (NOT YET IMPLEMENTED) if set, isolated banks with this tag",
+              "also benefit. If not set, isolated banks continue to offer zero collateral, even if they",
+              "use this tag.",
+              "* 2, 4, 8, 16, 32, etc - reserved for future use"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "asset_weight_init",
+            "docs": ["Note: If set below the collateral bank's weight, does nothing."],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "docs": ["Note: If set below the collateral bank's weight, does nothing."],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EmodeSettings",
+      "docs": [
+        "Controls the bank's e-mode configuration, allowing certain collateral sources to be treated more",
+        "favorably as collateral when used to borrow from this bank."
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "emode_tag",
+            "docs": [
+              "This bank's NON-unique id that other banks will use to determine what emode rate to use when",
+              "this bank is offered as collateral.",
+              "",
+              "For example, all stablecoin banks might share the same emode_tag, and in their entries, each",
+              "such stablecoin bank will recognize that collateral sources with this \"stable\" tag get",
+              "preferential weights. When a new stablecoin is added that is considered riskier, it may get",
+              "a new, less favorable emode tag, and eventually get upgraded to the same one as the other",
+              "stables",
+              "",
+              "* 0 is in an invalid tag and will do nothing."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "timestamp",
+            "docs": ["Unix timestamp from the system clock when emode state was last updated"],
+            "type": "i64"
+          },
+          {
+            "name": "flags",
+            "docs": [
+              "EMODE_ON (1) - If set, at least one entry is configured",
+              "2, 4, 8, etc, Reserved for future use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emode_config",
+            "type": {
+              "defined": {
+                "name": "EmodeConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeState",
+      "docs": [
+        "Unique per-program. The Program Owner uses this account to administrate fees collected by the protocol"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": ["The fee state's own key. A PDA derived from just `b\"feestate\"`"],
+            "type": "pubkey"
+          },
+          {
+            "name": "global_fee_admin",
+            "docs": ["Can modify fees"],
+            "type": "pubkey"
+          },
+          {
+            "name": "global_fee_wallet",
+            "docs": [
+              "The base wallet for all protocol fees. All SOL fees go to this wallet. All non-SOL fees go",
+              "to the cannonical ATA of this wallet for that asset."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "name": "bank_init_flat_sol_fee",
+            "docs": ["Flat fee assessed when a new bank is initialized, in lamports.", "* In SOL, in native decimals."],
+            "type": "u32"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": ["u8", 3]
+            }
+          },
+          {
+            "name": "liquidation_max_fee",
+            "docs": [
+              "Liquidators can claim at this premium, when liquidating an asset in receivership",
+              "liquidation, e.g. (1 + this) * amount repaid <= asset seized",
+              "* A percentage"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "program_fee_fixed",
+            "docs": ["Fee collected by the program owner from all groups", "* A percentage"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "program_fee_rate",
+            "docs": ["Fee collected by the program owner from all groups", "* A percentage"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "panic_state",
+            "docs": [
+              "When the global admin pauses the protocol in the event of an emergency, information about",
+              "the pause duration will be stored here and propagated to groups."
+            ],
+            "type": {
+              "defined": {
+                "name": "PanicState"
+              }
+            }
+          },
+          {
+            "name": "placeholder1",
+            "type": "u64"
+          },
+          {
+            "name": "liquidation_flat_sol_fee",
+            "docs": [
+              "Flat fee assessed for insurance/program use when a liquidation is executed",
+              "* In SOL, in native decimals."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 20]
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": ["u8", 32]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeStateCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "global_fee_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "program_fee_fixed",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "program_fee_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "last_update",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GroupEventHeader",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "marginfi_group",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HealthCache",
+      "docs": [
+        "A read-only cache of the internal risk engine's information. Only valid in borrow/withdraw if",
+        "the tx does not fail. To see the state in any context, e.g. to figure out if the risk engine is",
+        "failing due to some bad price information, use `pulse_health`."
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_value",
+            "docs": [
+              "Internal risk engine asset value, using initial weight (e.g. what is used for borrowing",
+              "purposes), with all confidence adjustments, and other discounts on price.",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_value",
+            "docs": [
+              "Internal risk engine liability value, using initial weight (e.g. what is used for borrowing",
+              "purposes), with all confidence adjustments, and other discounts on price.",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_value_maint",
+            "docs": [
+              "Internal risk engine asset value, using maintenance weight (e.g. what is used for",
+              "liquidation purposes), with all confidence adjustments.",
+              "* Zero if the risk engine failed to load",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_value_maint",
+            "docs": [
+              "Internal risk engine liability value, using maintenance weight (e.g. what is used for",
+              "liquidation purposes), with all confidence adjustments.",
+              "* Zero if the risk engine failed to load",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_value_equity",
+            "docs": [
+              "The \"true\" value of assets without any confidence or weight adjustments. Internally, used",
+              "only for bankruptcies.",
+              "* Zero if the risk engine failed to load",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_value_equity",
+            "docs": [
+              "The \"true\" value of liabilities without any confidence or weight adjustments.",
+              "Internally, used only for bankruptcies.",
+              "* Zero if the risk engine failed to load",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "timestamp",
+            "docs": ["Unix timestamp from the system clock when this cache was last updated"],
+            "type": "i64"
+          },
+          {
+            "name": "flags",
+            "docs": [
+              "The flags that indicate the state of the health cache. This is a u64 bitfield, where each",
+              "bit represents a flag.",
+              "",
+              "* HEALTHY = 1 - If set, the account cannot be liquidated. If 0, the account is unhealthy and",
+              "can be liquidated.",
+              "* ENGINE STATUS = 2 - If set, the engine did not error during the last health pulse. If 0,",
+              "the engine would have errored and this cache is likely invalid. `RiskEngineInitRejected`",
+              "is ignored and will allow the flag to be set anyways.",
+              "* ORACLE OK = 4 - If set, the engine did not error due to an oracle issue. If 0, engine was",
+              "passed a bad bank or oracle account, or an oracle was stale. Check the order in which",
+              "accounts were passed and ensure each balance has the correct banks/oracles, and that",
+              "oracle cranks ran recently enough. Check `internal_err` and `err_index` for more details",
+              "in some circumstances. Invalid if generated after borrow/withdraw (these instructions will",
+              "ignore oracle issues if health is still satisfactory with some balance zeroed out).",
+              "* 8, 16, 32, 64, 128, etc - reserved for future use"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "mrgn_err",
+            "docs": [
+              "If the engine errored, look here for the error code. If the engine returns ok, you may also",
+              "check here to see if the risk engine rejected this tx (3009)."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "prices",
+            "docs": [
+              "Each price corresponds to that index of Balances in the LendingAccount. Useful for debugging",
+              "or liquidator consumption, to determine how a user's position is priced internally.",
+              "* An f64 stored as bytes"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u8", 8]
+                },
+                16
+              ]
+            }
+          },
+          {
+            "name": "internal_err",
+            "docs": [
+              "Errors in asset oracles are ignored (with prices treated as zero). If you see a zero price",
+              "and the `ORACLE_OK` flag is not set, check here to see what error was ignored internally."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "err_index",
+            "docs": ["Index in `balances` where `internal_err` appeared"],
+            "type": "u8"
+          },
+          {
+            "name": "program_version",
+            "docs": ["Since 0.1.3, the version will be encoded here. See PROGRAM_VERSION."],
+            "type": "u8"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "internal_liq_err",
+            "type": "u32"
+          },
+          {
+            "name": "internal_bankruptcy_err",
+            "type": "u32"
+          },
+          {
+            "name": "reserved0",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "reserved1",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "HealthPulseEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "account",
+            "type": "pubkey"
+          },
+          {
+            "name": "health_cache",
+            "type": {
+              "defined": {
+                "name": "HealthCache"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InterestRateConfig",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "optimal_utilization_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "plateau_interest_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "max_interest_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "insurance_fee_fixed_apr",
+            "docs": ["Goes to insurance, funds `collected_insurance_fees_outstanding`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "insurance_ir_fee",
+            "docs": ["Goes to insurance, funds `collected_insurance_fees_outstanding`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_fixed_fee_apr",
+            "docs": ["Earned by the group, goes to `collected_group_fees_outstanding`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_ir_fee",
+            "docs": ["Earned by the group, goes to `collected_group_fees_outstanding`"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "zero_util_rate",
+            "docs": ["The base rate at utilization = 0", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": "u32"
+          },
+          {
+            "name": "hundred_util_rate",
+            "docs": ["The base rate at utilization = 100", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": "u32"
+          },
+          {
+            "name": "points",
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RatePoint"
+                  }
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "curve_type",
+            "docs": [
+              "Determines which interest rate curve implementation is active. 0 (INTEREST_CURVE_LEGACY) =",
+              "legacy three point curve, 1 (INTEREST_CURVE_SEVEN_POINT) = multi-point curve."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InterestRateConfigCompact",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "insurance_fee_fixed_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "insurance_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_fixed_fee_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "zero_util_rate",
+            "docs": ["The base rate at utilization = 0", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": "u32"
+          },
+          {
+            "name": "hundred_util_rate",
+            "docs": ["The base rate at utilization = 100", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": "u32"
+          },
+          {
+            "name": "points",
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RatePoint"
+                  }
+                },
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InterestRateConfigOpt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "insurance_fee_fixed_apr",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "insurance_ir_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_fixed_fee_apr",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_ir_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "zero_util_rate",
+            "docs": ["The base rate at utilization = 0", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "hundred_util_rate",
+            "docs": ["The base rate at utilization = 100", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "points",
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "type": {
+              "option": {
+                "array": [
+                  {
+                    "defined": {
+                      "name": "RatePoint"
+                    }
+                  },
+                  5
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "KaminoConfigCompact",
+      "docs": [
+        "Used to configure Kamino banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Kamino banks cannot earn interest or be borrowed against."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_setup",
+            "docs": ["Either `KaminoPythPush` or `KaminoSwitchboardPull`"],
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "docs": ["Bank operational state - allows starting banks in paused state"],
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "risk_tier",
+            "docs": ["Risk tier - determines if assets can be borrowed in isolation"],
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "config_flags",
+            "docs": ["Config flags for future-proofing"],
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "docs": ["Currently unused: Kamino's oracle age applies to kamino banks."],
+            "type": "u16"
+          },
+          {
+            "name": "oracle_max_confidence",
+            "docs": ["Oracle confidence threshold (0 = use default 10%)"],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccount",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "balances",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Balance"
+                  }
+                },
+                16
+              ]
+            }
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": ["u64", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccountBorrowEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccountDepositEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccountLiquidateEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "liquidatee_marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_marginfi_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "liability_bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "liability_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_pre_health",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_post_health",
+            "type": "f64"
+          },
+          {
+            "name": "pre_balances",
+            "type": {
+              "defined": {
+                "name": "LiquidationBalances"
+              }
+            }
+          },
+          {
+            "name": "post_balances",
+            "type": {
+              "defined": {
+                "name": "LiquidationBalances"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccountRepayEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "close_balance",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingAccountWithdrawEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "close_balance",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankAccrueInterestEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "delta",
+            "type": "u64"
+          },
+          {
+            "name": "fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_collected",
+            "type": "f64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankCollectFeesEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "group_fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "group_fees_outstanding",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_fees_outstanding",
+            "type": "f64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "BankConfigOpt"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureFrozenEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "borrow_limit",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureOracleEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_setup",
+            "type": "u8"
+          },
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankCreateEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankHandleBankruptcyEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "bad_debt",
+            "type": "f64"
+          },
+          {
+            "name": "covered_amount",
+            "type": "f64"
+          },
+          {
+            "name": "socialized_amount",
+            "type": "f64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPoolBankSetFixedOraclePriceEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "price",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationBalances",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidatee_asset_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_liability_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidator_asset_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidator_liability_balance",
+            "type": "f64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationCache",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_value_maint",
+            "docs": [
+              "Internal risk engine asset value snapshot taken when liquidation begins, using maintenance",
+              "weight with all confidence adjustments.",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_value_maint",
+            "docs": [
+              "Internal risk engine liability value snapshot taken when liquidation begins, using",
+              "maintenance weight with all confidence adjustments.",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_value_equity",
+            "docs": [
+              "Actual cash value of assets pre-liquidation (inclusive of price adjustment for oracle",
+              "confidence, but without any weights)",
+              "* Liquidator is allowed to seize up to `liability_value_equity` - this amount",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_value_equity",
+            "docs": [
+              "Actual cash value of liabilities pre-liquidation (inclusive of price adjustment for oracle",
+              "confidence, but without any weights)",
+              "* Liquidator is allowed to seize up to this amount - `asset_value_equity`",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_placeholder",
+            "type": "u64"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 32]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationEntry",
+      "docs": ["Used to record key details of the last few liquidation events on the account"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_amount_seized",
+            "docs": ["Dollar amount seized", "* An f64 stored as bytes"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "liab_amount_repaid",
+            "docs": ["Dollar amount repaid", "* An f64 stored as bytes"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationReceiverEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidation_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_assets_seized",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_liability_repaid",
+            "type": "f64"
+          },
+          {
+            "name": "lamps_fee_paid",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationRecord",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": ["This account's own key. A PDA derived from `marginfi_account`"],
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_account",
+            "docs": ["Account this record tracks"],
+            "type": "pubkey"
+          },
+          {
+            "name": "record_payer",
+            "docs": [
+              "The key that paid to create this account. At some point, we may allow this wallet to reclaim",
+              "the rent paid to open a record."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidation_receiver",
+            "docs": [
+              "The liquidator taking receivership of the `marginfi_account` to complete a liquidation. Pays",
+              "the liquidation fee.",
+              "* Always pubkey default unless actively within a liquidation event."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "entries",
+            "docs": ["Basic historical data for the last few liquidation events on this account"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "LiquidationEntry"
+                  }
+                },
+                4
+              ]
+            }
+          },
+          {
+            "name": "cache",
+            "type": {
+              "defined": {
+                "name": "LiquidationCache"
+              }
+            }
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "_reserved2",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "_reserved3",
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiAccount",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "lending_account",
+            "type": {
+              "defined": {
+                "name": "LendingAccount"
+              }
+            }
+          },
+          {
+            "name": "account_flags",
+            "docs": [
+              "The flags that indicate the state of the account. This is u64 bitfield, where each bit",
+              "represents a flag.",
+              "",
+              "Flags:MarginfiAccount",
+              "- 1: `ACCOUNT_DISABLED` - Indicates that the account is disabled and no further actions can",
+              "be taken on it.",
+              "- 2: `ACCOUNT_IN_FLASHLOAN` - Only set when an account is within a flash loan, e.g. when",
+              "start_flashloan is called, then unset when the flashloan ends.",
+              "- 4: `ACCOUNT_FLAG_DEPRECATED` - Deprecated, available for future use",
+              "- 8: `ACCOUNT_TRANSFER_AUTHORITY_DEPRECATED` - the admin has flagged with account to be",
+              "moved, original owner can now call `set_account_transfer_authority`",
+              "- 16: `ACCOUNT_IN_RECEIVERSHIP` - the account is eligible to be liquidated and has entered",
+              "receivership, a liquidator is able to control borrows and withdraws until the end of the",
+              "tx. This flag will only appear within a tx.",
+              "- 32: `ACCOUNT_IN_DELEVERAGE - the account is being deleveraged by the risk admin",
+              "- 64: `ACCOUNT_FROZEN` - the admin has frozen the account; only the group admin may perform",
+              "actions until unfrozen."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_destination_account",
+            "docs": [
+              "Set with `update_emissions_destination_account`. Emissions rewards can be withdrawn to the",
+              "cannonical ATA of this wallet without the user's input (withdraw_emissions_permissionless).",
+              "If pubkey default, the user has not opted into this feature, and must claim emissions",
+              "manually (withdraw_emissions)."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "health_cache",
+            "type": {
+              "defined": {
+                "name": "HealthCache"
+              }
+            }
+          },
+          {
+            "name": "migrated_from",
+            "docs": ["If this account was migrated from another one, store the original account key"],
+            "type": "pubkey"
+          },
+          {
+            "name": "migrated_to",
+            "docs": ["If this account has been migrated to another one, store the destination account key"],
+            "type": "pubkey"
+          },
+          {
+            "name": "last_update",
+            "type": "u64"
+          },
+          {
+            "name": "account_index",
+            "docs": [
+              "If a PDA-based account, the account index, a seed used to derive the PDA that can be chosen",
+              "arbitrarily (0.1.5 or later). Otherwise, does nothing."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "third_party_index",
+            "docs": [
+              "If a PDA-based account (0.1.5 or later), a \"vendor specific\" id. Values < PDA_FREE_THRESHOLD",
+              "can be used by anyone with no restrictions. Values >= PDA_FREE_THRESHOLD can only be used by",
+              "a particular program via CPI. These values require being added to a list, contact us for",
+              "more details. For legacy non-pda accounts, does nothing.",
+              "",
+              "Note: use a unique seed to tag accounts related to some particular program or campaign so",
+              "you can easily fetch them all later."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "bump",
+            "docs": ["This account's bump, if a PDA-based account (0.1.5 or later). Otherwise, does nothing."],
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 3]
+            }
+          },
+          {
+            "name": "liquidation_record",
+            "docs": [
+              "Stores information related to liquidations made against this account. A pda of this",
+              "account's key, and \"liq_record\"",
+              "* Typically pubkey default if this account has never been liquidated or close to liquidation",
+              "* Opening this account is permissionless. Typically the liquidator pays, but e.g. we may",
+              "also charge the user if they are opening a risky position on the front end."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": ["u64", 7]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiAccountCreateEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiAccountFreezeEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "frozen",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiAccountTransferToNewAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "old_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_account_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiGroup",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "docs": ["Broadly able to modify anything, and can set/remove other admins at will."],
+            "type": "pubkey"
+          },
+          {
+            "name": "group_flags",
+            "docs": [
+              "Bitmask for group settings flags.",
+              "* 0: `PROGRAM_FEES_ENABLED` If set, program-level fees are enabled.",
+              "* 1: `ARENA_GROUP` Deprecated, available for future use.",
+              "* Bits 1-63: Reserved for future use."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_state_cache",
+            "docs": ["Caches information from the global `FeeState` so the FeeState can be omitted on certain ixes"],
+            "type": {
+              "defined": {
+                "name": "FeeStateCache"
+              }
+            }
+          },
+          {
+            "name": "banks",
+            "type": "u16"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "emode_admin",
+            "docs": [
+              "This admin can configure collateral ratios above (but not below) the collateral ratio of",
+              "certain banks , e.g. allow SOL to count as 90% collateral when borrowing an LST instead of",
+              "the default rate."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate_curve_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate_limit_admin",
+            "docs": [
+              "Can modify the `deposit_limit`, `borrow_limit`, `total_asset_value_init_limit` but nothing",
+              "else, for every bank under this group"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate_emissions_admin",
+            "docs": [
+              "Can modify the emissions `flags`, `emissions_rate` and `emissions_mint`, but nothing else,",
+              "for every bank under this group"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "panic_state_cache",
+            "docs": [
+              "When program keeper temporarily puts the program into panic mode, information about the",
+              "duration of the lockup will be available here."
+            ],
+            "type": {
+              "defined": {
+                "name": "PanicStateCache"
+              }
+            }
+          },
+          {
+            "name": "deleverage_withdraw_window_cache",
+            "docs": [
+              "Keeps track of the liquidity withdrawn from the group over the day as a result of",
+              "deleverages. Used as a protection mechanism against too big (and unwanted) withdrawals (e.g.",
+              "when the risk admin is compromised)."
+            ],
+            "type": {
+              "defined": {
+                "name": "WithdrawWindowCache"
+              }
+            }
+          },
+          {
+            "name": "risk_admin",
+            "docs": ["Can run bankruptcy and forced deleverage ixes to e.g. sunset risky/illiquid assets"],
+            "type": "pubkey"
+          },
+          {
+            "name": "metadata_admin",
+            "docs": ["Can modify a Bank's metadata, and nothing else."],
+            "type": "pubkey"
+          },
+          {
+            "name": "emode_max_init_leverage",
+            "type": "u32"
+          },
+          {
+            "name": "emode_max_maint_leverage",
+            "type": "u32"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 2]
+                },
+                11
+              ]
+            }
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 2]
+                },
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiGroupConfigureEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "flags",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginfiGroupCreateEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimalObligation",
+      "docs": ["A minimal copy of Kamino's Obligation for zero-copy deserialization"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "type": "u64"
+          },
+          {
+            "name": "last_update_slot",
+            "docs": [
+              "Kamino obligations are only good for one slot, e.g. `refresh_obligation` must have run within the",
+              "same slot as any ix that needs a non-stale obligation e.g. withdraw."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_update_stale",
+            "docs": [
+              "True if the obligation is stale, which will cause various ixes like withdraw to fail. Typically",
+              "set to true in any tx that modifies obligation balance, and set to false at the end of a",
+              "successful `refresh_obligation`",
+              "* 0 = false, 1 = true"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "last_update_price_status",
+            "docs": [
+              "Each bit represents a passed check in price status.",
+              "* 63 = all checks passed",
+              "",
+              "Otherwise:",
+              "* PRICE_LOADED =        0b_0000_0001; // 1",
+              "* PRICE_AGE_CHECKED =   0b_0000_0010; // 2",
+              "* TWAP_CHECKED =        0b_0000_0100; // 4",
+              "* TWAP_AGE_CHECKED =    0b_0000_1000; // 8",
+              "* HEURISTIC_CHECKED =   0b_0001_0000; // 16",
+              "* PRICE_USAGE_ALLOWED = 0b_0010_0000; // 32"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "last_update_placeholder",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "lending_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "For mrgn banks, the bank's Liquidity Vault Authority (a pda which can be derived if the bank",
+              "key is known)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "deposits",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "MinimalObligationCollateral"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "lowest_reserve_deposit_liquidation_ltv",
+            "type": "u64"
+          },
+          {
+            "name": "deposited_value_sf",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "padding_part1",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part2",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part3",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part4",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part5a",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "padding_part5c",
+            "type": {
+              "array": ["u8", 24]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimalObligationCollateral",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "deposit_reserve",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposited_amount",
+            "docs": [
+              "In collateral token (NOT liquidity token), use `collateral_to_liquidity` to convert back to",
+              "liquidity token!",
+              "* Always 6 decimals"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "market_value_sf",
+            "docs": [
+              "* In dollars, based on last oracle price update",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino.",
+              "* A float (arbitrary decimals)"
+            ],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "borrowed_amount_against_this_collateral_in_elevation_group",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u64", 9]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimalReserve",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u64"
+          },
+          {
+            "name": "slot",
+            "docs": [
+              "Kamino reserves are only good for one slot, e.g. `refresh_reserve` must have run within the",
+              "same slot as any ix that needs a non-stale reserve e.g. withdraw."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "stale",
+            "docs": [
+              "True if the reserve is stale, which will cause various ixes like withdraw to fail. Typically",
+              "set to true in any tx that modifies reserve balance, and set to false at the end of a",
+              "successful `refresh_reserve`",
+              "* 0 = false, 1 = true"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "price_status",
+            "docs": [
+              "Each bit represents a passed check in price status.",
+              "* 63 = all checks passed",
+              "",
+              "Otherwise:",
+              "* PRICE_LOADED =        0b_0000_0001; // 1",
+              "* PRICE_AGE_CHECKED =   0b_0000_0010; // 2",
+              "* TWAP_CHECKED =        0b_0000_0100; // 4",
+              "* TWAP_AGE_CHECKED =    0b_0000_1000; // 8",
+              "* HEURISTIC_CHECKED =   0b_0001_0000; // 16",
+              "* PRICE_USAGE_ALLOWED = 0b_0010_0000; // 32"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "placeholder",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "lending_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "farm_collateral",
+            "type": "pubkey"
+          },
+          {
+            "name": "farm_debt",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "supply_vault",
+            "docs": ["* A PDA"],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_vault",
+            "docs": ["* A PDA"],
+            "type": "pubkey"
+          },
+          {
+            "name": "available_amount",
+            "docs": [
+              "In simple terms: (amount in supply vault - outstanding borrows)",
+              "* In token, with `mint_decimals`"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowed_amount_sf",
+            "docs": ["* In token, with `mint_decimals`", "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "market_price_sf",
+            "docs": ["* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "market_price_last_updated_ts",
+            "type": "u64"
+          },
+          {
+            "name": "mint_decimals",
+            "type": "u64"
+          },
+          {
+            "name": "deposit_limit_crossed_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "borrow_limit_crossed_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_borrow_rate_bsf",
+            "type": {
+              "array": ["u8", 48]
+            }
+          },
+          {
+            "name": "accumulated_protocol_fees_sf",
+            "docs": ["* In token, with `mint_decimals`", "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "accumulated_referrer_fees_sf",
+            "docs": ["* In token, with `mint_decimals`", "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "pending_referrer_fees_sf",
+            "docs": ["* In token, with `mint_decimals`", "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "absolute_referral_rate_sf",
+            "docs": ["* In token, with `mint_decimals`", "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "token_program",
+            "docs": ["Token or Token22. If token22, note that Kamino does not support all Token22 extensions."],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding2_part1",
+            "type": {
+              "array": ["u8", 256]
+            }
+          },
+          {
+            "name": "padding2_part2",
+            "type": {
+              "array": ["u8", 128]
+            }
+          },
+          {
+            "name": "padding2_part3",
+            "type": {
+              "array": ["u8", 24]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part1",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part2",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding_part3",
+            "type": {
+              "array": ["u8", 128]
+            }
+          },
+          {
+            "name": "padding_part4",
+            "type": {
+              "array": ["u8", 48]
+            }
+          },
+          {
+            "name": "collateral_mint_pubkey",
+            "docs": [
+              "Mints collateral tokens",
+              "* A PDA",
+              "* technically 6 decimals, but uses `mint_decimals` regardless for all purposes",
+              "* authority = lending_market_authority"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_total_supply",
+            "docs": [
+              "Total number of collateral tokens",
+              "* uses `mint_decimals`, even though it's technically 6 decimals under the hood"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "collateral_supply_vault",
+            "docs": ["* A PDA"],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding1_reserve_collateral",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding2_reserve_collateral",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding4_part1",
+            "type": {
+              "array": ["u8", 4096]
+            }
+          },
+          {
+            "name": "padding4_part2",
+            "type": {
+              "array": ["u8", 512]
+            }
+          },
+          {
+            "name": "padding4_part3",
+            "type": {
+              "array": ["u8", 256]
+            }
+          },
+          {
+            "name": "padding4_part4",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "padding4_part5",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "padding4_part6",
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimalSpotMarket",
+      "docs": [
+        "Minimal representation of Drift's SpotMarket account",
+        "Only includes the fields we actually need for marginfi integration",
+        "https://github.com/drift-labs/protocol-v2/tree/master/programs/drift/src/state/spot_market.rs#L35"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": ["The address of the spot market. It is a pda of the market index"],
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle",
+            "docs": ["The oracle used to price the markets deposits/borrows"],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "docs": ["The token mint of the market"],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": ["The vault used to store the market's deposits"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 4]
+                },
+                9
+              ]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "deposit_balance",
+            "docs": ["All the fields we need for testing (stored as raw bytes for simplicity)"],
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "borrow_balance",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "cumulative_deposit_interest",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "cumulative_borrow_interest",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": ["u64", 9]
+            }
+          },
+          {
+            "name": "last_interest_ts",
+            "docs": [
+              "Last time the cumulative deposit and borrow interest was updated",
+              "Offset: 568 bytes from start of struct (including discriminator)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding4",
+            "type": {
+              "array": ["u64", 13]
+            }
+          },
+          {
+            "name": "decimals",
+            "type": "u32"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "_padding5",
+            "type": {
+              "array": ["u16", 24]
+            }
+          },
+          {
+            "name": "_padding6",
+            "type": {
+              "array": ["u8", 1]
+            }
+          },
+          {
+            "name": "pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "_padding7",
+            "docs": ["Padding to reach 776 bytes total (including discriminator)"],
+            "type": {
+              "array": ["u64", 5]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimalUser",
+      "docs": ["Minimal representation of Drift's User account", "Only includes the fields we actually need"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": ["The owner/authority of the account"],
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate",
+            "docs": ["An addresses that can control the account on the authority's behalf"],
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "docs": ["Encoded display name for the account"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "spot_positions",
+            "docs": ["The user's spot positions (8 positions)"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "SpotPosition"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "_padding1",
+            "docs": ["Skip to the fields we need at the end"],
+            "type": {
+              "array": ["u64", 256]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": ["u64", 128]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": ["u64", 64]
+            }
+          },
+          {
+            "name": "_padding4",
+            "type": {
+              "array": ["u64", 32]
+            }
+          },
+          {
+            "name": "_padding5",
+            "type": {
+              "array": ["u64", 8]
+            }
+          },
+          {
+            "name": "_padding6",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "_padding7",
+            "type": {
+              "array": ["u16", 1]
+            }
+          },
+          {
+            "name": "sub_account_id",
+            "docs": ["Sub account id for this user account"],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "UserStatus"
+              }
+            }
+          },
+          {
+            "name": "_padding8",
+            "type": {
+              "array": ["u8", 27]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleSetup",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "PythLegacy"
+          },
+          {
+            "name": "SwitchboardV2"
+          },
+          {
+            "name": "PythPushOracle"
+          },
+          {
+            "name": "SwitchboardPull"
+          },
+          {
+            "name": "StakedWithPythPush"
+          },
+          {
+            "name": "KaminoPythPush"
+          },
+          {
+            "name": "KaminoSwitchboardPull"
+          },
+          {
+            "name": "Fixed"
+          },
+          {
+            "name": "DriftPythPull"
+          },
+          {
+            "name": "DriftSwitchboardPull"
+          },
+          {
+            "name": "SolendPythPull"
+          },
+          {
+            "name": "SolendSwitchboardPull"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PanicState",
+      "docs": ["Panic state for emergency protocol pausing"],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pause_flags",
+            "docs": ["Whether the protocol is currently paused (1 = paused, 0 = not paused)"],
+            "type": "u8"
+          },
+          {
+            "name": "daily_pause_count",
+            "docs": ["Number of times paused today (resets every 24 hours)"],
+            "type": "u8"
+          },
+          {
+            "name": "consecutive_pause_count",
+            "docs": ["Number of consecutive pauses (resets when unpause happens)"],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "pause_start_timestamp",
+            "docs": [
+              "Timestamp when the current pause started (0 if not paused)",
+              "* When a pause is extended before expiring, this could be in the future."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_daily_reset_timestamp",
+            "docs": ["Timestamp of the last daily reset (for tracking daily pause count)"],
+            "type": "i64"
+          },
+          {
+            "name": "_reserved_space",
+            "docs": ["Reserved for future use (making total struct 32 bytes)"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PanicStateCache",
+      "docs": ["Cached panic state information for fast checking during user operations"],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pause_flags",
+            "docs": ["Whether the protocol is currently paused (1 = paused, 0 = not paused)"],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "pause_start_timestamp",
+            "docs": ["Timestamp when the current pause started (0 if not paused)"],
+            "type": "i64"
+          },
+          {
+            "name": "last_cache_update",
+            "docs": ["Timestamp when this cache was last updated"],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RatePoint",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "util",
+            "docs": [
+              "The utilization rate where `rate` applies",
+              "* a %, as u32, out of 100%, e.g. 50% = .5 * u32::MAX"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "rate",
+            "docs": ["The base rate that applies", "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RiskTier",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Isolated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolendConfigCompact",
+      "docs": [
+        "Used to configure Solend banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Solend banks cannot earn interest or be borrowed against."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_setup",
+            "docs": ["Either `SolendPythPull` or `SolendSwitchboardPull`"],
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "docs": ["Bank operational state - allows starting banks in paused state"],
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "risk_tier",
+            "docs": ["Risk tier - determines if assets can be borrowed in isolation"],
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "config_flags",
+            "docs": ["Config flags for future-proofing"],
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "oracle_max_confidence",
+            "docs": ["Oracle confidence threshold (0 = use default 10%)"],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolendMinimalReserve",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_update_slot",
+            "docs": ["Last slot when supply and rates updated"],
+            "type": "u64"
+          },
+          {
+            "name": "last_update_stale",
+            "docs": ["True when marked stale"],
+            "type": "u8"
+          },
+          {
+            "name": "lending_market",
+            "docs": ["Lending market address"],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_mint_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "liquidity_supply_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_pyth_oracle_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_switchboard_oracle_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_available_amount",
+            "type": "u64"
+          },
+          {
+            "name": "liquidity_borrowed_amount_wads",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "liquidity_cumulative_borrow_rate_wads",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "liquidity_market_price",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "collateral_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint_total_supply",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_supply_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_optimal_utilization_rate",
+            "type": "u8"
+          },
+          {
+            "name": "config_loan_to_value_ratio",
+            "type": "u8"
+          },
+          {
+            "name": "config_liquidation_bonus",
+            "type": "u8"
+          },
+          {
+            "name": "config_liquidation_threshold",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_to_fees_64",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "_padding_to_fees_6",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "liquidity_accumulated_protocol_fees_wads",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "_padding_final_128",
+            "type": {
+              "array": ["u8", 128]
+            }
+          },
+          {
+            "name": "_padding_final_64",
+            "type": {
+              "array": ["u8", 64]
+            }
+          },
+          {
+            "name": "_padding_final_32",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "_padding_final_6",
+            "type": {
+              "array": ["u8", 6]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotBalanceType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Borrow"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotPosition",
+      "docs": ["Minimal representation of a spot position within a User account"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaled_balance",
+            "docs": ["The scaled balance of the position.", "* Precision: SPOT_BALANCE_PRECISION"],
+            "type": "u64"
+          },
+          {
+            "name": "open_bids",
+            "docs": ["How many spot bids the user has open", "* Precision: token mint precision"],
+            "type": "i64"
+          },
+          {
+            "name": "open_asks",
+            "docs": ["How many spot asks the user has open", "* Precision: token mint precision"],
+            "type": "i64"
+          },
+          {
+            "name": "cumulative_deposits",
+            "docs": ["The cumulative deposits/borrows a user has made", "* Precision: token mint precision"],
+            "type": "i64"
+          },
+          {
+            "name": "market_index",
+            "docs": ["The market index of the corresponding spot market"],
+            "type": "u16"
+          },
+          {
+            "name": "balance_type",
+            "docs": ["Whether the position is deposit or borrow"],
+            "type": {
+              "defined": {
+                "name": "SpotBalanceType"
+              }
+            }
+          },
+          {
+            "name": "open_orders",
+            "docs": ["Number of open orders"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding"],
+            "type": {
+              "array": ["u8", 4]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakedSettings",
+      "docs": [
+        "Unique per-group. Staked Collateral banks created under a group automatically use these",
+        "settings. Groups that have not created this struct cannot create staked collateral banks. When",
+        "this struct updates, changes must be permissionlessly propogated to staked collateral banks.",
+        "Administrators can also edit the bank manually, i.e. with configure_bank, to temporarily make",
+        "changes such as raising the deposit limit for a single bank."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": ["This account's own key. A PDA derived from `marginfi_group` and `STAKED_SETTINGS_SEED`"],
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_group",
+            "docs": ["Group for which these settings apply"],
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle",
+            "docs": ["Generally, the Pyth push oracle for SOL"],
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "_reserved0",
+            "docs": [
+              "The following values are irrelevant because staked collateral positions do not support",
+              "borrowing."
+            ],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "_reserved2",
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakedSettingsConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "risk_tier",
+            "docs": [
+              "WARN: You almost certainly want \"Collateral\", using Isolated risk tier makes the asset",
+              "worthless as collateral, and is generally useful only when creating a staked collateral pool",
+              "for rewards purposes only."
+            ],
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakedSettingsEditConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracle_max_age",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "risk_tier",
+            "docs": [
+              "WARN: You almost certainly want \"Collateral\", using Isolated risk tier makes the asset",
+              "worthless as collateral, making all outstanding accounts eligible to be liquidated, and is",
+              "generally useful only when creating a staked collateral pool for rewards purposes only."
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RiskTier"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStatus",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "BeingLiquidated"
+          },
+          {
+            "name": "Bankrupt"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "AdvancedLp"
+          },
+          {
+            "name": "ProtectedMakerOrders"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawWindowCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "daily_limit",
+            "type": "u32"
+          },
+          {
+            "name": "withdrawn_today",
+            "type": "u32"
+          },
+          {
+            "name": "last_daily_reset_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WrappedI80F48",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "align": 8
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/marginfi/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/marginfi/mod.rs
@@ -1,0 +1,325 @@
+//! Marginfi preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionView, InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext,
+    VisualizerKind, format_arg_value,
+};
+use config::MarginfiConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const MARGINFI_PROGRAM_ID: &str = "MFv2hWf31Z9kbCa1snEPdcgp7X3GK4Y9EtyMkRxBUGA";
+
+const MARGINFI_DISPLAY_NAME: &str = "Marginfi";
+
+const MARGINFI_IDL_JSON: &str = include_str!("marginfi.json");
+
+static MARGINFI_CONFIG: MarginfiConfig = MarginfiConfig;
+
+pub struct MarginfiVisualizer;
+
+impl InstructionVisualizer for MarginfiVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let view = InstructionView::from_context(context);
+        let data = context.data();
+
+        let instruction_data_hex = hex::encode(data);
+        let fallback_text =
+            format!("Program ID: {}\nData: {instruction_data_hex}", view.program_id);
+
+        let parsed = parse_marginfi_instruction(data, &view.accounts);
+
+        let (title, condensed_fields, mut expanded_fields) = match parsed {
+            Ok(parsed) => build_parsed_fields(&parsed, &view.program_id)?,
+            Err(e) => {
+                tracing::warn!("Failed to parse Marginfi instruction with IDL: {e}");
+                build_fallback_fields(&view.program_id)?
+            }
+        };
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        expanded_fields.push(create_raw_data_field(data, Some(instruction_data_hex))?);
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_fields,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        let index = context.instruction_index() + 1;
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {index}"),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&MARGINFI_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Lending(MARGINFI_DISPLAY_NAME)
+    }
+}
+
+fn get_marginfi_idl() -> Option<&'static Idl> {
+    static IDL: OnceLock<Option<Idl>> = OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(MARGINFI_IDL_JSON).ok())
+        .as_ref()
+}
+
+fn parse_marginfi_instruction(
+    data: &[u8],
+    accounts: &[String],
+) -> Result<MarginfiParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_marginfi_idl().ok_or("Marginfi IDL not available")?;
+    let parsed = parse_instruction_with_idl(data, MARGINFI_PROGRAM_ID, idl)?;
+
+    let (named_accounts, extra_accounts) = build_named_accounts(data, idl, accounts);
+
+    Ok(MarginfiParsedInstruction {
+        parsed,
+        named_accounts,
+        extra_accounts,
+    })
+}
+
+fn build_named_accounts(
+    data: &[u8],
+    idl: &Idl,
+    accounts: &[String],
+) -> (BTreeMap<String, String>, Vec<String>) {
+    let mut named_accounts = BTreeMap::new();
+    let mut extra_accounts = Vec::new();
+
+    let idl_instruction = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.get(..disc.len()) == Some(disc.as_slice()))
+    });
+
+    if let Some(idl_instruction) = idl_instruction {
+        for (index, account_str) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_str.clone());
+            } else {
+                extra_accounts.push(account_str.clone());
+            }
+        }
+    }
+
+    (named_accounts, extra_accounts)
+}
+
+struct MarginfiParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: BTreeMap<String, String>,
+    extra_accounts: Vec<String>,
+}
+
+fn build_parsed_fields(
+    instruction: &MarginfiParsedInstruction,
+    program_id: &str,
+) -> Result<
+    (
+        String,
+        Vec<AnnotatedPayloadField>,
+        Vec<AnnotatedPayloadField>,
+    ),
+    VisualSignError,
+> {
+    let parsed = &instruction.parsed;
+    let instruction_name = &parsed.instruction_name;
+    let title = format!("{MARGINFI_DISPLAY_NAME}: {instruction_name}");
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    condensed_fields.push(create_text_field("Program", MARGINFI_DISPLAY_NAME)?);
+    condensed_fields.push(create_text_field("Instruction", instruction_name)?);
+    for (key, value) in &parsed.program_call_args {
+        condensed_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    expanded_fields.push(create_text_field("Program", MARGINFI_DISPLAY_NAME)?);
+    expanded_fields.push(create_text_field("Program ID", program_id)?);
+    expanded_fields.push(create_text_field("Instruction", instruction_name)?);
+    expanded_fields.push(create_text_field("Discriminator", &parsed.discriminator)?);
+
+    for (account_name, account_address) in &instruction.named_accounts {
+        expanded_fields.push(create_text_field(account_name, account_address)?);
+    }
+
+    for (index, pubkey) in instruction.extra_accounts.iter().enumerate() {
+        expanded_fields.push(create_text_field(
+            &format!("Remaining Account {}", index + 1),
+            pubkey,
+        )?);
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    Ok((title, condensed_fields, expanded_fields))
+}
+
+fn build_fallback_fields(
+    program_id: &str,
+) -> Result<
+    (
+        String,
+        Vec<AnnotatedPayloadField>,
+        Vec<AnnotatedPayloadField>,
+    ),
+    VisualSignError,
+> {
+    let title = format!("{MARGINFI_DISPLAY_NAME}: Unknown Instruction");
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    condensed_fields.push(create_text_field("Program", MARGINFI_DISPLAY_NAME)?);
+    condensed_fields.push(create_text_field("Status", "Unknown instruction type")?);
+
+    expanded_fields.push(create_text_field("Program", MARGINFI_DISPLAY_NAME)?);
+    expanded_fields.push(create_text_field("Program ID", program_id)?);
+    expanded_fields.push(create_text_field("Status", "Unknown instruction type")?);
+
+    Ok((title, condensed_fields, expanded_fields))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use solana_parser::IdlSource;
+
+    fn dummy_account_strings(n: usize) -> Vec<String> {
+        use solana_sdk::pubkey::Pubkey;
+        (0..n).map(|_| Pubkey::new_unique().to_string()).collect()
+    }
+
+    fn field_label_value(field: &AnnotatedPayloadField) -> (String, String) {
+        match &field.signable_payload_field {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                (common.label.clone(), text_v2.text.clone())
+            }
+            other => panic!("expected TextV2 field, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_marginfi_idl_loads() {
+        let idl = get_marginfi_idl();
+        assert!(idl.is_some(), "Marginfi IDL should load successfully");
+        assert!(!idl.unwrap().instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_marginfi_idl_has_discriminators() {
+        let idl = get_marginfi_idl().unwrap();
+        for ix in &idl.instructions {
+            let len = ix.discriminator.as_ref().map(Vec::len).unwrap_or(0);
+            assert_eq!(len, 8, "instruction {} missing 8-byte discriminator", ix.name);
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        let accounts = dummy_account_strings(0);
+        let result = parse_marginfi_instruction(&garbage_data, &accounts);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short_data = [0x01, 0x02, 0x03];
+        let accounts = dummy_account_strings(0);
+        let result = parse_marginfi_instruction(&short_data, &accounts);
+        assert!(result.is_err(), "Short data should return error");
+    }
+
+    #[test]
+    fn test_build_named_accounts_surfaces_extra_accounts() {
+        let idl = get_marginfi_idl().unwrap();
+        // Pick any IDL instruction with at least one named account
+        let ix = idl.instructions.first().expect("IDL has at least one instruction");
+        let disc = ix.discriminator.as_ref().expect("instruction has a discriminator").clone();
+        let n_named = ix.accounts.len();
+
+        // Provide n_named + 2 accounts to get 2 extras
+        let accounts = dummy_account_strings(n_named + 2);
+        let (named, extra) = build_named_accounts(&disc, idl, &accounts);
+
+        assert_eq!(named.len(), n_named, "first {n_named} accounts should be named");
+        assert_eq!(extra.len(), 2, "remaining 2 accounts should be extras");
+        assert_eq!(extra[0], accounts[n_named]);
+        assert_eq!(extra[1], accounts[n_named + 1]);
+    }
+
+    #[test]
+    fn test_remaining_account_label_is_human_readable() {
+        let pubkeys = dummy_account_strings(3);
+        let parsed = MarginfiParsedInstruction {
+            parsed: SolanaParsedInstructionData {
+                instruction_name: "test_ix".to_string(),
+                discriminator: "00".to_string(),
+                named_accounts: Default::default(),
+                program_call_args: serde_json::Map::new(),
+                idl_source: IdlSource::Custom,
+                idl_hash: String::new(),
+            },
+            named_accounts: BTreeMap::new(),
+            extra_accounts: pubkeys.clone(),
+        };
+        let (_title, _condensed, expanded) = build_parsed_fields(&parsed, "PROGRAM_ID").unwrap();
+        let entries: Vec<(String, String)> = expanded
+            .iter()
+            .map(field_label_value)
+            .filter(|(label, _)| label.starts_with("Remaining Account"))
+            .collect();
+        assert_eq!(
+            entries,
+            vec![
+                ("Remaining Account 1".to_string(), pubkeys[0].clone()),
+                ("Remaining Account 2".to_string(), pubkeys[1].clone()),
+                ("Remaining Account 3".to_string(), pubkeys[2].clone()),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Single, **additive** PR consolidating the `solana-add-idl` skill work (supersedes #401, closed into this).

- **`core::arg_rendering`** — adds `format_arg_value` (+ `charset_safe`, `bytes_as_hex`): a charset-safe, single-field-per-arg renderer (byte arrays -> `0x` hex). New presets import it from `crate::core`; existing presets are left untouched.
- **Marginfi preset** — new IDL-based preset, auto-registered via `build.rs`, as a live validation of the skill.
- **SKILL.md** — Sonnet-subagent dispatch (model enforced at the API layer) + compare mode; import `format_arg_value` from `crate::core`; bootstrap-only scope (scaffold a *new* preset, never regenerate an existing one); subtitle convention; surfpool live-fuzz validation; and an "Improving this skill" section with two non-destructive validation loops (corpus diff + model compare).

No existing preset is modified — clean on `main`.

## Test plan
- [x] `cargo clippy -p visualsign-solana --all-targets -- -D warnings`
- [x] `cargo clippy -p visualsign-solana --features diagnostics --all-targets -- -D warnings`
- [x] `cargo test -p visualsign-solana` — 270 passed
- [x] `cargo test -p visualsign-solana --features diagnostics`
- [ ] Add `surfpool` label to run live fuzz CI (incl. Marginfi)

Closes #397
