### PR TITLE
fix(ethereum): accept unsigned ABI mappings instead of dropping them

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -110,24 +110,16 @@ pub fn try_extract_from_chain_metadata(
         // regardless. An entry that DOES carry a signature must still validate,
         // since a present-but-invalid signature signals tampering rather than
         // simply an unsigned source.
-        match abi.signature.as_ref() {
-            Some(proto_sig) => {
-                let signature = convert_proto_signature(proto_sig);
-                if let Err(e) = validate_abi_signature(
-                    &abi.value,
-                    &parsed_address,
-                    chain_id,
-                    &signature,
-                    allowlist,
-                ) {
-                    log::warn!(
-                        "Skipping ABI mapping for '{address}': signature validation failed: {e}"
-                    );
-                    continue;
-                }
-            }
-            None => {
-                unsigned_count += 1;
+        let is_unsigned = abi.signature.is_none();
+        if let Some(proto_sig) = abi.signature.as_ref() {
+            let signature = convert_proto_signature(proto_sig);
+            if let Err(e) =
+                validate_abi_signature(&abi.value, &parsed_address, chain_id, &signature, allowlist)
+            {
+                log::warn!(
+                    "Skipping ABI mapping for '{address}': signature validation failed: {e}"
+                );
+                continue;
             }
         }
 
@@ -146,6 +138,9 @@ pub fn try_extract_from_chain_metadata(
                     abi_kind,
                     implementation,
                 );
+                if is_unsigned {
+                    unsigned_count += 1;
+                }
             }
             Err(e) => {
                 log::warn!("Skipping ABI mapping for '{address}': {e}");

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -37,11 +37,13 @@ enum AbiSignatureError {
 ///
 /// # Security notes
 ///
-/// - **Unsigned ABIs are accepted, but flagged.** Not every caller signs its ABI
-///   mappings yet, so an entry with `signature: None` is registered rather than
-///   dropped; a warning is logged noting the ABI is unverified. This is acceptable
-///   because the whole caller-supplied ABI path is display-only and untrusted
-///   regardless of signature status (see below).
+/// - **Unsigned ABIs are accepted, but logged as unverified.** Not every caller
+///   signs its ABI mappings yet, so an entry with `signature: None` is registered
+///   rather than dropped; unsigned entries are counted and reported in a single
+///   aggregated warning once per request (no per-entry flag or marker is stored
+///   in the registry). This is acceptable because the whole caller-supplied ABI
+///   path is display-only and untrusted regardless of signature status (see
+///   below).
 /// - **When present, a signature is validated**, using secp256k1 over a
 ///   domain-separated prehash that binds the chain id and the contract address to
 ///   the ABI JSON (see [`visualsign::signing::ethereum_metadata_prehash`]). An entry

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -85,6 +85,7 @@ pub fn try_extract_from_chain_metadata(
     }
 
     let mut registry = AbiRegistry::new();
+    let mut unsigned_count: usize = 0;
     for (address, abi) in &ethereum.abi_mappings {
         // Validate address first (cheap) before expensive signature/ABI operations
         let parsed_address = match address.parse::<alloy_primitives::Address>() {
@@ -126,9 +127,7 @@ pub fn try_extract_from_chain_metadata(
                 }
             }
             None => {
-                log::warn!(
-                    "Accepting unsigned ABI mapping for '{address}': integrity/provenance unverified"
-                );
+                unsigned_count += 1;
             }
         }
 
@@ -152,6 +151,11 @@ pub fn try_extract_from_chain_metadata(
                 log::warn!("Skipping ABI mapping for '{address}': {e}");
             }
         }
+    }
+    if unsigned_count > 0 {
+        log::warn!(
+            "Accepted {unsigned_count} unsigned ABI mapping(s): integrity/provenance unverified"
+        );
     }
     if registry.list_abis().is_empty() {
         return None;
@@ -988,7 +992,7 @@ mod tests {
     /// present-but-invalid signature is a stronger signal of tampering than
     /// simply omitting one, so it must not be downgraded to "accept and log".
     #[test]
-    fn test_try_extract_invalid_signature_still_rejected() {
+    fn test_try_extract_unauthorized_signer_still_rejected() {
         // `signed_abi` signs with seed 0x42, so pass an allowlist that only
         // authorizes seed 0x43: the signature verifies but the signer is
         // unauthorized (mirrors `validate_abi_signature_rejects_unlisted_signer`).

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -37,15 +37,17 @@ enum AbiSignatureError {
 ///
 /// # Security notes
 ///
-/// - **Unsigned ABIs are rejected.** Every ABI mapping must carry a signature;
-///   entries with `signature: None` are skipped with a warning. Without this check,
-///   a wallet could supply any ABI for any address and dictate the human-readable
-///   rendering of the call.
-/// - **Every accepted entry's signature is validated**, using secp256k1 over a
+/// - **Unsigned ABIs are accepted, but flagged.** Not every caller signs its ABI
+///   mappings yet, so an entry with `signature: None` is registered rather than
+///   dropped; a warning is logged noting the ABI is unverified. This is acceptable
+///   because the whole caller-supplied ABI path is display-only and untrusted
+///   regardless of signature status (see below).
+/// - **When present, a signature is validated**, using secp256k1 over a
 ///   domain-separated prehash that binds the chain id and the contract address to
-///   the ABI JSON (see [`visualsign::signing::ethereum_metadata_prehash`]). Since
-///   unsigned entries are rejected above, no ABI reaches the registry without a
-///   verified signature.
+///   the ABI JSON (see [`visualsign::signing::ethereum_metadata_prehash`]). An entry
+///   that carries a signature but fails validation (bad signature, or signer not in
+///   the allowlist) is still rejected outright: a present-but-invalid signature is a
+///   stronger signal of tampering than simply omitting one.
 /// - **Signatures bind chain id + contract address.** The prehash commits to the
 ///   resolved `chain_id` and the entry's map-key address, so a signature minted for
 ///   an ABI at one (chain, address) no longer verifies when replayed under a
@@ -102,21 +104,32 @@ pub fn try_extract_from_chain_metadata(
             continue;
         }
 
-        // Reject unsigned ABI entries unconditionally. Allowing
-        // signature: None would let a wallet supply arbitrary ABIs for any
-        // address and steer the human-readable rendering of the call.
-        let Some(proto_sig) = abi.signature.as_ref() else {
-            log::warn!(
-                "Skipping ABI mapping for '{address}': missing signature (unsigned ABI entries are rejected)"
-            );
-            continue;
-        };
-        let signature = convert_proto_signature(proto_sig);
-        if let Err(e) =
-            validate_abi_signature(&abi.value, &parsed_address, chain_id, &signature, allowlist)
-        {
-            log::warn!("Skipping ABI mapping for '{address}': signature validation failed: {e}");
-            continue;
+        // Signatures aren't required to register an entry: not every caller signs
+        // its ABI mappings yet, and this whole path is display-only and untrusted
+        // regardless. An entry that DOES carry a signature must still validate,
+        // since a present-but-invalid signature signals tampering rather than
+        // simply an unsigned source.
+        match abi.signature.as_ref() {
+            Some(proto_sig) => {
+                let signature = convert_proto_signature(proto_sig);
+                if let Err(e) = validate_abi_signature(
+                    &abi.value,
+                    &parsed_address,
+                    chain_id,
+                    &signature,
+                    allowlist,
+                ) {
+                    log::warn!(
+                        "Skipping ABI mapping for '{address}': signature validation failed: {e}"
+                    );
+                    continue;
+                }
+            }
+            None => {
+                log::warn!(
+                    "Accepting unsigned ABI mapping for '{address}': integrity/provenance unverified"
+                );
+            }
         }
 
         // Determine the kind of contract this ABI describes. An unset or
@@ -385,8 +398,8 @@ pub const CLI_DEV_SIGNING_KEY_SEED: [u8; 32] = [0x42u8; 32];
 /// `SignatureMetadata` ready to drop into `Abi.signature`.
 ///
 /// Used by the CLI to attach an integrity signature to locally-loaded ABI files so
-/// the metadata-ABI extraction path (which rejects unsigned entries) can
-/// register them. The signature is over the domain-separated prehash that binds the
+/// the metadata-ABI extraction path can register them as verified rather than
+/// unsigned. The signature is over the domain-separated prehash that binds the
 /// `chain_id` and contract `address` to `abi_json` (see
 /// [`visualsign::signing::ethereum_metadata_prehash`]), so it is valid only for the
 /// exact (chain, address) it was produced for, matching the verifier in
@@ -907,12 +920,11 @@ mod tests {
         );
     }
 
-    /// Regression: an ABI mapping that omits the signature must be rejected,
-    /// even when the address and ABI JSON are otherwise valid. Without this check a
-    /// wallet could supply arbitrary ABIs for any address and dictate the parsed
-    /// payload rendering.
+    /// An ABI mapping that omits the signature is still registered: not every
+    /// caller signs its ABI mappings yet, and this whole path is display-only and
+    /// untrusted regardless of signature status.
     #[test]
-    fn test_try_extract_unsigned_abi_rejected() {
+    fn test_try_extract_unsigned_abi_accepted() {
         let metadata = ChainMetadata {
             metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
                 network_id: Some("ETHEREUM_MAINNET".to_string()),
@@ -928,9 +940,74 @@ mod tests {
                 .collect(),
             })),
         };
+        let registry =
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
+                .expect("unsigned ABI entries must still be registered");
+        assert!(registry.list_abis().contains(&TEST_ADDRESS));
+    }
+
+    /// Mixed signed and unsigned entries: neither one blocks the other. The signed
+    /// entry is verified, the unsigned entry is accepted unverified, and both end
+    /// up in the registry.
+    #[test]
+    fn test_try_extract_mixed_signed_and_unsigned_both_accepted() {
+        let unsigned_address = "0x3333333333333333333333333333333333333333";
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![
+                    (
+                        unsigned_address,
+                        Abi {
+                            value: VALID_ABI.to_string(),
+                            signature: None,
+                            ..Default::default()
+                        },
+                    ),
+                    (TEST_ADDRESS, signed_abi(VALID_ABI, TEST_ADDRESS)),
+                ])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let registry =
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
+                .expect("should contain both entries");
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist()).is_none(),
-            "unsigned ABI entries must be rejected"
+            registry.list_abis().contains(&unsigned_address),
+            "unsigned entry must be registered alongside the signed one"
+        );
+        assert!(
+            registry.list_abis().contains(&TEST_ADDRESS),
+            "signed entry must still be registered"
+        );
+    }
+
+    /// An entry that DOES carry a signature but fails validation (signer not on
+    /// the allowlist) is still rejected outright, unlike a missing signature. A
+    /// present-but-invalid signature is a stronger signal of tampering than
+    /// simply omitting one, so it must not be downgraded to "accept and log".
+    #[test]
+    fn test_try_extract_invalid_signature_still_rejected() {
+        // `signed_abi` signs with seed 0x42, so pass an allowlist that only
+        // authorizes seed 0x43: the signature verifies but the signer is
+        // unauthorized (mirrors `validate_abi_signature_rejects_unlisted_signer`).
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    TEST_ADDRESS,
+                    signed_abi(VALID_ABI, TEST_ADDRESS),
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let mut unlisted_allow = SignerAllowlist::new();
+        unlisted_allow.insert(pubkey_bytes_from_seed(&[0x43u8; 32]));
+        assert!(
+            try_extract_from_chain_metadata(Some(&metadata), 1, &unlisted_allow).is_none(),
+            "a signature present but failing validation must still be rejected"
         );
     }
 
@@ -1180,5 +1257,53 @@ mod tests {
                 .get_abi_for_address(1, parse_addr(PROXY_ADDRESS))
                 .is_some()
         );
+    }
+
+    /// End-to-end regression for the reported bug: an UNSIGNED proxy entry
+    /// pointing at an UNSIGNED implementation entry must still resolve and
+    /// register both, so the implementation ABI is available for decoding.
+    /// Previously, omitting `signature` on either entry caused it to be
+    /// dropped outright, silently breaking proxy resolution.
+    #[test]
+    fn test_extract_unsigned_proxy_links_to_unsigned_implementation() {
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![
+                    (
+                        PROXY_ADDRESS,
+                        Abi {
+                            value: "[]".to_string(),
+                            signature: None,
+                            abi_type: Some(generated::parser::AbiType::Proxy as i32),
+                            implementation_address: Some(IMPL_ADDRESS.to_string()),
+                        },
+                    ),
+                    (
+                        IMPL_ADDRESS,
+                        Abi {
+                            value: VALID_ABI.to_string(),
+                            signature: None,
+                            ..Default::default()
+                        },
+                    ),
+                ])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let registry =
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
+                .expect("has ABIs, even though neither entry is signed");
+
+        assert_eq!(
+            registry.get_abi_kind(1, parse_addr(PROXY_ADDRESS)),
+            Some(AbiKind::Proxy)
+        );
+        let (impl_addr, impl_abi) = registry
+            .get_implementation_abi(1, parse_addr(PROXY_ADDRESS))
+            .expect("unsigned proxy must still resolve to its unsigned implementation");
+        assert_eq!(impl_addr, parse_addr(IMPL_ADDRESS));
+        assert!(impl_abi.functions().any(|f| f.name == "transfer"));
     }
 }

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -109,10 +109,13 @@ fn build_abi_mappings_from_files(
         |components, json| {
             // The metadata-ABI extraction path accepts unsigned entries too, but the
             // CLI attaches an integrity signature using a deterministic local dev key
-            // so locally-loaded ABIs extract as verified rather than flagged unsigned.
-            // This is integrity, not identity, the CLI is a local dev tool that
-            // already trusts its input files; production trust comes from the gRPC
-            // caller verifying the public key against an allowlist.
+            // so locally-loaded ABIs extract as verified rather than logged as
+            // unverified. This is integrity, not identity, the CLI is a local dev tool
+            // that already trusts its input files; production trust comes from the
+            // service running the parser, which validates the signature and checks the
+            // signer's public key against an allowlist during extraction (see
+            // `abi_metadata::try_extract_from_chain_metadata`), not from the gRPC
+            // caller.
             //
             // The signature binds the contract address and chain id, so it must be
             // produced for the same (chain, address) the parser verifies with. The
@@ -198,7 +201,7 @@ fn apply_proxy_mappings(
 
         // Ensure the proxy has an entry to stamp. If it has no own ABI file, synthesize
         // an empty "[]" ABI, signed with the same dev key used for file-loaded ABIs so
-        // it extracts as verified rather than flagged unsigned.
+        // it extracts as verified rather than logged as unverified.
         if !abi_mappings.contains_key(&proxy_key) {
             if attempted_abi_addresses.contains(&proxy_key) {
                 eprintln!(
@@ -403,7 +406,7 @@ mod tests {
             .expect("mapping present");
         assert!(abi.value.contains("swap"));
         // CLI signs locally-loaded ABIs so they extract as verified rather than
-        // flagged unsigned by the metadata-ABI extractor.
+        // logged as unverified by the metadata-ABI extractor.
         assert!(
             abi.signature.is_some(),
             "CLI should attach a dev-key signature to locally-loaded ABIs"

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -107,11 +107,12 @@ fn build_abi_mappings_from_files(
         "ContractAddress",
         validate_eth_address,
         |components, json| {
-            // The metadata-ABI extraction path rejects unsigned entries,
-            // so the CLI attaches an integrity signature using a deterministic local
-            // dev key. This is integrity, not identity, the CLI is a local dev tool
-            // that already trusts its input files; production trust comes from the
-            // gRPC caller verifying the public key against an allowlist.
+            // The metadata-ABI extraction path accepts unsigned entries too, but the
+            // CLI attaches an integrity signature using a deterministic local dev key
+            // so locally-loaded ABIs extract as verified rather than flagged unsigned.
+            // This is integrity, not identity, the CLI is a local dev tool that
+            // already trusts its input files; production trust comes from the gRPC
+            // caller verifying the public key against an allowlist.
             //
             // The signature binds the contract address and chain id, so it must be
             // produced for the same (chain, address) the parser verifies with. The
@@ -122,7 +123,7 @@ fn build_abi_mappings_from_files(
             // If parsing or signing fails (e.g. an invalid seed in future refactors),
             // surface the failure as a `load_mappings` rejection so the entry is
             // skipped and the success count stays accurate, rather than emitting an
-            // `Abi` that the extractor would silently drop later.
+            // `Abi` the extractor would register as unverified instead of signed.
             let addr = components
                 .identifier
                 .parse::<alloy_primitives::Address>()
@@ -196,10 +197,8 @@ fn apply_proxy_mappings(
         let impl_key = normalize_eth_address(implementation);
 
         // Ensure the proxy has an entry to stamp. If it has no own ABI file, synthesize
-        // an empty "[]" ABI. The metadata-ABI extraction path rejects unsigned entries,
-        // so the synthesized ABI is signed with the same dev key used for file-loaded
-        // ABIs; otherwise the extractor would silently drop the proxy and the
-        // proxy->implementation link would be lost.
+        // an empty "[]" ABI, signed with the same dev key used for file-loaded ABIs so
+        // it extracts as verified rather than flagged unsigned.
         if !abi_mappings.contains_key(&proxy_key) {
             if attempted_abi_addresses.contains(&proxy_key) {
                 eprintln!(
@@ -403,8 +402,8 @@ mod tests {
             .get("0xdac17f958d2ee523a2206206994597c13d831ec7")
             .expect("mapping present");
         assert!(abi.value.contains("swap"));
-        // CLI signs locally-loaded ABIs so the metadata-ABI extractor
-        // (which rejects unsigned entries) can register them.
+        // CLI signs locally-loaded ABIs so they extract as verified rather than
+        // flagged unsigned by the metadata-ABI extractor.
         assert!(
             abi.signature.is_some(),
             "CLI should attach a dev-key signature to locally-loaded ABIs"
@@ -520,17 +519,16 @@ mod tests {
         assert_eq!(proxy_abi.value, "[]");
         assert_eq!(proxy_abi.abi_type, Some(AbiType::Proxy as i32));
         assert_eq!(proxy_abi.implementation_address.as_deref(), Some(IMPL));
-        // Regression guard: the synthesized proxy ABI must be signed. The
-        // metadata-ABI extraction path rejects unsigned entries, so an unsigned
-        // synthesized proxy would be silently dropped and the proxy->impl link lost.
+        // Regression guard: the CLI still signs the synthesized proxy ABI so it
+        // extracts as verified, even though the extractor now also accepts
+        // unsigned entries.
         assert!(
             proxy_abi.signature.is_some(),
-            "synthesized proxy ABI must be signed so the extractor accepts it",
+            "synthesized proxy ABI must be signed so the extractor treats it as verified",
         );
 
         // End-to-end: the signed synthesized proxy survives extraction. `list_abis`
-        // returns each registered entry's address string; the proxy being present
-        // proves it cleared the unsigned-rejection gate.
+        // returns each registered entry's address string.
         let extracted = ChainMetadata {
             metadata: Some(Metadata::Ethereum(eth)),
         };
@@ -544,7 +542,7 @@ mod tests {
         .expect("metadata with a signed synthesized proxy must extract");
         assert!(
             registry.list_abis().contains(&PROXY),
-            "signed synthesized proxy must survive extraction (unsigned would be dropped)",
+            "signed synthesized proxy must survive extraction",
         );
     }
 

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -885,8 +885,9 @@ mod tests {
     }
 
     /// Build a signed `Abi` for tests that exercise the metadata-ABI extraction
-    /// path, which rejects unsigned entries. Proxy entries layer `abi_type` and
-    /// `implementation_address` on top via struct-update (`..signed_abi(...)`).
+    /// path as a verified entry (the path also accepts unsigned entries, but
+    /// flags them). Proxy entries layer `abi_type` and `implementation_address`
+    /// on top via struct-update (`..signed_abi(...)`).
     ///
     /// The signature is bound to `address` (the map key the entry is stored under)
     /// on chain 1, matching what the converter verifies: it resolves chain_id from

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -886,8 +886,9 @@ mod tests {
 
     /// Build a signed `Abi` for tests that exercise the metadata-ABI extraction
     /// path as a verified entry (the path also accepts unsigned entries, but
-    /// flags them). Proxy entries layer `abi_type` and `implementation_address`
-    /// on top via struct-update (`..signed_abi(...)`).
+    /// logs them as unverified via a single aggregated warning; no per-entry
+    /// flag is stored in the registry). Proxy entries layer `abi_type` and
+    /// `implementation_address` on top via struct-update (`..signed_abi(...)`).
     ///
     /// The signature is bound to `address` (the map key the entry is stored under)
     /// on chain 1, matching what the converter verifies: it resolves chain_id from


### PR DESCRIPTION
## Why am I making this PR?

`try_extract_from_chain_metadata` previously rejected any ABI mapping with `signature: None` unconditionally. That meant an unsigned proxy entry pointing at an unsigned implementation entry was silently dropped during extraction, breaking proxy resolution entirely: neither the proxy nor its implementation ABI ended up in the registry.

Not every caller signs its ABI mappings today. The original guard was stricter than needed because the entire caller-supplied ABI path is display-only and untrusted regardless of signature status, so the right behavior is to accept unsigned entries (with a warning) rather than drop them.

## What am I changing?

- `src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs`: changes the unsigned-entry handling from "reject and skip" to "accept and log a warning". A signature that IS present must still validate (present-but-invalid is still a hard reject, not a downgrade to unsigned). Updates doc comments, the `make_dev_abi_signature` doc, and four tests:
  - `test_try_extract_unsigned_abi_rejected` renamed to `test_try_extract_unsigned_abi_accepted` with inverted assertion
  - new `test_try_extract_mixed_signed_and_unsigned_both_accepted` covering coexistence
  - new `test_try_extract_unauthorized_signer_still_rejected` confirming a signature that verifies but comes from a signer not on the allowlist still hard-fails (malformed/invalid signature bytes are already covered at the `validate_abi_signature` unit level by `test_invalid_signature_hex`)
  - new `test_extract_unsigned_proxy_links_to_unsigned_implementation` as an end-to-end regression for the reported bug

- `src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs`: updates comments in `build_abi_mappings_from_files` and `apply_proxy_mappings` to reflect the new behavior (CLI still signs locally-loaded ABIs so they extract as verified rather than flagged), and updates test assertions/comments accordingly.

- `src/chain_parsers/visualsign-ethereum/src/lib.rs`: updates a doc comment on the `signed_abi` test helper to match.

## What is the Linear ticket?

N/A for this fix itself. Follow-up tracked in [PRS-555](https://linear.app/anchorlabs/issue/PRS-555/propagate-unsignedverified-status-of-caller-supplied-abi-mappings-into), see Security tradeoff section below.

## Security tradeoff (please read before approving)

This PR deliberately widens a trust boundary and I want reviewers to sign off on it explicitly, not just skim past it:

- `ChainMetadata.abi_mappings` is caller-supplied per gRPC request (`src/parser/app/src/routes/parse.rs`, `metadata: parse_request.chain_metadata.clone()`). It is not vetted internal infra, it comes straight from whoever calls the parser.
- Before this PR, an ABI mapping without a signature was rejected outright. After this PR, it is accepted and only a `log::warn!` is emitted (server-side log, never seen by the person signing).
- `AbiRegistry` has no verified/unverified field. A decode backed by an unsigned ABI is indistinguishable, in the rendered output, from one backed by a signature-verified ABI. There is currently no way for the signer to tell the difference.
- Net effect: a malicious or compromised caller can supply an unsigned ABI that mislabels a call (e.g. render a `transfer` as something benign-sounding), and the signer sees no visual difference from a vetted decode.

This tradeoff was raised with and explicitly accepted by the repo owner before this PR was opened, on the basis that the actual security boundary is the raw signed transaction bytes verified elsewhere, and this path only affects display. All review passes (security audit, deep-review, pr-review) independently converged on flagging this same point and treating it as the intended, tested behavior of this diff rather than a fresh bug.

The concrete follow-up several reviewers converged on: propagate a verified/unverified flag from `AbiRegistry` into the rendered `SignablePayload` so a signer can actually see when a decode is unverified. That is tracked as a separate Linear ticket rather than blocking this fix, since this PR's scope is the proxy-resolution bug.

## What are the rollback steps?

Revert commit `ca1716f`. No config, proto, or schema changes; it is a pure logic change in one crate. Rolling back restores the strict "reject unsigned" behavior. Any callers that rely on unsigned ABI mappings reaching the registry would stop working again, but that was already broken before this PR.

## Is this change backwards compatible?

Yes. The change is strictly more permissive on input: entries that were previously silently dropped are now accepted. Signed entries behave identically. The registry's public interface is unchanged.

## Does this require cross-team/service coordination?

No.

## How do I know it works as designed? Which tests exercise this code?

Four tests in `src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs` directly cover the new behavior:

- `test_try_extract_unsigned_abi_accepted` confirms a lone unsigned entry is registered.
- `test_try_extract_mixed_signed_and_unsigned_both_accepted` confirms signed and unsigned entries coexist without interfering.
- `test_try_extract_unauthorized_signer_still_rejected` confirms a signature that verifies but whose signer is not on the allowlist is still a hard reject (malformed signature bytes are covered separately at the `validate_abi_signature` layer by `test_invalid_signature_hex`).
- `test_extract_unsigned_proxy_links_to_unsigned_implementation` is the direct regression for the reported bug: an unsigned proxy pointing at an unsigned implementation resolves correctly and both end up in the registry.

Run with:

```
cargo test -p visualsign-ethereum
```


