### PR TITLE
fix(visualsign): allow embedded JSON escapes in charset validation (PRS-572)

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/dflow_aggregator/mod.rs
@@ -230,11 +230,15 @@ fn build_fallback_fields(
 ///    array such as `RecordId.id` (76 bytes) would otherwise blow up into 76
 ///    per-byte fields and bury the meaningful arguments (`quoted_out_amount`,
 ///    `slippage_bps`, ...). See `test_format_arg_value_does_not_blow_up_nested_fields`.
-/// 2. **Charset safety.** `SignablePayload::validate_charset` rejects the `\"`
-///    JSON escape (see #332). Real compact JSON of an object contains quoted
-///    keys, which serialize to `\"` and fail validation. Emitting quote-free
-///    output keeps the whole payload charset-valid. See
-///    `test_format_arg_value_is_charset_safe`.
+/// 2. **Charset safety (historical).** `SignablePayload::validate_charset`
+///    used to reject the `\"` / `\\` JSON escapes (see #332), so real compact
+///    JSON of an object -- with its quoted keys -- would fail validation.
+///    Quote-free output was required to keep the payload charset-valid.
+///    PRS-572 relaxed that deny-list to allow `\"` / `\\` (both decode to
+///    already-permitted printable-ASCII bytes), so quote-free rendering is no
+///    longer *required* here -- it's kept anyway for reason 1 above (no field
+///    explosion) and to avoid a behavior change to this preset's existing,
+///    already-tested output. See `test_format_arg_value_is_charset_safe`.
 ///
 /// Arrays whose elements are all byte-sized integers (0..=255) -- e.g. a
 /// `[u8; 32]` market id or the 76-byte `RecordId.id` -- render as a single
@@ -268,12 +272,15 @@ fn format_arg_value(value: &serde_json::Value) -> String {
     }
 }
 
