### PR TITLE
ci: namespace PR trigger and outcome labels with test: and ci: prefixes

### DIFF
--- a/.github/workflows/fuzz-solana.yml
+++ b/.github/workflows/fuzz-solana.yml
@@ -66,7 +66,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${{ steps.fuzz_transaction_string.outcome }}" = "failure" ] || [ "${{ steps.fuzz_versioned_transaction.outcome }}" = "failure" ]; then
-            gh pr edit "$PR_NUMBER" --add-label fuzz-failure || true
+            gh pr edit "$PR_NUMBER" --add-label test:fuzz-failure || true
           else
-            gh pr edit "$PR_NUMBER" --remove-label fuzz-failure || true
+            gh pr edit "$PR_NUMBER" --remove-label test:fuzz-failure || true
           fi

--- a/.github/workflows/fuzz-solana.yml
+++ b/.github/workflows/fuzz-solana.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   fuzz:
-    if: contains(github.event.pull_request.labels.*.name, 'fuzz')
+    if: contains(github.event.pull_request.labels.*.name, 'test:fuzz')
     runs-on: ubuntu-latest-4-cores
     permissions:
       pull-requests: write

--- a/.github/workflows/proptest-solana.yml
+++ b/.github/workflows/proptest-solana.yml
@@ -55,7 +55,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${{ steps.proptest.outcome }}" = "failure" ]; then
-            gh pr edit "$PR_NUMBER" --add-label proptest-failure || true
+            gh pr edit "$PR_NUMBER" --add-label test:proptest-failure || true
           else
-            gh pr edit "$PR_NUMBER" --remove-label proptest-failure || true
+            gh pr edit "$PR_NUMBER" --remove-label test:proptest-failure || true
           fi

--- a/.github/workflows/proptest-solana.yml
+++ b/.github/workflows/proptest-solana.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   proptest:
-    if: contains(github.event.pull_request.labels.*.name, 'proptest')
+    if: contains(github.event.pull_request.labels.*.name, 'test:proptest')
     runs-on: ubuntu-latest-4-cores
     permissions:
       pull-requests: write

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build ${{ matrix.target.label || matrix.target.name }}
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.label.name == 'stagex'
+      github.event.label.name == 'ci:stagex'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/surfpool-solana.yml
+++ b/.github/workflows/surfpool-solana.yml
@@ -22,9 +22,9 @@ jobs:
     #    would be empty and `gh pr edit` would lack write permissions.
     if: |
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'surfpool')
+        (github.event.action == 'labeled' && github.event.label.name == 'test:surfpool')
         ||
-        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'surfpool'))
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'test:surfpool'))
       )
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest-4-cores

--- a/.github/workflows/surfpool-solana.yml
+++ b/.github/workflows/surfpool-solana.yml
@@ -14,9 +14,9 @@ env:
 jobs:
   surfpool:
     # Two guards:
-    # 1. On `labeled` events only run when the label being added is `surfpool`.
-    #    Without this, the workflow's own `surfpool-failure` add (and any other
-    #    label change on a PR that happens to already carry `surfpool`) would
+    # 1. On `labeled` events only run when the label being added is `test:surfpool`.
+    #    Without this, the workflow's own `test:surfpool-failure` add (and any other
+    #    label change on a PR that happens to already carry `test:surfpool`) would
     #    re-fire the workflow.
     # 2. Skip fork PRs: secrets aren't passed across forks, so HELIUS_API_KEY
     #    would be empty and `gh pr edit` would lack write permissions.

--- a/.github/workflows/surfpool-solana.yml
+++ b/.github/workflows/surfpool-solana.yml
@@ -95,7 +95,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${{ steps.surfpool.outcome }}" = "failure" ]; then
-            gh pr edit "$PR_NUMBER" --add-label surfpool-failure || true
+            gh pr edit "$PR_NUMBER" --add-label test:surfpool-failure || true
           else
-            gh pr edit "$PR_NUMBER" --remove-label surfpool-failure || true
+            gh pr edit "$PR_NUMBER" --remove-label test:surfpool-failure || true
           fi

--- a/docs/contributor-guides/testing-visualizations.mdx
+++ b/docs/contributor-guides/testing-visualizations.mdx
@@ -219,9 +219,13 @@ Tests are triggered by adding labels to a PR:
 |-------|----------|-----------|
 | `test:proptest` | `proptest-solana.yml` | `cargo test -p visualsign-solana` |
 | `test:fuzz` | `fuzz-solana.yml` | Both libFuzzer targets for 30 seconds each |
+| `test:surfpool` | `surfpool-solana.yml` | `scripts/surfpool_fuzz_all_idls.sh` against all embedded IDLs |
+| `ci:stagex` | `stagex.yml` | Hermetic stagex OCI image builds |
 | `ci` | `main.yml` | Full build, lint, and test suite |
 
-If a fuzz target crashes, the `test:fuzz-failure` label is added to the PR. If a proptest fails, the `test:proptest-failure` label is added. These labels are removed automatically on a clean run.
+`test:` labels gate test runs; `ci:` labels gate the build/image pipeline.
+
+When a run fails, the workflow adds an outcome label to the PR: `test:fuzz-failure` if a fuzz target crashes, `test:proptest-failure` if a proptest fails, and `test:surfpool-failure` if a surfpool run fails. These labels are removed automatically on a clean run.
 
 ## End-to-end format chain with test coverage
 

--- a/docs/contributor-guides/testing-visualizations.mdx
+++ b/docs/contributor-guides/testing-visualizations.mdx
@@ -217,11 +217,11 @@ Tests are triggered by adding labels to a PR:
 
 | Label | Workflow | What runs |
 |-------|----------|-----------|
-| `proptest` | `proptest.yml` | `cargo test -p visualsign-solana` |
-| `fuzz` | `fuzz.yml` | Both libFuzzer targets for 30 seconds each |
+| `test:proptest` | `proptest-solana.yml` | `cargo test -p visualsign-solana` |
+| `test:fuzz` | `fuzz-solana.yml` | Both libFuzzer targets for 30 seconds each |
 | `ci` | `main.yml` | Full build, lint, and test suite |
 
-If a fuzz target crashes, the `fuzz-failure` label is added to the PR. If a proptest fails, the `proptest-failure` label is added. These labels are removed automatically on a clean run.
+If a fuzz target crashes, the `test:fuzz-failure` label is added to the PR. If a proptest fails, the `test:proptest-failure` label is added. These labels are removed automatically on a clean run.
 
 ## End-to-end format chain with test coverage
 


### PR DESCRIPTION
## Summary

Renames the four label-gated CI workflow triggers and their outcome labels to align with the `chain:` prefix convention already in use.

| Old | New | Role |
|-----|-----|------|
| `fuzz` | `test:fuzz` | trigger |
| `proptest` | `test:proptest` | trigger |
| `surfpool` | `test:surfpool` | trigger |
| `stagex` | `ci:stagex` | trigger |
| `fuzz-failure` | `test:fuzz-failure` | outcome |
| `proptest-failure` | `test:proptest-failure` | outcome |
| `surfpool-failure` | `test:surfpool-failure` | outcome |

`test:` groups labels that gate test runs; `ci:` covers the build/image pipeline.

## Manual steps required after merge

1. Rename all seven labels in GitHub (Settings → Labels)
2. Re-apply `test:surfpool` on open PRs currently carrying `surfpool` (at minimum #291, #290)

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)