### PR TITLE
feat(visualsign): Anchorage wallet render-support validator

### DIFF
--- a/docs/specs/anchorage-wallet-render-rules.md
+++ b/docs/specs/anchorage-wallet-render-rules.md
@@ -33,10 +33,10 @@ other string decodes to unknown → unsupported.
 | `delta`          | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
 | `highlight`      | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
 | `rule`           | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
-| `preview_layout` | yes      | container  | requires both `Condensed`/`Expanded` on the wire, and every descendant to render |
+| `preview_layout` | yes      | container  | every descendant must render                       |
 | `accordion`      | wallet-only | container | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
 | `list_layout`    | **structural only** | — | valid only as a container's `Condensed`/`Expanded`; **never as a field entry** |
-| `number`         | **no**   | —          | not a VSP type → use `amount_v2`                   |
+| `number`         | yes, as `amount_v2` | leaf | not a VSP type on its own; the in-memory `Number` variant serializes to `amount_v2` on the wire (see #393), so it renders fine |
 | `text` (v1)      | **no**   | —          | superseded by `text_v2`                            |
 | `address` (v1)   | **no**   | —          | superseded by `address_v2`                         |
 | `amount` (v1)    | **no**   | —          | superseded by `amount_v2`                          |
@@ -64,19 +64,20 @@ when a parser field variant starts emitting it.
    containing unsupported nested fields. Nesting of supported leaves is unlimited in
    depth; nesting via `preview_layout` is the supported way to express hierarchy.
 
-3. **`preview_layout` requires both `Condensed` and `Expanded` on the wire.**
-   The wallet's model has no optional case for either list; a missing key fails
-   to decode and the whole container falls back to plain text. The validator
-   checks the actual serialized output rather than the in-memory value, since a
-   builder leaving a list unset and the serializer's choice of how to represent
-   that (omit the key vs. default to an empty list) are independent concerns.
-   `create_preview_layout` always leaves `Condensed` unset today, and several
-   Ethereum visualizers (e.g. the ERC-20 `Transfer` preview) leave `Expanded`
-   unset too, so this is a live parser output shape, not a hypothetical one.
+3. **`preview_layout` always carries both `Condensed` and `Expanded` on the
+   wire.** The `SignablePayloadFieldPreviewLayout` serializer emits an empty
+   list for whichever is unset (see #403), so the wallet's decoder always
+   receives both — there is no missing-list failure mode for the validator to
+   catch. `create_preview_layout` always leaves `Condensed` unset in memory,
+   and several Ethereum visualizers (e.g. the ERC-20 `Transfer` preview) leave
+   `Expanded` unset too; both cases render clean.
 
-4. **Numeric values use `amount_v2`, never `number`.** `number` is a legacy
-   parser-only variant that the wallet never recognized; render numbers (token
-   amounts, slippage bps, fees, compute units) as `amount_v2`.
+4. **`number` fields render fine, via `amount_v2` on the wire.** VSP has no
+   `number` type; the in-memory `Number` variant is serialized to `amount_v2`
+   (see #393), so it is not flagged as unsupported. New code should still
+   prefer building `amount_v2` fields directly (via `create_amount_field`)
+   rather than `create_number_field`, since the remap is a compatibility
+   shim, not the primary path.
 
 ## Validator
 
@@ -95,8 +96,6 @@ when a parser field variant starts emitting it.
   since a variant can be remapped to a different wire representation.
 - `ListLayoutAsStandaloneField` — `list_layout` used as a field entry.
 - `ContainsUnsupportedNestedFields` — a container with an unsupported descendant.
-- `MissingRequiredList` — a `preview_layout` missing `Condensed` or `Expanded`
-  on the wire.
 
 Ad-hoc check of a payload JSON:
 
@@ -107,8 +106,7 @@ cargo run -p visualsign --features diagnostics \
 
 ## Known parser violations (as of this writing)
 
-`create_number_field` emits the unsupported `number` type, used by the
-`compute_budget`, `system`, `token_2022`, and `jupiter_swap` presets. Payloads
-containing those instructions carry unrenderable fields today (e.g. a DFlow swap
-transaction's leading ComputeBudget instructions). Migrating those call sites to
-`amount_v2` is tracked separately.
+None. `create_number_field` (used by the `compute_budget`, `system`,
+`token_2022`, and `jupiter_swap` presets) previously emitted the unrenderable
+`number` type; #393 made the `Number` variant serialize as `amount_v2` on the
+wire, so those call sites render fine without needing a migration.

--- a/docs/specs/anchorage-wallet-render-rules.md
+++ b/docs/specs/anchorage-wallet-render-rules.md
@@ -1,0 +1,114 @@
+# Anchorage Wallet Render Validation Rules
+
+Status: draft · Owner: parser team
+
+## Purpose
+
+The parser's output is consumed by the **Anchorage wallet**, whose Visual
+Signing Protocol engine renders each `SignablePayload` field according to a
+fixed support matrix. Any field the wallet does not recognize is surfaced to the
+user as an **unsupported field** (and nested containers are flagged as
+containing unsupported nested fields). Because VSP is WYSIWYS ("what you see is what
+you sign"), an unrenderable field is a **correctness bug**, not a cosmetic one.
+
+These rules let the parser validate its own output against the wallet's support
+matrix *before* shipping, the same way `validate_charset` guards the character
+set.
+
+Source of truth: the Anchorage wallet's Visual Signing Protocol engine (its
+field-type decoder, preview-layout and accordion parsing, and field-diagnostic
+model). Mirror this spec to the wallet whenever that engine changes.
+
+## Field support matrix
+
+The wallet's field-type decoder recognizes exactly these `Type` strings; every
+other string decodes to unknown → unsupported.
+
+| `Type`           | Renders? | Kind       | Notes                                              |
+|------------------|----------|------------|----------------------------------------------------|
+| `text_v2`        | yes      | leaf       |                                                    |
+| `address_v2`     | yes      | leaf       |                                                    |
+| `amount_v2`      | yes      | leaf       | **use this for numeric values** (amounts, bps, fees) |
+| `diagnostic`     | yes      | leaf       | data-quality surfacing; never omitted (WYSIWYS)    |
+| `delta`          | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
+| `highlight`      | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
+| `rule`           | wallet-only | leaf    | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
+| `preview_layout` | yes      | container  | requires both `Condensed`/`Expanded` on the wire, and every descendant to render |
+| `accordion`      | wallet-only | container | wallet renders it, but **not in the validator's allowed set** (parser emits none; no plans) |
+| `list_layout`    | **structural only** | — | valid only as a container's `Condensed`/`Expanded`; **never as a field entry** |
+| `number`         | **no**   | —          | not a VSP type → use `amount_v2`                   |
+| `text` (v1)      | **no**   | —          | superseded by `text_v2`                            |
+| `address` (v1)   | **no**   | —          | superseded by `address_v2`                         |
+| `amount` (v1)    | **no**   | —          | superseded by `amount_v2`                          |
+| `divider`        | **no**   | —          | not in the wallet decoder                          |
+| `unknown`        | **no**   | —          | explicit fallback / unsupported                    |
+
+The validator's allowed leaf set is intentionally narrower than the wallet's
+decoder: only the `yes` rows (`text_v2`, `address_v2`, `amount_v2`, `diagnostic`,
+plus the `preview_layout` container). The `wallet-only` types render in the wallet
+but the parser has no field variant that emits them and no plans to add one, so a
+payload using one is flagged. Promote a `wallet-only` row to the allowed set only
+when a parser field variant starts emitting it.
+
+## Structural rules
+
+1. **`list_layout` is not a field type.** The wallet decodes `list_layout` only
+   as the `Condensed`/`Expanded` list inside a `preview_layout`, or the
+   `Condensed`/`Expanded` of an `accordion` section. A `list_layout` appearing as
+   an entry in a `Fields` array is unrenderable. **To nest a group, wrap it in a
+   `preview_layout`** (title + condensed + expanded), not a bare `list_layout`.
+
+2. **Containers propagate unsupported-ness.** A `preview_layout` (or `accordion`)
+   is rendered only if *every* descendant in its `Condensed`/`Expanded` lists is
+   renderable. A single unsupported descendant flags the whole container as
+   containing unsupported nested fields. Nesting of supported leaves is unlimited in
+   depth; nesting via `preview_layout` is the supported way to express hierarchy.
+
+3. **`preview_layout` requires both `Condensed` and `Expanded` on the wire.**
+   The wallet's model has no optional case for either list; a missing key fails
+   to decode and the whole container falls back to plain text. The validator
+   checks the actual serialized output rather than the in-memory value, since a
+   builder leaving a list unset and the serializer's choice of how to represent
+   that (omit the key vs. default to an empty list) are independent concerns.
+   `create_preview_layout` always leaves `Condensed` unset today, and several
+   Ethereum visualizers (e.g. the ERC-20 `Transfer` preview) leave `Expanded`
+   unset too, so this is a live parser output shape, not a hypothetical one.
+
+4. **Numeric values use `amount_v2`, never `number`.** `number` is a legacy
+   parser-only variant that the wallet never recognized; render numbers (token
+   amounts, slippage bps, fees, compute units) as `amount_v2`.
+
+## Validator
+
+`visualsign::SignablePayload` exposes:
+
+- `anchorage_render_findings() -> Vec<AnchorageRenderFinding>` — every
+  unrenderable field, each with a JSON-ish `path` (e.g.
+  `Fields[2].Expanded.Fields[1]`), `label`, `field_type`, and `reason`.
+- `validate_anchorage_wallet_renderable() -> Result<(), VisualSignError>` — a
+  hard gate that errors (listing offending paths) if any field is unrenderable.
+
+`reason` mirrors the wallet's `UnsupportedReason`:
+
+- `UnsupportedFieldType` — type not in the renderable set. Checked against the
+  wire `Type` the field actually serializes to, not the in-memory variant name,
+  since a variant can be remapped to a different wire representation.
+- `ListLayoutAsStandaloneField` — `list_layout` used as a field entry.
+- `ContainsUnsupportedNestedFields` — a container with an unsupported descendant.
+- `MissingRequiredList` — a `preview_layout` missing `Condensed` or `Expanded`
+  on the wire.
+
+Ad-hoc check of a payload JSON:
+
+```bash
+cargo run -p visualsign --features diagnostics \
+  --example check_anchorage_render -- path/to/payload.json
+```
+
+## Known parser violations (as of this writing)
+
+`create_number_field` emits the unsupported `number` type, used by the
+`compute_budget`, `system`, `token_2022`, and `jupiter_swap` presets. Payloads
+containing those instructions carry unrenderable fields today (e.g. a DFlow swap
+transaction's leading ComputeBudget instructions). Migrating those call sites to
+`amount_v2` is tracked separately.

--- a/src/visualsign/examples/check_anchorage_render.rs
+++ b/src/visualsign/examples/check_anchorage_render.rs
@@ -1,0 +1,37 @@
+//! Report the fields an Anchorage wallet cannot render in a SignablePayload JSON.
+//!
+//! Usage:
+//!   cargo run -p visualsign --features diagnostics \
+//!     --example check_anchorage_render -- <payload.json>
+
+use std::fs;
+
+use visualsign::SignablePayload;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or("usage: check_anchorage_render <payload.json>")?;
+    let json = fs::read_to_string(&path)?;
+    let payload: SignablePayload = serde_json::from_str(&json).map_err(|e| {
+        format!(
+            "failed to parse {path} as a SignablePayload: {e}\n\
+             hint: a \"diagnostic\" field requires rebuilding with `--features diagnostics`"
+        )
+    })?;
+
+    let findings = payload.anchorage_render_findings();
+    if findings.is_empty() {
+        println!("{path}: CLEAN (0 unrenderable fields)");
+        return Ok(());
+    }
+
+    println!("{path}: {} unrenderable field(s):", findings.len());
+    for f in &findings {
+        println!(
+            "  - {} [{}] \"{}\" -> {:?}",
+            f.path, f.field_type, f.label, f.reason
+        );
+    }
+    Ok(())
+}

--- a/src/visualsign/src/anchorage_render.rs
+++ b/src/visualsign/src/anchorage_render.rs
@@ -14,11 +14,11 @@
 //! |------------------|--------------------|-----------------------------------------|
 //! | `text_v2`        | yes                |                                         |
 //! | `address_v2`     | yes                |                                         |
-//! | `amount_v2`      | yes                | use this for numeric values, NOT number |
+//! | `amount_v2`      | yes                | use this for numeric values             |
 //! | `diagnostic`     | yes                |                                         |
-//! | `preview_layout` | yes (container)    | needs both Condensed/Expanded lists on the wire, and every descendant to render |
+//! | `preview_layout` | yes (container)    | every descendant must render            |
 //! | `list_layout`    | only as a container| INVALID as a standalone field entry     |
-//! | `number`         | no                 | not a VSP type; use `amount_v2`         |
+//! | `number`         | yes (as `amount_v2`)| the in-memory `Number` variant serializes to `amount_v2` on the wire (VSP has no `number` type), so it renders fine |
 //! | `text` (v1)      | no                 | superseded by `text_v2`                 |
 //! | `address` (v1)   | no                 | superseded by `address_v2`              |
 //! | `amount` (v1)    | no                 | superseded by `amount_v2`               |
@@ -37,6 +37,13 @@
 //! `Expanded` list inside a `preview_layout` (or `accordion` section), never via
 //! the field-type decoder. So a `list_layout` appearing as an entry in a `Fields`
 //! array is unrenderable — to nest, wrap the group in a `preview_layout`.
+//!
+//! `preview_layout` always carries both a `Condensed` and an `Expanded` list on
+//! the wire: the `SignablePayloadFieldPreviewLayout` serializer emits an empty
+//! list for whichever is unset, so the wallet's decoder always sees both and
+//! there is no missing-list failure mode for this validator to catch. The check
+//! recurses into whichever lists are present so an unsupported descendant still
+//! marks the container.
 
 use crate::errors::VisualSignError;
 use crate::{FieldSerializer, SignablePayload, SignablePayloadField};
@@ -50,8 +57,8 @@ pub const ANCHORAGE_RENDERABLE_LEAF_TYPES: &[&str] =
 /// unsupported-reason diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AnchorageUnsupportedReason {
-    /// The field's `Type` is not in the wallet's renderable set (e.g. `number`,
-    /// legacy `text`/`address`/`amount`, `divider`, `unknown`).
+    /// The field's `Type` is not in the wallet's renderable set (e.g. legacy
+    /// `text`/`address`/`amount`, `divider`, `unknown`).
     UnsupportedFieldType,
     /// `list_layout` appears as a standalone field entry. It is only valid as
     /// the `Condensed`/`Expanded` container of a `preview_layout`/`accordion`.
@@ -60,10 +67,6 @@ pub enum AnchorageUnsupportedReason {
     /// more unsupported descendants. Mirrors the wallet's
     /// contains-unsupported-nested-fields flag.
     ContainsUnsupportedNestedFields,
-    /// A `preview_layout` container is missing its `Condensed` or `Expanded`
-    /// list on the wire. The wallet's model requires both; a missing list
-    /// fails to decode and the whole container falls back to plain text.
-    MissingRequiredList,
 }
 
 impl AnchorageUnsupportedReason {
@@ -72,7 +75,6 @@ impl AnchorageUnsupportedReason {
             Self::UnsupportedFieldType => "unsupported field type",
             Self::ListLayoutAsStandaloneField => "list_layout used as a standalone field",
             Self::ContainsUnsupportedNestedFields => "contains unsupported nested fields",
-            Self::MissingRequiredList => "missing required Condensed/Expanded list",
         }
     }
 }
@@ -125,17 +127,12 @@ fn check_field(
     out: &mut Vec<AnchorageRenderFinding>,
 ) -> bool {
     match field {
-        // Container: supported iff both lists are present on the wire and
-        // every descendant is.
+        // Container: supported iff every descendant renders. The
+        // `SignablePayloadFieldPreviewLayout` serializer always emits both the
+        // `Condensed` and `Expanded` lists (an empty list for whichever is
+        // unset), so the wallet's decoder always receives both and there is no
+        // missing-list failure mode to flag here.
         SignablePayloadField::PreviewLayout { preview_layout, .. } => {
-            // The wallet's PreviewLayout model requires both `Condensed` and
-            // `Expanded`. Check the actual wire output rather than the
-            // in-memory `Option`s: whether a `None` list is omitted or
-            // defaulted on the wire is a serialization-layer decision
-            // independent of this check, and this stays correct either way.
-            let missing_list = !wire_has_key(field, "PreviewLayout", "Condensed")
-                || !wire_has_key(field, "PreviewLayout", "Expanded");
-
             let mut descendants_ok = true;
             if let Some(condensed) = &preview_layout.condensed {
                 for (index, child) in condensed.fields.iter().enumerate() {
@@ -158,20 +155,14 @@ fn check_field(
                 }
             }
 
-            if missing_list {
-                out.push(finding(
-                    path,
-                    field,
-                    AnchorageUnsupportedReason::MissingRequiredList,
-                ));
-            } else if !descendants_ok {
+            if !descendants_ok {
                 out.push(finding(
                     path,
                     field,
                     AnchorageUnsupportedReason::ContainsUnsupportedNestedFields,
                 ));
             }
-            !missing_list && descendants_ok
+            descendants_ok
         }
         // `list_layout` is never a valid standalone field.
         SignablePayloadField::ListLayout { .. } => {
@@ -216,17 +207,6 @@ fn wire_type(field: &SignablePayloadField) -> String {
         .unwrap_or_else(|| field.field_type().to_string())
 }
 
-/// Whether `field`'s wire serialization of its `container_key` object
-/// actually includes `inner_key`.
-fn wire_has_key(field: &SignablePayloadField, container_key: &str, inner_key: &str) -> bool {
-    let Ok(map) = field.serialize_to_map() else {
-        return false;
-    };
-    map.get(container_key)
-        .and_then(|value| value.get(inner_key))
-        .is_some()
-}
-
 fn finding(
     path: &str,
     field: &SignablePayloadField,
@@ -246,7 +226,8 @@ mod tests {
     use super::*;
     use crate::field_builders::{create_amount_field, create_number_field, create_text_field};
     use crate::{
-        AnnotatedPayloadField, SignablePayloadFieldCommon, SignablePayloadFieldListLayout,
+        AnnotatedPayloadField, DividerStyle, SignablePayloadFieldCommon,
+        SignablePayloadFieldDivider, SignablePayloadFieldListLayout,
         SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
     };
 
@@ -282,6 +263,26 @@ mod tests {
                     fallback_text: label.to_string(),
                 },
                 list_layout: SignablePayloadFieldListLayout { fields: vec![] },
+            },
+        }
+    }
+
+    /// A genuinely unsupported leaf: `divider` is not in the wallet's renderable
+    /// set and (unlike `number`) is not remapped to a renderable type on the
+    /// wire, so it stays a stable "unsupported" example across serializer
+    /// remaps such as #393 (`number` -> `amount_v2`).
+    fn divider(label: &str) -> AnnotatedPayloadField {
+        AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::Divider {
+                common: SignablePayloadFieldCommon {
+                    label: label.to_string(),
+                    fallback_text: label.to_string(),
+                },
+                divider: SignablePayloadFieldDivider {
+                    style: DividerStyle::THIN,
+                },
             },
         }
     }
@@ -331,17 +332,17 @@ mod tests {
     }
 
     #[test]
-    fn number_field_is_unsupported() {
+    fn number_field_renders_as_amount_v2_on_the_wire() {
+        // The in-memory `Number` variant serializes to `amount_v2` on the wire
+        // (VSP has no `number` type; see #393), so an Anchorage wallet renders
+        // it. The validator must track the *wire* type and not flag this as
+        // unsupported — otherwise every `number` field is a permanent false
+        // positive even though the wallet decodes it fine.
         let p = payload(vec![bare(number("Slippage"))]);
         let findings = p.anchorage_render_findings();
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].field_type, "number");
-        assert_eq!(
-            findings[0].reason,
-            AnchorageUnsupportedReason::UnsupportedFieldType
-        );
-        assert_eq!(findings[0].path, "Fields[0]");
-        assert!(p.validate_anchorage_wallet_renderable().is_err());
+        assert!(findings.is_empty(), "{findings:?}");
+        assert!(p.validate_anchorage_wallet_renderable().is_ok());
+        assert_eq!(wire_type(&bare(number("Slippage"))), "amount_v2");
     }
 
     #[test]
@@ -368,20 +369,20 @@ mod tests {
 
     #[test]
     fn preview_layout_with_unsupported_child_flags_child_and_container() {
-        // A `number` inside the expanded list makes the whole preview_layout
+        // A `divider` inside the expanded list makes the whole preview_layout
         // contain unsupported nested fields, and the child itself is reported.
         let p = payload(vec![bare(preview(
             "Instruction 1",
             vec![text("Program")],
-            vec![number("Slippage")],
+            vec![divider("Separator")],
         ))]);
         let findings = p.anchorage_render_findings();
         assert_eq!(findings.len(), 2, "{findings:?}");
 
         let child = findings
             .iter()
-            .find(|f| f.field_type == "number")
-            .expect("number child reported");
+            .find(|f| f.field_type == "divider")
+            .expect("divider child reported");
         assert_eq!(child.path, "Fields[0].Expanded.Fields[0]");
         assert_eq!(
             child.reason,
@@ -418,49 +419,40 @@ mod tests {
     }
 
     #[test]
-    fn preview_layout_missing_condensed_is_unsupported_even_with_clean_descendants() {
-        // Mirrors `create_preview_layout`, which always leaves `condensed:
-        // None` (and several Ethereum visualizers leave `expanded: None`
-        // too, e.g. the ERC-20 Transfer preview): the wallet's PreviewLayout
-        // model requires both lists, so a missing one is a render failure
-        // even though every present descendant is supported.
+    fn preview_layout_with_unset_lists_renders_clean() {
+        // `create_preview_layout` always leaves `condensed: None` and several
+        // Ethereum visualizers leave `expanded: None` too (e.g. the ERC-20
+        // Transfer preview). The PreviewLayout serializer (#403) emits an
+        // empty list for whichever is unset, so the wallet's decoder always
+        // sees both — there is no missing-list failure mode, and the validator
+        // must not flag this. Every present descendant is still checked.
         let p = payload(vec![bare(preview_with_lists(
             "Instruction 1",
             None,
             Some(vec![text("Program")]),
         ))]);
-        let findings = p.anchorage_render_findings();
-        assert_eq!(findings.len(), 1, "{findings:?}");
-        assert_eq!(findings[0].path, "Fields[0]");
-        assert_eq!(
-            findings[0].reason,
-            AnchorageUnsupportedReason::MissingRequiredList
-        );
-        assert!(p.validate_anchorage_wallet_renderable().is_err());
+        assert!(p.anchorage_render_findings().is_empty());
+        assert!(p.validate_anchorage_wallet_renderable().is_ok());
     }
 
     #[test]
-    fn preview_layout_missing_both_lists_is_unsupported() {
+    fn preview_layout_with_both_lists_unset_renders_clean() {
         let p = payload(vec![bare(preview_with_lists("Instruction 1", None, None))]);
-        let findings = p.anchorage_render_findings();
-        assert_eq!(findings.len(), 1, "{findings:?}");
-        assert_eq!(
-            findings[0].reason,
-            AnchorageUnsupportedReason::MissingRequiredList
-        );
+        assert!(p.anchorage_render_findings().is_empty());
+        assert!(p.validate_anchorage_wallet_renderable().is_ok());
     }
 
     #[test]
     fn validate_error_lists_offending_paths() {
         let p = payload(vec![
             bare(text("ok")),
-            bare(preview("Instruction 2", vec![], vec![number("Fee")])),
+            bare(preview("Instruction 2", vec![], vec![divider("Fee")])),
         ]);
         let err = p
             .validate_anchorage_wallet_renderable()
             .expect_err("should be unrenderable");
         let msg = err.to_string();
         assert!(msg.contains("Fields[1].Expanded.Fields[0]"), "{msg}");
-        assert!(msg.contains("number"), "{msg}");
+        assert!(msg.contains("divider"), "{msg}");
     }
 }

--- a/src/visualsign/src/anchorage_render.rs
+++ b/src/visualsign/src/anchorage_render.rs
@@ -1,0 +1,466 @@
+//! Validation that a [`SignablePayload`] only uses fields the **Anchorage
+//! wallet** can render.
+//!
+//! The wallet's Visual Signing Protocol engine decodes each field's `Type`
+//! against a fixed set; anything else is treated as unknown and surfaced to the
+//! user as an *unsupported field*. This module mirrors that support matrix so
+//! the parser can catch payloads that would fail to render BEFORE they ship —
+//! the parser's WYSIWYS contract means an unrenderable field is a correctness
+//! bug, not a cosmetic one.
+//!
+//! Support matrix (kept in lockstep with the wallet's field-type decoder):
+//!
+//! | Parser type      | Anchorage renders? | Notes                                   |
+//! |------------------|--------------------|-----------------------------------------|
+//! | `text_v2`        | yes                |                                         |
+//! | `address_v2`     | yes                |                                         |
+//! | `amount_v2`      | yes                | use this for numeric values, NOT number |
+//! | `diagnostic`     | yes                |                                         |
+//! | `preview_layout` | yes (container)    | needs both Condensed/Expanded lists on the wire, and every descendant to render |
+//! | `list_layout`    | only as a container| INVALID as a standalone field entry     |
+//! | `number`         | no                 | not a VSP type; use `amount_v2`         |
+//! | `text` (v1)      | no                 | superseded by `text_v2`                 |
+//! | `address` (v1)   | no                 | superseded by `address_v2`              |
+//! | `amount` (v1)    | no                 | superseded by `amount_v2`               |
+//! | `divider`        | no                 | not in the wallet decoder               |
+//! | `unknown`        | no                 | explicit fallback/unsupported           |
+//!
+//! The wallet additionally renders the `delta`, `highlight`, and `rule` leaf
+//! types and the `accordion` container, but the parser has no field variant that
+//! emits any of them and no plans to add one. They are therefore deliberately
+//! excluded — the leaves are absent from [`ANCHORAGE_RENDERABLE_LEAF_TYPES`] and
+//! there is no `accordion` container handling — so a payload carrying any of them
+//! would be flagged as unsupported. Add support here only when a parser field
+//! variant starts emitting the type.
+//!
+//! `list_layout` is special: the wallet decodes it only as the `Condensed` /
+//! `Expanded` list inside a `preview_layout` (or `accordion` section), never via
+//! the field-type decoder. So a `list_layout` appearing as an entry in a `Fields`
+//! array is unrenderable — to nest, wrap the group in a `preview_layout`.
+
+use crate::errors::VisualSignError;
+use crate::{FieldSerializer, SignablePayload, SignablePayloadField};
+
+/// Field types the Anchorage wallet renders as standalone (non-container)
+/// fields. Mirrors the recognized cases in the wallet's field-type decoder.
+pub const ANCHORAGE_RENDERABLE_LEAF_TYPES: &[&str] =
+    &["text_v2", "address_v2", "amount_v2", "diagnostic"];
+
+/// Why a field cannot be rendered by the Anchorage wallet. Mirrors the wallet's
+/// unsupported-reason diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnchorageUnsupportedReason {
+    /// The field's `Type` is not in the wallet's renderable set (e.g. `number`,
+    /// legacy `text`/`address`/`amount`, `divider`, `unknown`).
+    UnsupportedFieldType,
+    /// `list_layout` appears as a standalone field entry. It is only valid as
+    /// the `Condensed`/`Expanded` container of a `preview_layout`/`accordion`.
+    ListLayoutAsStandaloneField,
+    /// A `preview_layout` container whose `Condensed`/`Expanded` holds one or
+    /// more unsupported descendants. Mirrors the wallet's
+    /// contains-unsupported-nested-fields flag.
+    ContainsUnsupportedNestedFields,
+    /// A `preview_layout` container is missing its `Condensed` or `Expanded`
+    /// list on the wire. The wallet's model requires both; a missing list
+    /// fails to decode and the whole container falls back to plain text.
+    MissingRequiredList,
+}
+
+impl AnchorageUnsupportedReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::UnsupportedFieldType => "unsupported field type",
+            Self::ListLayoutAsStandaloneField => "list_layout used as a standalone field",
+            Self::ContainsUnsupportedNestedFields => "contains unsupported nested fields",
+            Self::MissingRequiredList => "missing required Condensed/Expanded list",
+        }
+    }
+}
+
+/// A single field the Anchorage wallet cannot render, with a JSON-ish path so
+/// the offending location is easy to find (e.g. `Fields[4].Expanded.Fields[6]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchorageRenderFinding {
+    pub path: String,
+    pub label: String,
+    pub field_type: String,
+    pub reason: AnchorageUnsupportedReason,
+}
+
+impl SignablePayload {
+    /// Collect every field the Anchorage wallet cannot render. An empty result
+    /// means the payload renders clean.
+    pub fn anchorage_render_findings(&self) -> Vec<AnchorageRenderFinding> {
+        let mut findings = Vec::new();
+        for (index, field) in self.fields.iter().enumerate() {
+            check_field(field, &format!("Fields[{index}]"), &mut findings);
+        }
+        findings
+    }
+
+    /// Returns `Err` if any field is unrenderable by the Anchorage wallet.
+    /// Suitable as a hard gate (CI / pre-ship) alongside [`Self::validate_charset`].
+    pub fn validate_anchorage_wallet_renderable(&self) -> Result<(), VisualSignError> {
+        let findings = self.anchorage_render_findings();
+        if findings.is_empty() {
+            return Ok(());
+        }
+        let summary = findings
+            .iter()
+            .map(|f| format!("{} [{}] ({})", f.path, f.field_type, f.reason.as_str()))
+            .collect::<Vec<_>>()
+            .join("; ");
+        Err(VisualSignError::ValidationError(format!(
+            "payload contains {} field(s) the Anchorage wallet cannot render: {summary}",
+            findings.len()
+        )))
+    }
+}
+
+/// Walk `field`, pushing a finding for every unrenderable field. Returns whether
+/// `field` (and all of its descendants) render cleanly.
+fn check_field(
+    field: &SignablePayloadField,
+    path: &str,
+    out: &mut Vec<AnchorageRenderFinding>,
+) -> bool {
+    match field {
+        // Container: supported iff both lists are present on the wire and
+        // every descendant is.
+        SignablePayloadField::PreviewLayout { preview_layout, .. } => {
+            // The wallet's PreviewLayout model requires both `Condensed` and
+            // `Expanded`. Check the actual wire output rather than the
+            // in-memory `Option`s: whether a `None` list is omitted or
+            // defaulted on the wire is a serialization-layer decision
+            // independent of this check, and this stays correct either way.
+            let missing_list = !wire_has_key(field, "PreviewLayout", "Condensed")
+                || !wire_has_key(field, "PreviewLayout", "Expanded");
+
+            let mut descendants_ok = true;
+            if let Some(condensed) = &preview_layout.condensed {
+                for (index, child) in condensed.fields.iter().enumerate() {
+                    let ok = check_field(
+                        &child.signable_payload_field,
+                        &format!("{path}.Condensed.Fields[{index}]"),
+                        out,
+                    );
+                    descendants_ok = descendants_ok && ok;
+                }
+            }
+            if let Some(expanded) = &preview_layout.expanded {
+                for (index, child) in expanded.fields.iter().enumerate() {
+                    let ok = check_field(
+                        &child.signable_payload_field,
+                        &format!("{path}.Expanded.Fields[{index}]"),
+                        out,
+                    );
+                    descendants_ok = descendants_ok && ok;
+                }
+            }
+
+            if missing_list {
+                out.push(finding(
+                    path,
+                    field,
+                    AnchorageUnsupportedReason::MissingRequiredList,
+                ));
+            } else if !descendants_ok {
+                out.push(finding(
+                    path,
+                    field,
+                    AnchorageUnsupportedReason::ContainsUnsupportedNestedFields,
+                ));
+            }
+            !missing_list && descendants_ok
+        }
+        // `list_layout` is never a valid standalone field.
+        SignablePayloadField::ListLayout { .. } => {
+            out.push(finding(
+                path,
+                field,
+                AnchorageUnsupportedReason::ListLayoutAsStandaloneField,
+            ));
+            false
+        }
+        // Every other variant is a leaf: renderable iff its wire `Type` is in
+        // the set. Checked against the wire type, not `field_type()`: a
+        // variant's wire representation can be remapped (e.g. serialized
+        // under a different `Type`) without changing what `field_type()`
+        // reports, and this must track what actually reaches the wallet.
+        _ => {
+            if ANCHORAGE_RENDERABLE_LEAF_TYPES.contains(&wire_type(field).as_str()) {
+                true
+            } else {
+                out.push(finding(
+                    path,
+                    field,
+                    AnchorageUnsupportedReason::UnsupportedFieldType,
+                ));
+                false
+            }
+        }
+    }
+}
+
+/// The `Type` string `field` actually serializes to on the wire. Falls back
+/// to [`SignablePayloadField::field_type`] if serialization fails.
+fn wire_type(field: &SignablePayloadField) -> String {
+    field
+        .serialize_to_map()
+        .ok()
+        .and_then(|map| {
+            map.get("Type")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| field.field_type().to_string())
+}
+
+/// Whether `field`'s wire serialization of its `container_key` object
+/// actually includes `inner_key`.
+fn wire_has_key(field: &SignablePayloadField, container_key: &str, inner_key: &str) -> bool {
+    let Ok(map) = field.serialize_to_map() else {
+        return false;
+    };
+    map.get(container_key)
+        .and_then(|value| value.get(inner_key))
+        .is_some()
+}
+
+fn finding(
+    path: &str,
+    field: &SignablePayloadField,
+    reason: AnchorageUnsupportedReason,
+) -> AnchorageRenderFinding {
+    AnchorageRenderFinding {
+        path: path.to_string(),
+        label: field.label().clone(),
+        field_type: wire_type(field),
+        reason,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::field_builders::{create_amount_field, create_number_field, create_text_field};
+    use crate::{
+        AnnotatedPayloadField, SignablePayloadFieldCommon, SignablePayloadFieldListLayout,
+        SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+    };
+
+    fn payload(fields: Vec<SignablePayloadField>) -> SignablePayload {
+        SignablePayload {
+            fields,
+            payload_type: "Test".to_string(),
+            subtitle: None,
+            title: "Test".to_string(),
+            version: "0".to_string(),
+        }
+    }
+
+    fn text(label: &str) -> AnnotatedPayloadField {
+        create_text_field(label, "x").unwrap()
+    }
+
+    fn number(label: &str) -> AnnotatedPayloadField {
+        create_number_field(label, "1", "bps").unwrap()
+    }
+
+    fn amount(label: &str) -> AnnotatedPayloadField {
+        create_amount_field(label, "1", "USDC").unwrap()
+    }
+
+    fn list_layout_field(label: &str) -> AnnotatedPayloadField {
+        AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::ListLayout {
+                common: SignablePayloadFieldCommon {
+                    label: label.to_string(),
+                    fallback_text: label.to_string(),
+                },
+                list_layout: SignablePayloadFieldListLayout { fields: vec![] },
+            },
+        }
+    }
+
+    fn preview(
+        label: &str,
+        condensed: Vec<AnnotatedPayloadField>,
+        expanded: Vec<AnnotatedPayloadField>,
+    ) -> AnnotatedPayloadField {
+        preview_with_lists(label, Some(condensed), Some(expanded))
+    }
+
+    fn preview_with_lists(
+        label: &str,
+        condensed: Option<Vec<AnnotatedPayloadField>>,
+        expanded: Option<Vec<AnnotatedPayloadField>>,
+    ) -> AnnotatedPayloadField {
+        AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: label.to_string(),
+                    fallback_text: label.to_string(),
+                },
+                preview_layout: SignablePayloadFieldPreviewLayout {
+                    title: Some(SignablePayloadFieldTextV2 {
+                        text: label.to_string(),
+                    }),
+                    subtitle: None,
+                    condensed: condensed.map(|fields| SignablePayloadFieldListLayout { fields }),
+                    expanded: expanded.map(|fields| SignablePayloadFieldListLayout { fields }),
+                },
+            },
+        }
+    }
+
+    fn bare(f: AnnotatedPayloadField) -> SignablePayloadField {
+        f.signable_payload_field
+    }
+
+    #[test]
+    fn supported_leaf_types_render_clean() {
+        let p = payload(vec![bare(text("a")), bare(amount("b"))]);
+        assert!(p.anchorage_render_findings().is_empty());
+        assert!(p.validate_anchorage_wallet_renderable().is_ok());
+    }
+
+    #[test]
+    fn number_field_is_unsupported() {
+        let p = payload(vec![bare(number("Slippage"))]);
+        let findings = p.anchorage_render_findings();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].field_type, "number");
+        assert_eq!(
+            findings[0].reason,
+            AnchorageUnsupportedReason::UnsupportedFieldType
+        );
+        assert_eq!(findings[0].path, "Fields[0]");
+        assert!(p.validate_anchorage_wallet_renderable().is_err());
+    }
+
+    #[test]
+    fn list_layout_as_standalone_field_is_unsupported() {
+        let p = payload(vec![bare(list_layout_field("group"))]);
+        let findings = p.anchorage_render_findings();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].field_type, "list_layout");
+        assert_eq!(
+            findings[0].reason,
+            AnchorageUnsupportedReason::ListLayoutAsStandaloneField
+        );
+    }
+
+    #[test]
+    fn preview_layout_with_supported_children_is_clean() {
+        let p = payload(vec![bare(preview(
+            "Instruction 1",
+            vec![text("Program")],
+            vec![text("Program ID"), amount("Quoted Out")],
+        ))]);
+        assert!(p.anchorage_render_findings().is_empty());
+    }
+
+    #[test]
+    fn preview_layout_with_unsupported_child_flags_child_and_container() {
+        // A `number` inside the expanded list makes the whole preview_layout
+        // contain unsupported nested fields, and the child itself is reported.
+        let p = payload(vec![bare(preview(
+            "Instruction 1",
+            vec![text("Program")],
+            vec![number("Slippage")],
+        ))]);
+        let findings = p.anchorage_render_findings();
+        assert_eq!(findings.len(), 2, "{findings:?}");
+
+        let child = findings
+            .iter()
+            .find(|f| f.field_type == "number")
+            .expect("number child reported");
+        assert_eq!(child.path, "Fields[0].Expanded.Fields[0]");
+        assert_eq!(
+            child.reason,
+            AnchorageUnsupportedReason::UnsupportedFieldType
+        );
+
+        let container = findings
+            .iter()
+            .find(|f| f.field_type == "preview_layout")
+            .expect("container reported");
+        assert_eq!(container.path, "Fields[0]");
+        assert_eq!(
+            container.reason,
+            AnchorageUnsupportedReason::ContainsUnsupportedNestedFields
+        );
+    }
+
+    #[test]
+    fn nested_preview_layout_with_supported_children_renders_clean() {
+        // The supported way to nest: a `preview_layout` (NOT a `list_layout`)
+        // inside another preview_layout's expanded list, with renderable leaves.
+        let inner = preview("Action 2", vec![text("venue")], vec![amount("amount")]);
+        let outer = preview(
+            "Instruction 3",
+            vec![text("Route")],
+            vec![text("Program ID"), inner],
+        );
+        let p = payload(vec![bare(outer)]);
+        assert!(
+            p.anchorage_render_findings().is_empty(),
+            "nested preview_layout of supported leaves should render clean: {:?}",
+            p.anchorage_render_findings()
+        );
+    }
+
+    #[test]
+    fn preview_layout_missing_condensed_is_unsupported_even_with_clean_descendants() {
+        // Mirrors `create_preview_layout`, which always leaves `condensed:
+        // None` (and several Ethereum visualizers leave `expanded: None`
+        // too, e.g. the ERC-20 Transfer preview): the wallet's PreviewLayout
+        // model requires both lists, so a missing one is a render failure
+        // even though every present descendant is supported.
+        let p = payload(vec![bare(preview_with_lists(
+            "Instruction 1",
+            None,
+            Some(vec![text("Program")]),
+        ))]);
+        let findings = p.anchorage_render_findings();
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].path, "Fields[0]");
+        assert_eq!(
+            findings[0].reason,
+            AnchorageUnsupportedReason::MissingRequiredList
+        );
+        assert!(p.validate_anchorage_wallet_renderable().is_err());
+    }
+
+    #[test]
+    fn preview_layout_missing_both_lists_is_unsupported() {
+        let p = payload(vec![bare(preview_with_lists("Instruction 1", None, None))]);
+        let findings = p.anchorage_render_findings();
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(
+            findings[0].reason,
+            AnchorageUnsupportedReason::MissingRequiredList
+        );
+    }
+
+    #[test]
+    fn validate_error_lists_offending_paths() {
+        let p = payload(vec![
+            bare(text("ok")),
+            bare(preview("Instruction 2", vec![], vec![number("Fee")])),
+        ]);
+        let err = p
+            .validate_anchorage_wallet_renderable()
+            .expect_err("should be unrenderable");
+        let msg = err.to_string();
+        assert!(msg.contains("Fields[1].Expanded.Fields[0]"), "{msg}");
+        assert!(msg.contains("number"), "{msg}");
+    }
+}

