### PR TITLE
fix(visualsign): render `number` fields as amount_v2 (VSP has no `number` type)

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/jupiter_swap/mod.rs
@@ -812,9 +812,12 @@ mod tests {
                         && field.get("Type").and_then(|t| t.as_str()) == Some("text_v2")
                 });
 
+                // `number` fields render as `amount_v2` on the wire (VSP has no
+                // `number` type; numbers are unitless/with-unit amounts); the
+                // in-memory variant stays Number.
                 let has_slippage = fields_array.iter().any(|field| {
                     field.get("Label").and_then(|l| l.as_str()) == Some("Slippage")
-                        && field.get("Type").and_then(|t| t.as_str()) == Some("number")
+                        && field.get("Type").and_then(|t| t.as_str()) == Some("amount_v2")
                 });
 
                 assert!(

--- a/src/parser/cli/tests/fixtures/solana-json.display.expected
+++ b/src/parser/cli/tests/fixtures/solana-json.display.expected
@@ -187,12 +187,13 @@
               "Type": "text_v2"
             },
             {
+              "AmountV2": {
+                "Abbreviation": "units",
+                "Amount": "400000"
+              },
               "FallbackText": "400000 units",
               "Label": "Compute Unit Limit",
-              "Number": {
-                "Number": "400000"
-              },
-              "Type": "number"
+              "Type": "amount_v2"
             },
             {
               "FallbackText": "02801a0600",
@@ -240,12 +241,13 @@
               "Type": "text_v2"
             },
             {
+              "AmountV2": {
+                "Abbreviation": "micro-lamports",
+                "Amount": "50000"
+              },
               "FallbackText": "50000 micro-lamports",
               "Label": "Price per Compute Unit",
-              "Number": {
-                "Number": "50000"
-              },
-              "Type": "number"
+              "Type": "amount_v2"
             },
             {
               "FallbackText": "0350c3000000000000",

--- a/src/visualsign/src/lib.rs
+++ b/src/visualsign/src/lib.rs
@@ -264,7 +264,20 @@ impl FieldSerializer for SignablePayloadField {
                 serialize_field_variant!(fields, "address_v2", common, ("AddressV2", address_v2));
             }
             SignablePayloadField::Number { common, number } => {
-                serialize_field_variant!(fields, "number", common, ("Number", number));
+                // VSP has no `number` field type; numbers render as `amount_v2`
+                // (a unitless number = empty abbreviation). The unit, if any, is
+                // the remainder of `fallback_text` after the numeric value (see
+                // `create_number_field`, which builds "{number} {unit}").
+                let abbreviation = common
+                    .fallback_text
+                    .strip_prefix(number.number.as_str())
+                    .map(|rest| rest.trim_start().to_string())
+                    .unwrap_or_default();
+                let amount_v2 = SignablePayloadFieldAmountV2 {
+                    amount: number.number.clone(),
+                    abbreviation: Some(abbreviation),
+                };
+                serialize_field_variant!(fields, "amount_v2", common, ("AmountV2", &amount_v2));
             }
             SignablePayloadField::Amount { common, amount } => {
                 serialize_field_variant!(fields, "amount", common, ("Amount", amount));
@@ -318,7 +331,8 @@ impl FieldSerializer for SignablePayloadField {
             SignablePayloadField::TextV2 { .. } => base_fields.push("TextV2"),
             SignablePayloadField::Address { .. } => base_fields.push("Address"),
             SignablePayloadField::AddressV2 { .. } => base_fields.push("AddressV2"),
-            SignablePayloadField::Number { .. } => base_fields.push("Number"),
+            // Serialized as `amount_v2` under the hood (see `serialize_to_map`).
+            SignablePayloadField::Number { .. } => base_fields.push("AmountV2"),
             SignablePayloadField::Amount { .. } => base_fields.push("Amount"),
             SignablePayloadField::AmountV2 { .. } => base_fields.push("AmountV2"),
             SignablePayloadField::Divider { .. } => base_fields.push("Divider"),


### PR DESCRIPTION
VSP defines **no `number` field type** — the HSM `vsp.py` enum and the iOS decoder recognize `text_v2, address_v2, **amount_v2**, preview_layout, list_layout, delta, accordion, diagnostic, divider`. So a `number` field decoded to `.unknown` and surfaced as *unsupported*.

This serializes the `Number` variant as **`amount_v2`** on the wire: `amount` = the numeric value, `abbreviation` = the unit (empty for unitless numbers — iOS `parseAmount` accepts an empty abbreviation). The in-memory `Number` variant and the `create_number_field` helper are unchanged (callers + variant-matching tests keep working); only the wire output changes. Covers every `number` producer (compute_budget, system, token_2022, jupiter_swap, …).

Replaces #390 (which used the legacy `fix/number-fields-text-v2` branch name and an earlier text_v2 approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)