### PR TITLE
test(solana): gate that IDL presets surface the instruction discriminator

### DIFF
--- a/.claude/skills/solana-add-idl/SKILL.md
+++ b/.claude/skills/solana-add-idl/SKILL.md
@@ -96,7 +96,7 @@ Read that file for the exact structure, then generate a generic version with the
 - Keep the `kind()` method returning the user's chosen `VisualizerKind` variant with `display_name` as the `&'static str` argument
 
 **Generic IDL pattern only:**
-- The generic scaffold uses the three helpers `dflow_aggregator` defines: `build_named_accounts`, `build_parsed_fields`, and `build_fallback_fields`. All three work with any IDL.
+- The generic scaffold uses the three helpers a preset defines: `build_named_accounts`, `build_parsed_fields`, and `build_fallback_fields`. All three work with any IDL.
 - Two additional helpers — `append_raw_data` (for byte-blob args) and `format_arg_value` (for custom scalar rendering) — are not present in `dflow_aggregator`. Add them when the target IDL needs them, copying the pattern from another preset such as `kamino_vault` or `jupiter_earn`.
 - The parse function should: check `data.len() < 8`, load IDL, call `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with parsed data + named accounts
 
@@ -111,6 +111,18 @@ These three accessors replace the old `context.current_instruction()`. They surf
 unresolved indices as `Err(VisualSignError::DecodeError(...))` with the bad index
 named, instead of returning a generic "no instruction found" failure. Use
 `context.instruction_index()` for any "Instruction N" labels.
+
+**Surface the discriminator (required convention).** `build_parsed_fields` must
+include the instruction discriminator in the expanded view:
+```rust
+expanded_fields.push(create_text_field("Discriminator", &parsed.discriminator)?);
+```
+Every Anchor/IDL Solana preset does this, and it is enforced by
+`chain_parsers/visualsign-solana/tests/preset_conventions.rs`, which scans
+`presets/*/mod.rs` for a `"Discriminator"` field. A new preset that omits it
+fails CI. Only native programs without an Anchor discriminator are exempt (via
+that test's `DISCRIMINATOR_ALLOWLIST`); an IDL preset should never be added to
+that allowlist.
 
 **Required imports** (at top of module, NOT inside functions):
 ```rust
@@ -174,3 +186,7 @@ make -C src test
 All must pass before the task is complete. Both feature configurations
 (diagnostics on and off) need to compile and test cleanly because parser_app
 builds without `diagnostics` while parser_cli builds with it.
+
+`cargo test -p visualsign-solana` includes the `preset_conventions` gate — if it
+reports your preset under "must surface a Discriminator field", add the
+`create_text_field("Discriminator", ...)` line above rather than allowlisting it.

--- a/src/chain_parsers/visualsign-solana/tests/preset_conventions.rs
+++ b/src/chain_parsers/visualsign-solana/tests/preset_conventions.rs
@@ -1,0 +1,76 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+//! Convention gate for Solana program visualizers.
+//!
+//! Every Anchor/IDL preset is expected to surface the instruction discriminator
+//! as a `create_text_field("Discriminator", ...)` in its expanded view, matching
+//! the established Solana program-visualization convention (drift, kamino_*,
+//! meteora_*, metadao_*, jupiter_{perps,earn,borrow}, exponent_finance,
+//! onre_app, neutral_trade, squads_multisig, swig_wallet, dflow_aggregator, ...).
+//!
+//! This is a source-level gate: it scans `src/presets/*/mod.rs` so any FUTURE
+//! preset is held to the convention automatically. Presets that legitimately do
+//! not have an Anchor discriminator (native programs) are allowlisted, as are a
+//! small number of grandfathered Anchor presets pending their own tickets.
+
+use std::fs;
+use std::path::Path;
+
+/// Presets exempt from the discriminator convention.
+const DISCRIMINATOR_ALLOWLIST: &[&str] = &[
+    // Native programs: no Anchor 8-byte discriminator (1-byte/native tags).
+    "associated_token_account",
+    "compute_budget",
+    "spl_token",
+    "stakepool",
+    "system",
+    "token_2022",
+    // Grandfathered Anchor presets that don't yet surface a Discriminator field.
+    // Tracked to be brought into line (see tickets); remove from this list then.
+    "jupiter_swap",
+    "orca_whirlpool",
+];
+
+#[test]
+fn all_idl_presets_surface_discriminator() {
+    let presets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/presets");
+    let mut missing: Vec<String> = Vec::new();
+
+    for entry in fs::read_dir(&presets_dir).expect("read presets dir") {
+        let entry = entry.expect("dir entry");
+        if !entry.file_type().expect("file type").is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if DISCRIMINATOR_ALLOWLIST.contains(&name.as_str()) {
+            continue;
+        }
+        let mod_rs = entry.path().join("mod.rs");
+        if !mod_rs.exists() {
+            continue;
+        }
+        let source = fs::read_to_string(&mod_rs).expect("read preset mod.rs");
+        if !source.contains("\"Discriminator\"") {
+            missing.push(name);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "these Solana presets must surface a \"Discriminator\" field \
+         (create_text_field(\"Discriminator\", ...)) per convention, or be added to \
+         DISCRIMINATOR_ALLOWLIST with a ticket: {missing:?}"
+    );
+}
+
+#[test]
+fn discriminator_allowlist_entries_still_exist() {
+    // Keep the allowlist honest: every entry must name a real preset directory,
+    // so stale exemptions don't silently linger after a preset is renamed/removed.
+    let presets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/presets");
+    for name in DISCRIMINATOR_ALLOWLIST {
+        assert!(
+            presets_dir.join(name).join("mod.rs").exists(),
+            "allowlisted preset '{name}' no longer exists; remove it from DISCRIMINATOR_ALLOWLIST"
+        );
+    }
+}


### PR DESCRIPTION
## What
A convention gate so all current and future Solana program visualizers surface the instruction discriminator (`create_text_field("Discriminator", ...)`) in their expanded view — the established pattern across drift, kamino_*, meteora_*, metadao_*, jupiter_{perps,earn,borrow}, exponent_finance, onre_app, neutral_trade, squads_multisig, swig_wallet, dflow_aggregator.

- `chain_parsers/visualsign-solana/tests/preset_conventions.rs` scans `presets/*/mod.rs` and fails if a preset omits a `"Discriminator"` field, except an explicit `DISCRIMINATOR_ALLOWLIST`: native programs without an Anchor discriminator (associated_token_account, compute_budget, spl_token, stakepool, system, token_2022) plus two grandfathered Anchor presets (jupiter_swap, orca_whirlpool, tracked by #389). A second test keeps the allowlist from going stale. The gate auto-covers any future preset directory.
- `solana-add-idl` skill: documents the discriminator requirement + the gate (and the Step-6 check).

## Tests
`cargo test -p visualsign-solana` (incl. the new `--test preset_conventions`), `clippy --all-targets -D warnings`, `cargo fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)