--- a/src/visualsign/src/lib.rs
+++ b/src/visualsign/src/lib.rs
@@ -2,6 +2,7 @@ use crate::errors::VisualSignError;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
+pub mod anchorage_render;
 pub mod encodings;
 pub mod errors;
 pub mod field_builders;


### PR DESCRIPTION
## What
A validator that checks a `SignablePayload` only uses fields the **Anchorage wallet** can render, mirroring the wallet's VSP field support matrix — so the parser can catch payloads that would surface as "unsupported fields" before they ship (VSP is WYSIWYS, so an unrenderable field is a correctness bug).

- `visualsign::SignablePayload::validate_anchorage_wallet_renderable()` — hard gate (errs listing offending paths).
- `anchorage_render_findings()` — every unrenderable field with a JSON-ish path (e.g. `Fields[4].Expanded.Fields[6]`), label, type, and reason. Flags `number`, legacy `text`/`address`/`amount`, `divider`, `unknown`, and `list_layout`-as-a-standalone-field; recurses through `preview_layout` propagating `ContainsUnsupportedNestedFields`.
- `examples/check_anchorage_render.rs` — `cargo run -p visualsign --features diagnostics --example check_anchorage_render -- <payload.json>`.
- `docs/specs/anchorage-wallet-render-rules.md` — the authoritative ruleset (source of truth: the Anchorage wallet's Visual Signing Protocol engine).

Draft — opening for visibility; a natural follow-up is wiring it into CI alongside `validate_charset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