-/// Drop characters from a leaf string/key that would otherwise force a forbidden
-/// JSON escape and make `SignablePayload::validate_charset` reject the payload:
-/// `"` and `\` (both ASCII-graphic, so excluded explicitly), plus tabs, carriage
-/// returns, other control bytes, and non-ASCII. Keeps printable ASCII + spaces.
-/// IDL strings here (pubkeys, enum names) are already clean; this is a defensive
-/// guard so the function's charset-safe contract always holds.
+/// Drop characters from a leaf string/key that would break this preset's
+/// quote-free rendering contract or (still, post-PRS-572) trip
+/// `SignablePayload::validate_charset`: `"` and `\` are stripped to preserve
+/// the quote-free format described in `format_arg_value` above (no longer
+/// required for charset safety itself -- see that comment), while tabs,
+/// carriage returns, other control bytes, and non-ASCII are stripped because
+/// `validate_charset` still forbids them. Keeps printable ASCII + spaces.
+/// IDL strings here (pubkeys, enum names) are already clean; this is a
+/// defensive guard so the function's charset-safe contract always holds.
 fn charset_safe(text: &str) -> String {
     text.chars()
         .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\'))
@@ -404,10 +411,12 @@ mod tests {
 
     #[test]
     fn test_format_arg_value_is_charset_safe() {
-        // SignablePayload::validate_charset rejects the `\"` and `\\` JSON
-        // escapes (#332). Real compact JSON of an object would emit quoted keys
-        // (-> `\"`) and fail. Our quote-free rendering must contain neither `"`
-        // nor `\` so the whole payload stays charset-valid end to end.
+        // Historically SignablePayload::validate_charset rejected the `\"`
+        // and `\\` JSON escapes (#332), so real compact JSON of an object --
+        // with quoted keys -- would fail. PRS-572 relaxed that deny-list, but
+        // this preset still deliberately renders quote-free (see
+        // `format_arg_value`'s doc comment), so this pins that our rendering
+        // continues to contain neither `"` nor `\`.
         let nested = json!({
             "actions": [{"RecordId": [{"id": (0u8..76).collect::<Vec<u8>>()}]}],
             "quoted_out_amount": 68_980_730u64,
@@ -421,9 +430,11 @@ mod tests {
 
     #[test]
     fn test_format_arg_value_sanitizes_string_values_and_keys() {
-        // Leaf strings and object keys that contain charset-forbidden characters
-        // (`"`, `\`, tab, CR, control bytes) are stripped so the payload always
-        // passes validate_charset, never silently rejected.
+        // Leaf strings and object keys have `"`/`\` stripped to preserve this
+        // preset's quote-free rendering contract (no longer required by
+        // validate_charset itself post-PRS-572, see format_arg_value's doc
+        // comment), and tab/CR/other control bytes stripped because
+        // validate_charset still forbids those.
         assert_eq!(format_arg_value(&json!("a\"b\\c\td")), "abcd");
         let object = format_arg_value(&json!({"a\"b": "x\\y"}));
         assert!(
@@ -463,7 +474,9 @@ mod tests {
         let value = parsed.program_call_args.get("params").unwrap();
         let now = format_arg_value(value);
 
-        // Charset-safe (the pre-#286 compact JSON would fail validate_charset).
+        // Charset-safe (the pre-#286 compact JSON would have failed the
+        // stricter pre-PRS-572 validate_charset; this preset still renders
+        // quote-free by choice, see format_arg_value's doc comment).
         assert!(
             !now.contains('"') && !now.contains('\\'),
             "not charset-safe: {now}"

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/mod.rs
@@ -234,4 +234,6 @@ mod tests {
         let result = parse_orca_whirlpool_instruction(&short, &accounts);
         assert!(result.is_err(), "Short data should return an error");
     }
+
+    mod fixture_tests;
 }

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/tests/fixture_tests.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/tests/fixture_tests.rs
@@ -133,6 +133,15 @@ fn test_increase_liquidity_by_token_amounts_v2_real_transaction() {
         let expected_str = expected_value
             .as_str()
             .unwrap_or_else(|| panic!("Expected field '{key}' is not a string"));
+        // `serde_json::Map`'s key order isn't guaranteed stable across builds
+        // (depends on whether the `preserve_order` feature gets pulled in
+        // transitively by whatever else is compiled alongside this crate), so
+        // an embedded-JSON arg like `method` can render with its object keys
+        // in a different order without the underlying value actually
+        // changing. Compare structurally (as serde_json::Value, which is
+        // order-independent for objects) when both sides parse as JSON;
+        // fall back to plain string equality otherwise.
+        let expected_json: Option<serde_json::Value> = serde_json::from_str(expected_str).ok();
 
         let found = expanded.fields.iter().any(|field| {
             let SignablePayloadField::TextV2 { common, text_v2 } = &field.signable_payload_field
@@ -140,7 +149,14 @@ fn test_increase_liquidity_by_token_amounts_v2_real_transaction() {
                 return false;
             };
             let label_normalized = common.label.to_lowercase().replace(' ', "_");
-            label_normalized == key.to_lowercase() && text_v2.text == expected_str
+            if label_normalized != key.to_lowercase() {
+                return false;
+            }
+            match &expected_json {
+                Some(expected_value) => serde_json::from_str::<serde_json::Value>(&text_v2.text)
+                    .is_ok_and(|actual_value| actual_value == *expected_value),
+                None => text_v2.text == expected_str,
+            }
         });
 
         assert!(

--- a/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/tests/fixture_tests.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/orca_whirlpool/tests/fixture_tests.rs
@@ -1,0 +1,164 @@
+// Fixture-based tests for Orca Whirlpool instruction parsing
+// See /src/chain_parsers/visualsign-solana/TESTING.md for documentation
+//
+// This file is wired into `mod tests` (mod.rs) via `mod fixture_tests;`.
+
+use super::*;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+};
+use std::str::FromStr;
+use visualsign::{SignablePayload, SignablePayloadField};
+
+#[derive(Debug, serde::Deserialize)]
+struct TestFixture {
+    #[allow(dead_code)]
+    description: String,
+    #[allow(dead_code)]
+    source: String,
+    #[allow(dead_code)]
+    signature: String,
+    #[allow(dead_code)]
+    cluster: String,
+    #[allow(dead_code)]
+    full_transaction_note: Option<String>,
+    #[allow(dead_code)]
+    instruction_index: usize,
+    instruction_data: String,
+    program_id: String,
+    accounts: Vec<TestAccount>,
+    expected_fields: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct TestAccount {
+    pubkey: String,
+    signer: bool,
+    writable: bool,
+    #[allow(dead_code)]
+    description: String,
+}
+
+fn load_fixture(name: &str) -> TestFixture {
+    let fixture_path = format!(
+        "{}/tests/fixtures/orca_whirlpool/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
+    let fixture_content = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|e| panic!("Failed to read fixture {fixture_path}: {e}"));
+    serde_json::from_str(&fixture_content)
+        .unwrap_or_else(|e| panic!("Failed to parse fixture {fixture_path}: {e}"))
+}
+
+fn create_instruction_from_fixture(fixture: &TestFixture) -> Instruction {
+    let program_id = Pubkey::from_str(&fixture.program_id).unwrap();
+    let accounts: Vec<AccountMeta> = fixture
+        .accounts
+        .iter()
+        .map(|acc| {
+            let pubkey = Pubkey::from_str(&acc.pubkey).unwrap();
+            AccountMeta {
+                pubkey,
+                is_signer: acc.signer,
+                is_writable: acc.writable,
+            }
+        })
+        .collect();
+
+    // Instruction data from JSON RPC responses is base58 encoded.
+    let data = bs58::decode(&fixture.instruction_data)
+        .into_vec()
+        .expect("Failed to decode base58 instruction data");
+
+    Instruction {
+        program_id,
+        accounts,
+        data,
+    }
+}
+
+/// PRS-572 regression: `increase_liquidity_by_token_amounts_v2`'s `method` arg
+/// is a struct rendered via `serde_json::Value::to_string()`, which embeds
+/// real quotes/braces in the field text. This previously tripped
+/// `SignablePayload::validate_charset`'s `\"` ban ("Restricted Characters
+/// Detected") for every instruction with a non-scalar arg. Assert both that
+/// the field renders the expected embedded-JSON text AND that the resulting
+/// payload passes charset validation end to end.
+#[test]
+fn test_increase_liquidity_by_token_amounts_v2_real_transaction() {
+    use crate::core::VisualizerContext;
+    use solana_parser::solana::structs::SolanaAccount;
+
+    let fixture: TestFixture = load_fixture("increase_liquidity_by_token_amounts_v2");
+    let instruction = create_instruction_from_fixture(&fixture);
+
+    let mut account_keys = vec![instruction.program_id];
+    for meta in &instruction.accounts {
+        account_keys.push(meta.pubkey);
+    }
+    let compiled = solana_sdk::instruction::CompiledInstruction {
+        program_id_index: 0,
+        accounts: (1..=instruction.accounts.len() as u8).collect(),
+        data: instruction.data.clone(),
+    };
+
+    let sender = SolanaAccount {
+        account_key: fixture.accounts.first().unwrap().pubkey.clone(),
+        signer: true,
+        writable: true,
+    };
+    let idl_registry = crate::idl::IdlRegistry::new();
+    let context = VisualizerContext::new(&sender, &compiled, &account_keys, &idl_registry, 0);
+
+    let visualizer = super::OrcaWhirlpoolVisualizer;
+    let result = visualizer
+        .visualize_tx_commands(&context)
+        .expect("Failed to visualize instruction");
+
+    let SignablePayloadField::PreviewLayout {
+        ref preview_layout, ..
+    } = result.signable_payload_field
+    else {
+        panic!("Expected PreviewLayout field type");
+    };
+
+    let expanded = preview_layout
+        .expanded
+        .as_ref()
+        .expect("expanded fields must be present");
+
+    for (key, expected_value) in &fixture.expected_fields {
+        let expected_str = expected_value
+            .as_str()
+            .unwrap_or_else(|| panic!("Expected field '{key}' is not a string"));
+
+        let found = expanded.fields.iter().any(|field| {
+            let SignablePayloadField::TextV2 { common, text_v2 } = &field.signable_payload_field
+            else {
+                return false;
+            };
+            let label_normalized = common.label.to_lowercase().replace(' ', "_");
+            label_normalized == key.to_lowercase() && text_v2.text == expected_str
+        });
+
+        assert!(
+            found,
+            "Expected field '{key}' with value '{expected_str}' not found in visualization"
+        );
+    }
+
+    // The whole point of this fixture: the embedded-JSON field must not trip
+    // validate_charset.
+    let payload = SignablePayload::new(
+        1,
+        "Orca Whirlpool".to_string(),
+        None,
+        vec![result.signable_payload_field],
+        "SolanaTx".to_string(),
+    );
+    payload
+        .validate_charset()
+        .expect("payload with embedded-JSON arg field must pass charset validation");
+}

--- a/src/chain_parsers/visualsign-solana/tests/fixtures/orca_whirlpool/increase_liquidity_by_token_amounts_v2.json
+++ b/src/chain_parsers/visualsign-solana/tests/fixtures/orca_whirlpool/increase_liquidity_by_token_amounts_v2.json
@@ -1,0 +1,31 @@
+{
+  "description": "PRS-572 regression: increase_liquidity_by_token_amounts_v2 renders a struct-valued arg ('method') that must survive validate_charset as real embedded JSON. This repro previously failed with 'Validation failed: Restricted Characters Detected' before the charset-validator fix.",
+  "source": "PRS-572 repro transaction (raw base64 tx supplied in the ticket)",
+  "signature": "n/a - unsigned repro transaction, PRS-572",
+  "cluster": "mainnet-beta",
+  "full_transaction_note": "Instruction 5 of a 5-instruction v0 transaction (compute budget x2, system transfer, orca open_position_with_token_extensions, orca increase_liquidity_by_token_amounts_v2). We're testing the increase_liquidity_by_token_amounts_v2 instruction in isolation.",
+  "instruction_index": 4,
+  "instruction_data": "3BcRfVthCtB9NCjTZV56JPQ2hoy2tvJW9LfVZznEXuqt9st2DFu1TVeyDGVARudfi5vD3HPDoahs2mwD",
+  "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+  "accounts": [
+    { "pubkey": "9tXiuRRw7kbejLhZXtxDxYs2REe43uH2e7k1kocgdM9B", "signer": true, "writable": true, "description": "Account 0 (position owner)" },
+    { "pubkey": "11111111111111111111111111111111", "signer": false, "writable": true, "description": "Account 1 (ALT-resolved in the real tx; placeholder here, not asserted on)" },
+    { "pubkey": "11111111111111111111111111111111", "signer": false, "writable": true, "description": "Account 2 (ALT-resolved in the real tx; placeholder here, not asserted on)" },
+    { "pubkey": "11111111111111111111111111111111", "signer": false, "writable": true, "description": "Account 3 (ALT-resolved in the real tx; placeholder here, not asserted on)" },
+    { "pubkey": "BTEByC4EFC5erpXs8JMLq5tx73aLnqEtK6BDjqmTFs7q", "signer": false, "writable": true, "description": "Account 4" },
+    { "pubkey": "HzieVsPqA9e91c26fXHih4nwdYUZKip2kZbWT3Wo8W16", "signer": false, "writable": true, "description": "Account 5" },
+    { "pubkey": "EpzFfaqn49Sj4AVdg7eKoy8tYXG8PDdx7sSAdtBrDFkh", "signer": false, "writable": true, "description": "Account 6" },
+    { "pubkey": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo", "signer": false, "writable": false, "description": "Account 7" },
+    { "pubkey": "11111111111111111111111111111111", "signer": false, "writable": false, "description": "Account 8 (ALT-resolved in the real tx; placeholder here, not asserted on)" },
+    { "pubkey": "CjR2rwcdnxyfDi5ejdYynH3sLpqhTyzNtokQxPrFJR1o", "signer": false, "writable": true, "description": "Account 9" },
+    { "pubkey": "3x6jNqyAp81trnPc73qGPAJWAovWj4UfuD34PeQ3m3N2", "signer": false, "writable": true, "description": "Account 10" },
+    { "pubkey": "EeF6oBy6AQiBJoRx5xiRNxa6cmpQE3ayVagj28QFZuyg", "signer": false, "writable": true, "description": "Account 11" },
+    { "pubkey": "MvB8poDgpDPbRgx8MXeb7EPEsawGuiBTqpkpM9exeLi", "signer": false, "writable": true, "description": "Account 12" },
+    { "pubkey": "8hXTpuvJQRar4Pf6BZiEWquFgtAtSf2RFDM6EL2FCcf1", "signer": false, "writable": true, "description": "Account 13" },
+    { "pubkey": "B1jXbjDzenSy8kPNaGw3GSKAVQis5K5tRLeXuaskZTpS", "signer": false, "writable": true, "description": "Account 14" }
+  ],
+  "expected_fields": {
+    "instruction_name": "increase_liquidity_by_token_amounts_v2",
+    "arg:_method": "{\"ByTokenAmounts\":{\"max_sqrt_price\":\"18675676272558904210\",\"min_sqrt_price\":\"18214477279551604378\",\"token_max_a\":1025000,\"token_max_b\":1461217}}"
+  }
+}

--- a/src/visualsign/src/lib.rs
+++ b/src/visualsign/src/lib.rs
@@ -934,12 +934,22 @@ impl SignablePayload {
         // smuggle non-printable / structural characters past the ASCII-only
         // checks below. The serializer (`serde_json::CompactFormatter`) emits
         // short-form escapes for 0x08, 0x09, 0x0A, 0x0C, 0x0D (`\b`, `\t`,
-        // `\n`, `\f`, `\r`) and escapes `"` and `\` as `\"` and `\\`. All of
-        // these survive `is_ascii() && (is_ascii_graphic() ||
-        // is_ascii_whitespace())` while still letting an attacker inject
-        // control bytes into the decoded field text and break single-line
-        // wallet UI. `\/` is included defensively even though the compact
-        // formatter does not emit it.
+        // `\n`, `\f`, `\r`). All of these survive `is_ascii() &&
+        // (is_ascii_graphic() || is_ascii_whitespace())` while still letting
+        // an attacker inject control bytes into the decoded field text and
+        // break single-line wallet UI.
+        //
+        // `\"` and `\\` are deliberately NOT forbidden: they decode to `"`
+        // and `\`, both already-permitted `is_ascii_graphic()` bytes, so
+        // allowing the escaped form smuggles nothing new past the checks
+        // below. This lets field text carry real, valid embedded JSON
+        // (objects/arrays/strings from chain-parser preset output) so it can
+        // be copied out of the wallet UI and parsed by any standard JSON
+        // parser, while every byte inside that embedded JSON must still be
+        // plain printable ASCII (PRS-572).
+        //
+        // `\/` stays forbidden defensively even though the compact formatter
+        // does not emit it, keeping the allow-list as narrow as possible.
         //
         // Carve-out: `\n` is the wallet's documented line separator for
         // multi-line field text (e.g. "Program ID: X\nData: Y" used by every
@@ -952,8 +962,7 @@ impl SignablePayload {
         // List order has no runtime effect: every match returns the same
         // generic `ValidationError`, so which entry fires first is not
         // observable. The defensive-first ordering is purely cosmetic.
-        const FORBIDDEN_JSON_ESCAPES: &[&str] =
-            &["\\u", "\\t", "\\r", "\\b", "\\f", "\\\"", "\\/", "\\\\"];
+        const FORBIDDEN_JSON_ESCAPES: &[&str] = &["\\u", "\\t", "\\r", "\\b", "\\f", "\\/"];
 
         let json_str = self.to_json().map_err(|e| {
             VisualSignError::SerializationError(format!("Failed to serialize for validation: {e}"))
@@ -2819,12 +2828,14 @@ mod tests {
         }
     }
 
-    /// `validate_charset` must reject `\"` (escaped double-quote) and `\\`
-    /// (escaped backslash) in serialized JSON. Embedded `"` / `\` in display
-    /// text can splice structural characters past a downstream JSON parser or
-    /// break out of single-line UI rendering.
+    /// `validate_charset` must accept `\"` (escaped double-quote) and `\\`
+    /// (escaped backslash) in serialized JSON. Both decode to bytes
+    /// (`"` and `\`) that are already permitted unescaped elsewhere in the
+    /// payload, so allowing the escaped form lets field text carry real,
+    /// valid embedded JSON without smuggling anything new past the
+    /// ascii-graphic checks (PRS-572).
     #[test]
-    fn test_validate_charset_rejects_quote_and_backslash_escapes() {
+    fn test_validate_charset_accepts_quote_and_backslash_escapes() {
         let cases: &[(&str, &str)] = &[
             ("double quote", "hello\"world"),
             ("backslash", "hello\\world"),
@@ -2832,39 +2843,24 @@ mod tests {
 
         for (label, text) in cases {
             let payload = payload_with_text(text);
-            let err = payload
+            payload
                 .validate_charset()
-                .expect_err(&format!("{label}: validator must reject"));
-            assert!(
-                matches!(err, VisualSignError::ValidationError(_)),
-                "{label}: expected ValidationError, got {err:?}",
-            );
+                .unwrap_or_else(|e| panic!("{label}: validator must accept, got {e:?}"));
         }
     }
 
     /// `validate_charset` must reject serialized JSON containing the literal
-    /// substring `\/`. The `serde_json::CompactFormatter` does not currently
-    /// emit `\/`, so this
-    /// test can't trigger that path through `to_json()` alone (a literal
-    /// backslash in field text serializes as `\\`, which contains `\/` as a
-    /// substring only if a `/` happens to follow it). The `\/` entry is
-    /// kept as a defensive guard against a future serializer that emits
-    /// bare `\/`.
-    ///
-    /// What this test actually asserts: input containing the two-character
-    /// sequence `\` `/` (which serializes as `\\/`) trips the deny-list. The
-    /// `\` `world` companion test
-    /// (`test_validate_charset_rejects_quote_and_backslash_escapes`) covers
-    /// the pure `\\` path. Either the `\/` or `\\` rule rejects this input;
-    /// since both return the same generic error, which one fires is not
-    /// observable.
+    /// substring `\/`, kept as a defensive guard even though the
+    /// `serde_json::CompactFormatter` does not currently emit it. `\\` alone
+    /// is permitted (see `test_validate_charset_accepts_quote_and_backslash_escapes`),
+    /// so this test's rejection comes solely from the still-forbidden `\/`
+    /// entry.
     #[test]
     fn test_validate_charset_rejects_backslash_slash_combination() {
         let payload = payload_with_text("path\\/to/resource");
         let json = payload.to_json().expect("serialization should succeed");
         // The serialized JSON contains `\\/` (backslash-slash combo), which
-        // matches both the `\/` and `\\` entries in FORBIDDEN_JSON_ESCAPES.
-        // Either way the payload must be rejected.
+        // matches the still-forbidden `\/` entry in FORBIDDEN_JSON_ESCAPES.
         assert!(
             json.contains("\\/"),
             "expected serialized JSON to contain \\\\/, got: {json}",
@@ -2910,5 +2906,19 @@ mod tests {
         payload.validate_charset().expect(
             "multi-line text with \\n is the wallet's documented line separator and must validate",
         );
+    }
+
+    /// PRS-572: field text carrying real, valid embedded JSON (as chain-parser
+    /// presets emit for struct/enum instruction args via
+    /// `serde_json::Value::to_string()`) must validate. The embedded quotes
+    /// become `\"` in the outer serialized payload; this is exactly the case
+    /// the fix allows so that copying a field's text out of the wallet UI
+    /// yields something any JSON parser can decode.
+    #[test]
+    fn test_validate_charset_accepts_embedded_json() {
+        let payload = payload_with_text(r#"{"a":"b","c":[1,2]}"#);
+        payload
+            .validate_charset()
+            .expect("field text containing valid embedded JSON should validate");
     }
 }

--- a/src/visualsign/src/lib.rs
+++ b/src/visualsign/src/lib.rs
@@ -2836,13 +2836,24 @@ mod tests {
     /// ascii-graphic checks (PRS-572).
     #[test]
     fn test_validate_charset_accepts_quote_and_backslash_escapes() {
-        let cases: &[(&str, &str)] = &[
-            ("double quote", "hello\"world"),
-            ("backslash", "hello\\world"),
+        // (label, text-containing-quote-or-backslash, expected escape in the
+        // serialized JSON). Mirrors the control-escape rejection test above:
+        // confirm the escape is actually present in `to_json()`'s output
+        // before asserting the validator accepts it, so this doesn't
+        // silently pass for the wrong reason if serde_json's formatter ever
+        // changes.
+        let cases: &[(&str, &str, &str)] = &[
+            ("double quote", "hello\"world", "\\\""),
+            ("backslash", "hello\\world", "\\\\"),
         ];
 
-        for (label, text) in cases {
+        for (label, text, expected_escape) in cases {
             let payload = payload_with_text(text);
+            let json = payload.to_json().expect("serialization should succeed");
+            assert!(
+                json.contains(expected_escape),
+                "{label}: expected serialized JSON to contain `{expected_escape}`, got: {json}",
+            );
             payload
                 .validate_charset()
                 .unwrap_or_else(|e| panic!("{label}: validator must accept, got {e:?}"));


### PR DESCRIPTION
## Summary
- `SignablePayload::validate_charset` rejected the `\"` / `\\` JSON escapes, which broke `sol_signTransaction` for any Solana IDL preset (Orca Whirlpool, Drift, Jupiter, Kamino, Meteora, Onre, Squads) rendering a struct/enum instruction arg via `serde_json::Value::to_string()` — valid compact JSON whose embedded quotes become `\"` once the outer payload is serialized.
- Both escapes decode to bytes (`"` and `\`) already permitted unescaped elsewhere in the payload, so allowing the escaped form lets field text carry real, copy-paste-parseable JSON. `\u`, `\t`, `\r`, `\b`, `\f` (the escapes that actually smuggle control bytes / arbitrary code points) stay forbidden — the security guarantee is unchanged.
- No preset code changes needed: they already emit valid JSON via `other.to_string()`; only the validator was overly strict.
- Adds a regression fixture for Orca Whirlpool's `increase_liquidity_by_token_amounts_v2`, the repro instruction from PRS-572.

Fixes PRS-572.

## Test plan
- [x] `cargo test -p visualsign` — 91 passed, including updated/new `validate_charset` unit tests
- [x] `cargo test -p visualsign-solana --lib` — 256 passed, including the new Orca Whirlpool fixture regression test
- [x] `cargo clippy --all-targets -- -D warnings` clean on `visualsign` and `visualsign-solana`
- [x] Rebuilt `parser_cli` and re-ran the PRS-572 repro transaction — now decodes successfully instead of `Error: Validation failed: Restricted Characters Detected`; confirmed the `Arg: method` field renders as valid, parseable JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)