### PR TITLE
draft: feat(skills): dispatch solana-add-idl scaffolding as Sonnet subagent

### DIFF
--- a/.claude/skills/solana-add-idl/SKILL.md
+++ b/.claude/skills/solana-add-idl/SKILL.md
@@ -8,6 +8,11 @@ user-invocable: true
 
 You are orchestrating the scaffolding of a new Solana program visualizer preset.
 
+## Mode Selection
+
+- **Standard** (`/solana-add-idl`): gather inputs, dispatch one Sonnet subagent to scaffold the preset
+- **Compare** (`/solana-add-idl compare`): gather inputs, dispatch Sonnet and Opus subagents in parallel to separate temp dirs, then diff their outputs to surface capability gaps
+
 ## Step 1: Gather Information
 
 Ask the user for:
@@ -15,185 +20,274 @@ Ask the user for:
 2. **Human-readable name** (e.g. "Squads Multisig", "Marinade Finance", "Jupiter Swap")
 3. **VisualizerKind** — one of: `Dex`, `Lending`, `StakingPools`, `Payments`
 
-Derive these from the human name:
+Derive from the human name:
 - `snake_name`: lowercase with underscores (e.g. `marinade_finance`)
 - `PascalName`: PascalCase (e.g. `MarinadeFinance`)
 - `SCREAMING_SNAKE`: uppercase with underscores (e.g. `MARINADE_FINANCE`)
-- `display_name`: the human name as-is for display strings
+- `display_name`: human name as-is
 
-## Step 2: Dispatch Implementation Subagent
+## Step 2: Dispatch
 
-Once you have all inputs, dispatch an Agent with **`model: "sonnet"`**. Substitute the gathered values into the prompt below before dispatching.
+### Standard mode
+
+Dispatch one Agent with **`model: "sonnet"`**, substituting gathered values into the implementation prompt below.
+
+### Compare mode
+
+Dispatch two Agents **in parallel** — one with `model: "sonnet"`, one with `model: "opus"`. Give each a different output directory:
+
+- Sonnet writes to: `/tmp/solana-add-idl-compare/sonnet/`
+- Opus writes to: `/tmp/solana-add-idl-compare/opus/`
+
+Both receive the same implementation prompt (below), with only the output directory differing.
+
+After both complete, diff the two output directories:
+
+```bash
+diff -ru /tmp/solana-add-idl-compare/sonnet/ /tmp/solana-add-idl-compare/opus/
+```
+
+Present the diff to the user and summarize: what did Opus add or do differently? Are any of those patterns general enough to encode in this skill's instructions?
+
+---
+
+## Implementation Prompt (for subagents)
 
 ```
-Agent:
-  description: "Scaffold Solana IDL preset for {display_name}"
-  model: "sonnet"
-  prompt: |
-    You are scaffolding a new Solana program visualizer preset from an Anchor IDL.
+You are scaffolding a Solana program visualizer preset from an Anchor IDL.
 
-    ## Inputs
+## Inputs
 
-    - Program address: {PROGRAM_ID}
-    - snake_name: {snake_name}
-    - PascalName: {PascalName}
-    - SCREAMING_SNAKE: {SCREAMING_SNAKE}
-    - display_name: {display_name}
-    - VisualizerKind: {VisualizerKind}
+- Program address: {PROGRAM_ID}
+- snake_name: {snake_name}
+- PascalName: {PascalName}
+- SCREAMING_SNAKE: {SCREAMING_SNAKE}
+- display_name: {display_name}
+- VisualizerKind: {VisualizerKind}
+- Output directory: {OUTPUT_DIR}   ← for compare mode; omit in standard mode (write to repo)
 
-    ## Step A: Fetch the IDL
+## Step A: Fetch the IDL
 
-    Try these in order:
+### Option A: Local Anchor CLI
+```bash
+anchor idl fetch {PROGRAM_ID} --provider.cluster mainnet
+```
 
-    ### Option A: Local Anchor CLI
-    ```bash
-    anchor idl fetch {PROGRAM_ID} --provider.cluster mainnet
-    ```
+### Option B: Docker container
+```bash
+docker images -q anchor-cli | grep -q . || \
+  docker build -t anchor-cli -f images/anchor-cli/Containerfile .
+docker run --rm anchor-cli idl fetch {PROGRAM_ID} --provider.cluster mainnet
+```
 
-    ### Option B: Docker container
-    If `anchor` is not installed locally, use the project's Anchor CLI container:
+### Option C: User-provided
+If both fail, ask the user for the IDL (file path, URL, or pasted JSON).
 
-    ```bash
-    docker images -q anchor-cli | grep -q . || \
-      docker build -t anchor-cli -f images/anchor-cli/Containerfile .
-    docker run --rm anchor-cli idl fetch {PROGRAM_ID} --provider.cluster mainnet
-    ```
+Save to: `{OUTPUT_DIR}src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
 
