### PR TITLE
feat(tvc-deploy): add verify-digest subcommand

### DIFF
--- a/tools/tvc-deploy/README.md
+++ b/tools/tvc-deploy/README.md
@@ -160,6 +160,24 @@ Resolve the existing activity (approve or reject it) and re-run, or pass
 `--force` to submit anyway. The check uses the active org by default; pass
 `--org <alias>` on `deploy` if the deployment's org differs from it.
 
+### Verifying the digest on its own
+
+`deploy` runs the digest gate itself, so a normal deploy needs nothing extra.
+`verify-digest` exposes the same gate as a standalone command:
+
+```
+tvc-deploy verify-digest \
+  --image-url "$IMAGE_URL" --expected-digest "$PIVOT_DIGEST"
+```
+
+Useful when the expected digest has to be recorded somewhere else before the
+deployment is created. `deploy` verifies the digest, but only once it is already
+running, which is too late to stop a wrong digest from being committed
+elsewhere first. Run this, record the digest, then deploy.
+
+No Turnkey auth needed, just Docker: it creates a container from the image,
+extracts `/parser_app`, sha256s it, and exits non-zero on a mismatch.
+
 ## Pruning deployments
 
 Deployments accumulate: every `deploy` creates a new one, and old ones are not

--- a/tools/tvc-deploy/src/main.rs
+++ b/tools/tvc-deploy/src/main.rs
@@ -51,6 +51,8 @@ enum Command {
     GenOperatorKey(GenOperatorKeyArgs),
     /// Deploy parser_app: digest-gate, create, approve, poll healthy, set live
     Deploy(DeployArgs),
+    /// Run only the digest gate: extract /parser_app from the image and compare its sha256
+    VerifyDigest(VerifyDigestArgs),
     /// Delete a single deployment by id (consensus via approve-activity)
     DeleteDeployment(invite::DeleteDeploymentArgs),
     /// Prune old deployments for an app, keeping the live one + newest --keep
@@ -120,6 +122,15 @@ struct DeployArgs {
     org: invite::OrgArgs,
 }
 
+#[derive(clap::Args)]
+struct VerifyDigestArgs {
+    #[arg(long)]
+    image_url: String,
+    /// Expected sha256 of the image's /parser_app binary (64 hex chars)
+    #[arg(long)]
+    expected_digest: String,
+}
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
@@ -136,6 +147,7 @@ fn run() -> Result<()> {
     match cli.command {
         Command::GenOperatorKey(args) => gen_operator_key(&args),
         Command::Deploy(args) => deploy(&sh, &args),
+        Command::VerifyDigest(args) => verify_digest(&sh, &args),
         Command::DeleteDeployment(args) => invite::delete_deployment(&args),
         Command::Prune(args) => invite::prune(&sh, &args),
         Command::Invite(args) => invite::invite(&args),
@@ -280,6 +292,15 @@ fn deploy(sh: &Shell, args: &DeployArgs) -> Result<()> {
     let deploy_id = outcome?;
     println!("deployment {deploy_id} is healthy and live");
     Ok(())
+}
+
+/// Standalone digest gate, for callers that must record the expected digest
+/// somewhere else before `deploy` runs. `deploy`'s own gate only fires once it
+/// is running, too late to stop a wrong digest being committed elsewhere first.
+/// Same check, same message, one implementation.
+fn verify_digest(sh: &Shell, args: &VerifyDigestArgs) -> Result<()> {
+    validate_digest(&args.expected_digest)?;
+    verify_image_digest(sh, &args.image_url, &args.expected_digest)
 }
 
 /// Extract `/parser_app` from the image and sha256 it; it MUST equal the


### PR DESCRIPTION
## Why

`deploy` already verifies that the image's `/parser_app` hashes to the expected digest, and refuses to proceed on a mismatch. But that gate only fires once `deploy` is running.

Some workflows have to record the expected digest somewhere else first, before the deployment is ever created. Those have no way to check the digest before committing to it, and by the time `deploy` would catch a wrong one, the record is already made.

## What

`tvc-deploy verify-digest --image-url <url> --expected-digest <sha256>` exposes that same gate as a standalone command, so it can be run as a precondition.

It reuses `validate_digest` + `verify_image_digest` rather than reimplementing the check, so there stays exactly one definition of what "the digest matches" means, and the failure message is identical wherever it fires. No existing code path changed.

Needs only Docker. No Turnkey auth, no org selection.

## Testing

Ran against the real `v0.819.0` GHCR image.

Matching digest:

```
$ cargo run -- verify-digest \
    --image-url ghcr.io/anchorageoss/parser_app:v0.819.0@sha256:<...> \
    --expected-digest <digest from the release notes>
✓ digest matches
```

Wrong digest fails with the existing mismatch message, and a malformed digest is rejected by `validate_digest` before Docker is touched.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Rollback

Additive: a new subcommand and a README section. Revert the commit; nothing else reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)