### PR TITLE
feat(tron): decode WithdrawBalanceContract (claim rewards)

### DIFF
--- a/src/chain_parsers/visualsign-tron/src/lib.rs
+++ b/src/chain_parsers/visualsign-tron/src/lib.rs
@@ -7,7 +7,8 @@ pub use cli_plugin::{TronArgs, TronPlugin};
 use anychain_tron::protocol::Tron::{Transaction as TronTransaction, transaction};
 use anychain_tron::protocol::balance_contract::{
     DelegateResourceContract, FreezeBalanceV2Contract, TransferContract,
-    UnDelegateResourceContract, UnfreezeBalanceV2Contract, WithdrawExpireUnfreezeContract,
+    UnDelegateResourceContract, UnfreezeBalanceV2Contract, WithdrawBalanceContract,
+    WithdrawExpireUnfreezeContract,
 };
 use anychain_tron::protocol::common::ResourceCode;
 use base64::{Engine as _, engine::general_purpose::STANDARD as b64};
@@ -302,6 +303,26 @@ fn decode_contract(
             fields.push(create_text_field(
                 "Contract Type",
                 "WithdrawExpireUnfreeze (Claim Unfrozen)",
+            )?);
+            fields.push(create_address_field(
+                "Owner",
+                &address_to_base58(&withdraw.owner_address),
+                None,
+                None,
+                None,
+                None,
+            )?);
+        }
+        "type.googleapis.com/protocol.WithdrawBalanceContract" => {
+            // Claims accumulated voting / Super Representative rewards to the owner's
+            // balance. The amount is computed by the chain at execution time, so the
+            // contract itself carries only the owner address.
+            let withdraw = WithdrawBalanceContract::parse_from_bytes(value).map_err(|e| {
+                VisualSignError::ConversionError(format!("decode WithdrawBalanceContract: {e}"))
+            })?;
+            fields.push(create_text_field(
+                "Contract Type",
+                "WithdrawBalance (Claim Rewards)",
             )?);
             fields.push(create_address_field(
                 "Owner",
@@ -812,6 +833,33 @@ mod tests {
             "WithdrawExpireUnfreeze (Claim Unfrozen)"
         );
         assert!(address_value(find_field(&payload, "Owner").unwrap()).starts_with('T'));
+    }
+
+    #[test]
+    fn synthetic_withdraw_balance() {
+        let inner = WithdrawBalanceContract {
+            owner_address: owner_bytes(),
+            ..Default::default()
+        };
+        let raw = build_raw_with_contract(
+            "type.googleapis.com/protocol.WithdrawBalanceContract",
+            inner.write_to_bytes().unwrap(),
+        );
+        let payload = TronVisualSignConverter
+            .to_visual_sign_payload(
+                TronTransactionWrapper::from_string(&encode_hex(&raw)).unwrap(),
+                VisualSignOptions::default(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            text_value(find_field(&payload, "Contract Type").unwrap()),
+            "WithdrawBalance (Claim Rewards)"
+        );
+        assert!(address_value(find_field(&payload, "Owner").unwrap()).starts_with('T'));
+        // No amount/resource fields — the reward amount is chain-computed, not in the tx.
+        assert!(find_field(&payload, "Amount").is_none());
+        assert!(find_field(&payload, "Resource").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds full decoding for Tron's `WithdrawBalanceContract` — the operation that claims accumulated voting / Super Representative rewards into the owner's balance. Previously this contract type fell through to the generic `(not fully decoded)` catch-all, showing the signer only the raw `type.googleapis.com/protocol.WithdrawBalanceContract` type URL.

## What it decodes

The contract carries only an `owner_address`; the reward amount is computed on-chain at execution time and is not part of the transaction. The payload now surfaces:

- `Contract Type: WithdrawBalance (Claim Rewards)`
- `Owner: <base58 address>`

This is distinct from the already-supported `WithdrawExpireUnfreeze` (claim *unfrozen TRX*).

## Implementation

- Added `WithdrawBalanceContract` to the `anychain_tron::protocol::balance_contract` import group.
- New match arm in `decode_contract()`, following the existing `WithdrawExpireUnfreeze` pattern.

## Testing

- `synthetic_withdraw_balance` — builds a transaction programmatically and asserts the contract type, owner field, and the absence of amount/resource fields.
- `cargo test -p visualsign-tron` — 23 passed
- `cargo clippy -p visualsign-tron --all-targets -- -D warnings` — clean
- `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)