### PR TITLE
fix(solana/spl_token): migrate to shared core::InstructionView, drop data clone

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/spl_token/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/spl_token/mod.rs
@@ -4,7 +4,7 @@
 mod config;
 
 use crate::core::{
-    AccountRef, InstructionVisualizer, ProgramRef, SolanaIntegrationConfig, VisualizerContext,
+    InstructionView, InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext,
     VisualizerKind,
 };
 use config::SplTokenConfig;
@@ -33,7 +33,7 @@ impl InstructionVisualizer for SplTokenVisualizer {
         // (including attacker-controlled input) degrade to a raw program_id +
         // data layout instead of returning `Err`, which the non-diagnostics
         // dispatch turns into a whole-transaction failure.
-        match TokenInstruction::unpack(&instruction.data) {
+        match TokenInstruction::unpack(context.data()) {
             Ok(token_instruction) => {
                 create_token_preview_layout(&token_instruction, &instruction, context)
             }
@@ -47,44 +47,6 @@ impl InstructionVisualizer for SplTokenVisualizer {
 
     fn kind(&self) -> VisualizerKind {
         VisualizerKind::Payments("SplToken")
-    }
-}
-
-/// A display-resolved view of the instruction built from the post-#228
-/// wire-data context.
-///
-/// The per-variant branches reference `instruction.program_id` /
-/// `instruction.accounts` / `instruction.data`; this builds that view at the
-/// entry point with every program and account index already resolved to a
-/// display string. Following the catch-all "partial rendering" contract
-/// documented on `VisualizerContext`, indices that need an address-table lookup
-/// (v0 transactions) render as `unresolved(N)` placeholders rather than aborting
-/// the whole transaction or being substituted with `Pubkey::default()` (which
-/// would render as a valid-looking address).
-struct InstructionView {
-    program_id: String,
-    accounts: Vec<String>,
-    data: Vec<u8>,
-}
-
-impl InstructionView {
-    fn from_context(context: &VisualizerContext) -> Self {
-        let program_id = match context.program_id() {
-            ProgramRef::Resolved(pk) => pk.to_string(),
-            ProgramRef::Unresolved { raw_index } => format!("unresolved({raw_index})"),
-        };
-        let accounts = (0..context.num_accounts())
-            .map(|i| match context.account(i) {
-                Some(AccountRef::Resolved(pk)) => pk.to_string(),
-                Some(AccountRef::Unresolved { raw_index }) => format!("unresolved({raw_index})"),
-                None => "unknown".to_string(),
-            })
-            .collect();
-        Self {
-            program_id,
-            accounts,
-            data: context.data().to_vec(),
-        }
     }
 }
 
@@ -106,7 +68,7 @@ fn create_unparsable_preview_layout(
         create_text_field("Instruction", title)?,
         create_text_field("Program", "SPL Token")?,
         create_text_field("Program ID", &instruction.program_id)?,
-        create_text_field("Raw Data", &hex::encode(&instruction.data))?,
+        create_text_field("Raw Data", &hex::encode(context.data()))?,
     ];
 
     create_preview_layout_field(
@@ -162,10 +124,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("mintAuthority", authority)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -200,10 +159,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("mintAuthority", authority)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -240,10 +196,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Current Authority", current_authority)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -284,10 +237,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -325,10 +275,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -362,10 +309,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -400,10 +344,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -441,10 +382,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -482,10 +420,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             let expanded_fields = expanded_fields;
 
@@ -519,10 +454,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Token Mint", mint)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -554,10 +486,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Token Mint", mint)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -588,10 +517,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -621,10 +547,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Token Mint", mint)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -653,10 +576,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Token Mint", mint)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -687,10 +607,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Freeze Authority", authority)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -721,10 +638,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Freeze Authority", authority)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -759,10 +673,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -793,10 +704,7 @@ fn create_token_preview_layout(
                 expanded_fields.push(create_text_field("Owner", owner)?);
             }
 
-            expanded_fields.push(create_text_field(
-                "Raw Data",
-                &hex::encode(&instruction.data),
-            )?);
+            expanded_fields.push(create_text_field("Raw Data", &hex::encode(context.data()))?);
 
             create_preview_layout_field(
                 instruction_name,
@@ -822,7 +730,7 @@ fn create_token_preview_layout(
                 create_text_field("Instruction", &instruction_name)?,
                 create_text_field("Program", "SPL Token")?,
                 create_text_field("Program ID", &instruction.program_id)?,
-                create_text_field("Raw Data", &hex::encode(&instruction.data))?,
+                create_text_field("Raw Data", &hex::encode(context.data()))?,
             ];
 
             create_preview_layout_field(
@@ -870,7 +778,7 @@ fn create_preview_layout_field(
                 fallback_text: format!(
                     "Program ID: {}\nData: {}",
                     instruction.program_id,
-                    hex::encode(&instruction.data)
+                    hex::encode(context.data())
                 ),
             },
             preview_layout,


### PR DESCRIPTION
## Summary

- Removes the private `InstructionView` struct from `spl_token/mod.rs` that clones `context.data().to_vec()` into a `Vec<u8>` on every instruction — a per-instruction heap allocation with no architectural justification.
- Switches to the shared `crate::core::InstructionView` for program ID and account resolution.
- Accesses instruction bytes via `context.data()` directly (a zero-copy borrow), consistent with all other presets in the codebase.
- Fixes the stale `None => "unknown"` fallback arm (now `"unresolved(oob:N)"` matching the canonical form in `core::InstructionView`).

Closes #380

## Test plan

- [x] `cargo test -p visualsign-solana` — 328 passed, 0 failed, 3 ignored
- [x] `make -C src lint` — clippy clean with `-D warnings`
- [x] `cargo fmt --all -- --check` — clean
- [x] Diff is mechanical: import change, struct deletion, `&instruction.data` -> `context.data()` substitutions, and the rustfmt reflow those substitutions imply (the shorter argument lets 17 `create_text_field("Raw Data", ...)` calls fit on one line)

## Note on formatting coverage

The rustfmt reflow above is invisible to CI. `presets/mod.rs` declares preset modules through `include!(concat!(env!("OUT_DIR"), "/generated_presets_mod.rs"))`, so rustfmt cannot traverse into `presets/*/` — `cargo fmt --all` formats `presets/mod.rs` and nothing beneath it. The whole preset tree is therefore unformatted as far as the `make generated` + clean-tree gate is concerned. Worth a follow-up issue; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
