### PR TITLE
refactor(solana): rename drift tests to reflect happy-path-only coverage

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/drift/mod.rs
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_fallback_fields_returns_result() {
+    fn test_build_fallback_fields_renders_unknown_instruction() {
         let (title, condensed, expanded) =
             build_fallback_fields(DRIFT_PROGRAM_ID).unwrap();
         assert_eq!(title, "Drift: Unknown Instruction");
@@ -258,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_parsed_fields_returns_result() {
+    fn test_build_parsed_fields_renders_deposit_instruction() {
         let instruction = make_parsed_instruction("deposit");
         let (title, condensed, expanded) =
             build_parsed_fields(&instruction, DRIFT_PROGRAM_ID)
@@ -269,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn test_append_raw_data_returns_result() {
+    fn test_append_raw_data_appends_one_field() {
         let data = &[0x01u8, 0x02, 0x03];
         let hex_str = hex::encode(data);
         let fields = append_raw_data(vec![], data, &hex_str).unwrap();


### PR DESCRIPTION
## Summary

- Addresses prasanna's review nit on PR #372: the three test names `test_build_fallback_fields_returns_result`, `test_build_parsed_fields_returns_result`, and `test_append_raw_data_returns_result` oversold what they verify
- Renamed to `test_build_fallback_fields_renders_unknown_instruction`, `test_build_parsed_fields_renders_deposit_instruction`, and `test_append_raw_data_appends_one_field` to make clear these are happy-path render guards, not error-propagation tests
- The field builders these helpers call (`create_text_field`, `create_raw_data_field`) are currently infallible, so error paths cannot be exercised

Stacked on #372.

## Test plan

- [x] `cargo test -p visualsign-solana` passes — all three renamed tests run under `presets::drift::tests`
- [x] `cargo clippy -p visualsign-solana --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)