-    ### Option C: User-provided IDL
-    If both methods fail, tell the user and ask them to provide the IDL via a local
-    file path, a URL, or pasted JSON.
+The IDL **must** have an `instructions` array. Stop and report if missing.
 
-    Save the IDL to:
-    `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
+## Step B: Scaffold config.rs
 
-    The IDL JSON **must** have an `instructions` array. Verify this before proceeding.
-    If it's missing, stop and report the IDL as invalid.
+```rust
+use super::{SCREAMING_SNAKE}_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::HashMap;
 
-    ## Step B: Scaffold the Preset
+pub struct {PascalName}Config;
 
-    Create directory: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/`
+impl SolanaIntegrationConfig for {PascalName}Config {
+    fn new() -> Self { Self }
 
-    ### File: `config.rs`
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = HashMap::new();
+            let mut instructions = HashMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert({SCREAMING_SNAKE}_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}
+```
 
-    ```rust
-    use super::{SCREAMING_SNAKE}_PROGRAM_ID;
-    use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
-    use std::collections::HashMap;
+## Step C: Scaffold mod.rs
 
-    pub struct {PascalName}Config;
+Use `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs` as the
+structural template. Make these substitutions:
+- `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` → appropriate casing
+- Program ID string → {PROGRAM_ID}
+- `"DFlow Aggregator"` display strings → `{display_name}`
+- `include_str!("dflow_aggregator.json")` → `include_str!("{snake_name}.json")`
+- `kind()` → returns `{VisualizerKind}("{display_name}")`
 
-    impl SolanaIntegrationConfig for {PascalName}Config {
-        fn new() -> Self {
-            Self
+**Wire-data context API** — at the top of `visualize_tx_commands`:
+```rust
+let program_id = context.resolve_program_id()?.to_string();
+let accounts = context.resolve_accounts()?;
+let data = context.data();
+```
+
+**Required imports** (at top of module, NOT inside functions):
+```rust
+use crate::core::{
+    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+};
+use config::{PascalName}Config;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+```
+
+`BTreeMap` (not `HashMap`) — keeps named-account order deterministic.
+
+### Required: arg rendering helpers
+
+Every preset **must** include these three helpers. They solve two constraints that
+apply to all programs, not just this one:
+
+**Constraint 1 — charset safety.** `SignablePayload::validate_charset` rejects `"`
+and `\`. Compact JSON of any object contains quoted keys, which serialize to `\"`
+and fail validation. Arg values must never emit `"` or `\`.
+
+**Constraint 2 — field explosion.** Recursing into nested structs/arrays produces
+one field per leaf. A `[u8; 32]` seed or a 76-byte opaque ID becomes 32 or 76
+per-byte fields, burying the meaningful human-readable arguments.
+
+```rust
+/// Renders one top-level program-call argument as a single field value.
+/// Objects/arrays: quote-free (no `"` or `\`), JSON-like.
+/// All-byte arrays (every element 0–255): `0x`-prefixed hex string.
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => charset_safe(s),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Array(items) => {
+            if let Some(hex) = bytes_as_hex(items) {
+                hex
+            } else {
+                let inner: Vec<String> = items.iter().map(format_arg_value).collect();
+                format!("[{}]", inner.join(","))
+            }
         }
-
-        fn data(&self) -> &SolanaIntegrationConfigData {
-            static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
-            DATA.get_or_init(|| {
-                let mut programs = HashMap::new();
-                let mut instructions = HashMap::new();
-                instructions.insert("*", vec!["*"]);
-                programs.insert({SCREAMING_SNAKE}_PROGRAM_ID, instructions);
-                SolanaIntegrationConfigData { programs }
-            })
+        serde_json::Value::Object(map) => {
+            let inner: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}:{}", charset_safe(k), format_arg_value(v)))
+                .collect();
+            format!("{{{}}}", inner.join(","))
         }
     }
-    ```
+}
 
-    ### File: `mod.rs`
+/// Strips `"`, `\`, control chars, and non-ASCII from strings/keys so the
+/// charset-safe contract holds even for unexpected arg values.
+fn charset_safe(text: &str) -> String {
+    text.chars()
+        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\'))
+        .collect()
+}
 
-    Use the dflow_aggregator preset as a template:
-    `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs`
+/// Returns `Some(0x…)` if every element is an integer in 0–255; `None` otherwise.
+/// Empty arrays return `None` (caller falls back to bracketed list).
+fn bytes_as_hex(items: &[serde_json::Value]) -> Option<String> {
+    if items.is_empty() { return None; }
+    let mut bytes = Vec::with_capacity(items.len());
+    for item in items {
+        let byte = item.as_u64().filter(|n| *n <= u8::MAX as u64)? as u8;
+        bytes.push(byte);
+    }
+    Some(format!("0x{}", hex::encode(bytes)))
+}
+```
 
-    Read that file for the exact structure, then generate a generic version with:
-    - Replace `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` with the
-      appropriate casing of the new program name
-    - Replace the program ID string with {PROGRAM_ID}
-    - Replace `"DFlow Aggregator"` display strings with `{display_name}`
-    - Replace IDL file reference: `include_str!("{snake_name}.json")`
-    - Keep the `kind()` method returning `{VisualizerKind}` with `{display_name}` as
-      the `&'static str` argument
+Use `format_arg_value` in `build_parsed_fields` for every program-call arg:
+```rust
+for (key, value) in &parsed.program_call_args {
+    condensed_fields.push(create_text_field(key, &format_arg_value(value))?);
+}
+// same in expanded_fields
+```
 
-    **Generic IDL pattern only:**
-    The scaffold uses `build_named_accounts`, `build_parsed_fields`, and
-    `build_fallback_fields` — all three work with any IDL. `append_raw_data` and
-    `format_arg_value` are not in `dflow_aggregator`; add them only if the target IDL
-    needs them, copying from `kamino_vault` or `jupiter_earn`.
+For raw-data fields, pass `None` as the second arg of `create_raw_data_field`
+unless you already have a precomputed hex string to reuse.
 
-    The parse function must: check `data.len() < 8`, load IDL, call
-    `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with
-    parsed data + named accounts.
+### Required tests
 
-    **Visualizer body must use the wire-data context API.** At the top of
-    `visualize_tx_commands`:
-    ```rust
-    let program_id = context.resolve_program_id()?.to_string();
-    let accounts = context.resolve_accounts()?;
-    let data = context.data();
-    ```
-    Use `context.instruction_index()` for any "Instruction N" labels.
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
 
-    **Required imports** (at top of module, NOT inside functions):
-    ```rust
-    use crate::core::{
-        InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
-    };
-    use config::{PascalName}Config;
-    use solana_parser::{
-        Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
-    };
-    use solana_sdk::instruction::AccountMeta;
-    use std::collections::BTreeMap;
-    use std::sync::OnceLock;
-    use visualsign::errors::VisualSignError;
-    use visualsign::field_builders::{create_raw_data_field, create_text_field};
-    use visualsign::{
-        AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
-        SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
-    };
-    ```
+    #[test]
+    fn test_{snake_name}_idl_loads() { /* IDL loads and has instructions */ }
 
-    `BTreeMap` (not `HashMap`) keeps named-accounts order deterministic.
+    #[test]
+    fn test_{snake_name}_idl_has_discriminators() { /* every instruction has 8-byte discriminator */ }
 
-    **Required tests** (in `#[cfg(test)] mod tests`):
-    - `test_{snake_name}_idl_loads` — IDL loads and has instructions
-    - `test_{snake_name}_idl_has_discriminators` — every instruction has an 8-byte discriminator
-    - `test_unknown_discriminator_returns_error` — garbage 9-byte data returns error
-    - `test_short_data_returns_error` — 3-byte data returns error
+    #[test]
+    fn test_unknown_discriminator_returns_error() { /* garbage 9-byte data returns error */ }
 
-    ## Step C: Register in presets/mod.rs
+    #[test]
+    fn test_short_data_returns_error() { /* 3-byte data returns error */ }
 
-    Add `pub mod {snake_name};` to
-    `src/chain_parsers/visualsign-solana/src/presets/mod.rs`.
+    #[test]
+    fn test_format_arg_value_is_charset_safe() {
+        // No `"` or `\` in output for any input shape
+        let nested = serde_json::json!({"key": "val\"ue", "arr": [1u8, 2, 3]});
+        let rendered = format_arg_value(&nested);
+        assert!(!rendered.contains('"') && !rendered.contains('\\'));
+    }
 
-    Keep entries in alphabetical order.
+    #[test]
+    fn test_format_arg_value_no_field_explosion() {
+        // A 32-element byte array becomes one hex string, not 32 fields
+        let bytes: Vec<u8> = (0..32).collect();
+        let val = serde_json::json!(bytes);
+        let rendered = format_arg_value(&val);
+        assert!(rendered.starts_with("0x"), "byte array should be hex: {rendered}");
+        assert!(!rendered.contains(','), "byte array must not expand to list: {rendered}");
+    }
+}
+```
 
-    No other registration is needed. `build.rs` auto-discovers `{PascalName}Visualizer`
-    from any directory under `src/presets/`.
+## Step D: Register in presets/mod.rs
 
-    ## Step D: Code Quality
+Add `pub mod {snake_name};` to
+`src/chain_parsers/visualsign-solana/src/presets/mod.rs`, maintaining alphabetical
+order.
 
-    - `use` statements at top of module, never inside functions
-    - Inline format strings: `format!("{variable}")` not `format!("{}", variable)`
-    - Use `create_text_field` and `create_raw_data_field` from `visualsign::field_builders`
-    - For raw-data fields, pass `None` as the second arg of `create_raw_data_field` unless
-      you already have a precomputed hex string to reuse. Do not call `hex::encode(data)`
-      solely to populate this arg.
-    - ASCII only in user-visible strings: `>=` not `≥`, `->` not `→`
-    - Rust edition 2024 on nightly
+No other registration needed — `build.rs` auto-discovers `{PascalName}Visualizer`.
 
-    ## Step E: Verify
+## Step E: Code Quality
 
-    Run these commands and fix any issues before reporting done:
+- `use` statements at top of module, never inside functions
+- Inline format strings: `format!("{variable}")` not `format!("{}", variable)`
+- ASCII only in user-visible strings: `>=` not `≥`, `->` not `→`
+- Rust edition 2024 on nightly
 
-    ```bash
-    cargo fmt -p visualsign-solana
-    cargo clippy -p visualsign-solana --all-targets -- -D warnings
-    cargo clippy -p visualsign-solana --features diagnostics --all-targets -- -D warnings
-    cargo test -p visualsign-solana
-    cargo test -p visualsign-solana --features diagnostics
-    make -C src test
-    ```
+## Step F: Verify
 
-    Both feature configurations (diagnostics on and off) must compile and test cleanly.
+```bash
+cargo fmt -p visualsign-solana
+cargo clippy -p visualsign-solana --all-targets -- -D warnings
+cargo clippy -p visualsign-solana --features diagnostics --all-targets -- -D warnings
+cargo test -p visualsign-solana
+cargo test -p visualsign-solana --features diagnostics
+make -C src test
+```
+
+Both feature configurations must pass. Report any failures before marking done.
 ```

--- a/.claude/skills/solana-add-idl/SKILL.md
+++ b/.claude/skills/solana-add-idl/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 # Add Solana IDL Visualizer Preset
 
-You are scaffolding a new Solana program visualizer preset from an Anchor IDL.
+You are orchestrating the scaffolding of a new Solana program visualizer preset.
 
 ## Step 1: Gather Information
 
@@ -21,156 +21,179 @@ Derive these from the human name:
 - `SCREAMING_SNAKE`: uppercase with underscores (e.g. `MARINADE_FINANCE`)
 - `display_name`: the human name as-is for display strings
 
-## Step 2: Fetch the IDL
+## Step 2: Dispatch Implementation Subagent
 
-Try these in order:
+Once you have all inputs, dispatch an Agent with **`model: "sonnet"`**. Substitute the gathered values into the prompt below before dispatching.
 
-### Option A: Local Anchor CLI
-```bash
-anchor idl fetch <PROGRAM_ID> --provider.cluster mainnet
 ```
+Agent:
+  description: "Scaffold Solana IDL preset for {display_name}"
+  model: "sonnet"
+  prompt: |
+    You are scaffolding a new Solana program visualizer preset from an Anchor IDL.
 
-### Option B: Docker container
-If `anchor` is not installed locally, use the project's Anchor CLI container:
+    ## Inputs
 
-```bash
-# Build the image if it doesn't exist
-docker images -q anchor-cli | grep -q . || \
-  docker build -t anchor-cli -f images/anchor-cli/Containerfile .
+    - Program address: {PROGRAM_ID}
+    - snake_name: {snake_name}
+    - PascalName: {PascalName}
+    - SCREAMING_SNAKE: {SCREAMING_SNAKE}
+    - display_name: {display_name}
+    - VisualizerKind: {VisualizerKind}
 
-# Fetch the IDL
-docker run --rm anchor-cli idl fetch <PROGRAM_ID> --provider.cluster mainnet
-```
+    ## Step A: Fetch the IDL
 
-### Option C: User-provided IDL
-If both methods fail, ask the user to provide the IDL via:
-- A local file path
-- A URL to fetch
-- Pasted JSON
+    Try these in order:
 
-Save the IDL to: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
+    ### Option A: Local Anchor CLI
+    ```bash
+    anchor idl fetch {PROGRAM_ID} --provider.cluster mainnet
+    ```
 
-### Validation
-The IDL JSON **must** have an `instructions` array. Verify this before proceeding. If it's missing, tell the user the IDL is invalid.
+    ### Option B: Docker container
+    If `anchor` is not installed locally, use the project's Anchor CLI container:
 
-## Step 3: Scaffold the Preset
+    ```bash
+    docker images -q anchor-cli | grep -q . || \
+      docker build -t anchor-cli -f images/anchor-cli/Containerfile .
+    docker run --rm anchor-cli idl fetch {PROGRAM_ID} --provider.cluster mainnet
+    ```
 
-Create directory: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/`
+    ### Option C: User-provided IDL
+    If both methods fail, tell the user and ask them to provide the IDL via a local
+    file path, a URL, or pasted JSON.
 
-### File: `config.rs`
+    Save the IDL to:
+    `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/{snake_name}.json`
 
-```rust
-use super::{SCREAMING_SNAKE}_PROGRAM_ID;
-use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
-use std::collections::HashMap;
+    The IDL JSON **must** have an `instructions` array. Verify this before proceeding.
+    If it's missing, stop and report the IDL as invalid.
 
-pub struct {PascalName}Config;
+    ## Step B: Scaffold the Preset
 
-impl SolanaIntegrationConfig for {PascalName}Config {
-    fn new() -> Self {
-        Self
+    Create directory: `src/chain_parsers/visualsign-solana/src/presets/{snake_name}/`
+
+    ### File: `config.rs`
+
+    ```rust
+    use super::{SCREAMING_SNAKE}_PROGRAM_ID;
+    use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+    use std::collections::HashMap;
+
+    pub struct {PascalName}Config;
+
+    impl SolanaIntegrationConfig for {PascalName}Config {
+        fn new() -> Self {
+            Self
+        }
+
+        fn data(&self) -> &SolanaIntegrationConfigData {
+            static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+            DATA.get_or_init(|| {
+                let mut programs = HashMap::new();
+                let mut instructions = HashMap::new();
+                instructions.insert("*", vec!["*"]);
+                programs.insert({SCREAMING_SNAKE}_PROGRAM_ID, instructions);
+                SolanaIntegrationConfigData { programs }
+            })
+        }
     }
+    ```
 
-    fn data(&self) -> &SolanaIntegrationConfigData {
-        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
-        DATA.get_or_init(|| {
-            let mut programs = HashMap::new();
-            let mut instructions = HashMap::new();
-            instructions.insert("*", vec!["*"]);
-            programs.insert({SCREAMING_SNAKE}_PROGRAM_ID, instructions);
-            SolanaIntegrationConfigData { programs }
-        })
-    }
-}
+    ### File: `mod.rs`
+
+    Use the dflow_aggregator preset as a template:
+    `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs`
+
+    Read that file for the exact structure, then generate a generic version with:
+    - Replace `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` with the
+      appropriate casing of the new program name
+    - Replace the program ID string with {PROGRAM_ID}
+    - Replace `"DFlow Aggregator"` display strings with `{display_name}`
+    - Replace IDL file reference: `include_str!("{snake_name}.json")`
+    - Keep the `kind()` method returning `{VisualizerKind}` with `{display_name}` as
+      the `&'static str` argument
+
+    **Generic IDL pattern only:**
+    The scaffold uses `build_named_accounts`, `build_parsed_fields`, and
+    `build_fallback_fields` — all three work with any IDL. `append_raw_data` and
+    `format_arg_value` are not in `dflow_aggregator`; add them only if the target IDL
+    needs them, copying from `kamino_vault` or `jupiter_earn`.
+
+    The parse function must: check `data.len() < 8`, load IDL, call
+    `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with
+    parsed data + named accounts.
+
+    **Visualizer body must use the wire-data context API.** At the top of
+    `visualize_tx_commands`:
+    ```rust
+    let program_id = context.resolve_program_id()?.to_string();
+    let accounts = context.resolve_accounts()?;
+    let data = context.data();
+    ```
+    Use `context.instruction_index()` for any "Instruction N" labels.
+
+    **Required imports** (at top of module, NOT inside functions):
+    ```rust
+    use crate::core::{
+        InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
+    };
+    use config::{PascalName}Config;
+    use solana_parser::{
+        Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+    };
+    use solana_sdk::instruction::AccountMeta;
+    use std::collections::BTreeMap;
+    use std::sync::OnceLock;
+    use visualsign::errors::VisualSignError;
+    use visualsign::field_builders::{create_raw_data_field, create_text_field};
+    use visualsign::{
+        AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+        SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+    };
+    ```
+
+    `BTreeMap` (not `HashMap`) keeps named-accounts order deterministic.
+
+    **Required tests** (in `#[cfg(test)] mod tests`):
+    - `test_{snake_name}_idl_loads` — IDL loads and has instructions
+    - `test_{snake_name}_idl_has_discriminators` — every instruction has an 8-byte discriminator
+    - `test_unknown_discriminator_returns_error` — garbage 9-byte data returns error
+    - `test_short_data_returns_error` — 3-byte data returns error
+
+    ## Step C: Register in presets/mod.rs
+
+    Add `pub mod {snake_name};` to
+    `src/chain_parsers/visualsign-solana/src/presets/mod.rs`.
+
+    Keep entries in alphabetical order.
+
+    No other registration is needed. `build.rs` auto-discovers `{PascalName}Visualizer`
+    from any directory under `src/presets/`.
+
+    ## Step D: Code Quality
+
+    - `use` statements at top of module, never inside functions
+    - Inline format strings: `format!("{variable}")` not `format!("{}", variable)`
+    - Use `create_text_field` and `create_raw_data_field` from `visualsign::field_builders`
+    - For raw-data fields, pass `None` as the second arg of `create_raw_data_field` unless
+      you already have a precomputed hex string to reuse. Do not call `hex::encode(data)`
+      solely to populate this arg.
+    - ASCII only in user-visible strings: `>=` not `≥`, `->` not `→`
+    - Rust edition 2024 on nightly
+
+    ## Step E: Verify
+
+    Run these commands and fix any issues before reporting done:
+
+    ```bash
+    cargo fmt -p visualsign-solana
+    cargo clippy -p visualsign-solana --all-targets -- -D warnings
+    cargo clippy -p visualsign-solana --features diagnostics --all-targets -- -D warnings
+    cargo test -p visualsign-solana
+    cargo test -p visualsign-solana --features diagnostics
+    make -C src test
+    ```
+
+    Both feature configurations (diagnostics on and off) must compile and test cleanly.
 ```
-
-### File: `mod.rs`
-
-Use the dflow_aggregator preset as a template: `src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs`
-
-Read that file for the exact structure, then generate a generic version with these substitutions:
-- Replace `DflowAggregator` / `dflow_aggregator` / `DFLOW_AGGREGATOR` with the appropriate casing of the new program name
-- Replace the program ID string with the new program address
-- Replace `"DFlow Aggregator"` display strings with `{display_name}`
-- Replace IDL file reference: `include_str!("{snake_name}.json")`
-- Keep the `kind()` method returning the user's chosen `VisualizerKind` variant with `display_name` as the `&'static str` argument
-
-**Generic IDL pattern only:**
-- The generic scaffold uses the three helpers `dflow_aggregator` defines: `build_named_accounts`, `build_parsed_fields`, and `build_fallback_fields`. All three work with any IDL.
-- Two additional helpers — `append_raw_data` (for byte-blob args) and `format_arg_value` (for custom scalar rendering) — are not present in `dflow_aggregator`. Add them when the target IDL needs them, copying the pattern from another preset such as `kamino_vault` or `jupiter_earn`.
-- The parse function should: check `data.len() < 8`, load IDL, call `parse_instruction_with_idl`, call `build_named_accounts`, return a struct with parsed data + named accounts
-
-**Visualizer body must use the wire-data context API.** At the top of `visualize_tx_commands`:
-```rust
-let program_id = context.resolve_program_id()?.to_string();
-let accounts = context.resolve_accounts()?;
-let data = context.data();
-```
-
-These three accessors replace the old `context.current_instruction()`. They surface
-unresolved indices as `Err(VisualSignError::DecodeError(...))` with the bad index
-named, instead of returning a generic "no instruction found" failure. Use
-`context.instruction_index()` for any "Instruction N" labels.
-
-**Required imports** (at top of module, NOT inside functions):
-```rust
-use crate::core::{
-    InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext, VisualizerKind,
-};
-use config::{PascalName}Config;
-use solana_parser::{
-    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
-};
-use solana_sdk::instruction::AccountMeta;
-use std::collections::BTreeMap;
-use std::sync::OnceLock;
-use visualsign::errors::VisualSignError;
-use visualsign::field_builders::{create_raw_data_field, create_text_field};
-use visualsign::{
-    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
-    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
-};
-```
-
-`BTreeMap` (not `HashMap`) keeps the rendered named-accounts order deterministic.
-
-**Required tests** (in `#[cfg(test)] mod tests`):
-- `test_{snake_name}_idl_loads` — IDL loads and has instructions
-- `test_{snake_name}_idl_has_discriminators` — every instruction has an 8-byte discriminator
-- `test_unknown_discriminator_returns_error` — garbage 9-byte data returns error
-- `test_short_data_returns_error` — 3-byte data returns error
-
-## Step 4: Register in presets/mod.rs
-
-Add `pub mod {snake_name};` to `src/chain_parsers/visualsign-solana/src/presets/mod.rs`.
-
-**Keep entries in alphabetical order.** The existing entries are sorted — insert the new module in the correct position.
-
-No other registration is needed. `build.rs` auto-discovers `{PascalName}Visualizer` from any directory under `src/presets/`.
-
-## Step 5: Code Quality
-
-Follow these rules in all generated code:
-- `use` statements at top of module, never inside functions
-- Inline format strings: `format!("{variable}")` not `format!("{}", variable)`
-- Use `create_text_field` and `create_raw_data_field` from `visualsign::field_builders` — never construct field structs directly
-- For raw-data fields, pass `None` as the second arg of `create_raw_data_field` unless you already have a precomputed hex string to reuse (e.g. one you built for `fallback_text`). Do not call `hex::encode(data)` solely to populate this arg — the helper falls back to the same lowercase byte-by-byte hex on `None`.
-- ASCII only in user-visible strings: `>=` not `≥`, `->` not `→`
-- Rust edition 2024 on nightly
-
-## Step 6: Verify
-
-Run these commands and fix any issues:
-
-```bash
-cargo fmt -p visualsign-solana
-cargo clippy -p visualsign-solana --all-targets -- -D warnings
-cargo clippy -p visualsign-solana --features diagnostics --all-targets -- -D warnings
-cargo test -p visualsign-solana
-cargo test -p visualsign-solana --features diagnostics
-make -C src test
-```
-
-All must pass before the task is complete. Both feature configurations
-(diagnostics on and off) need to compile and test cleanly because parser_app
-builds without `diagnostics` while parser_cli builds with it.


### PR DESCRIPTION
## Summary

- Restructures `solana-add-idl` into two phases so the model is hard-enforced at the API layer rather than advisory
- Orchestrator phase (session model): gathers program address, name, and VisualizerKind interactively from the user
- Subagent phase (`model: "sonnet"` in the Agent dispatch call): fetches IDL, scaffolds all files, registers the preset, and verifies

The `model:` frontmatter field is advisory only — the subagent dispatch with an explicit model parameter is the only mechanism that actually enforces a specific model independent of the user's active session model.

Closes #397

## Test plan

- [ ] Invoke `/solana-add-idl` and confirm scaffolding subagent runs on Sonnet
- [ ] Confirm generated `config.rs`, `mod.rs`, and tests match expected codebase patterns
- [ ] Confirm both diagnostics feature flag configurations compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)