### PR TITLE
feat(prs-556): make ABI trust posture an explicit policy type

### DIFF
--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -27,11 +27,46 @@ enum AbiSignatureError {
     Validation(String),
 }
 
+/// Outcome of extracting caller-supplied ABI mappings from `ChainMetadata`.
+///
+/// The counts travel with the registry because the rendered payload cannot tell
+/// these two requests apart: one that supplied no ABI mappings at all, and one
+/// whose every mapping this deployment's posture refused. Both fall back to the
+/// raw selector, and the only thing separating them used to be a `log::warn!`.
+/// That is not a channel anyone can read from the enclave: `parser_app` declares
+/// no `log` dependency and initialises no logger, so those calls are compiled-in
+/// no-ops there rather than log lines nobody happens to look at.
+///
+/// Surfacing the counts in the payload itself needs a field on the payload (the
+/// follow-up to PRS-555, which shipped without one). Until that exists, this at
+/// least lets the caller distinguish the two cases instead of discarding the
+/// difference inside the extractor.
+#[derive(Default)]
+pub struct AbiExtraction {
+    /// The accepted entries, or `None` when nothing was registered, whether
+    /// because the request carried no usable mapping or because every mapping
+    /// was refused. `rejected_by_policy` tells those apart.
+    pub registry: Option<AbiRegistry>,
+    /// Entries refused by the deployment's trust posture: no signature at all
+    /// under require-signed, or a signature that failed to verify or whose
+    /// signer is not allowlisted. Entries dropped for a malformed address,
+    /// oversized JSON, or unparseable ABI are not counted here; those are the
+    /// caller's own malformed input rather than a trust decision.
+    pub rejected_by_policy: usize,
+    /// Accepted entries whose signer identity was not established. Under
+    /// require-signed this is always zero. Under accept-unsigned it counts every
+    /// accepted entry, signed or not: see the counting note in
+    /// [`try_extract_from_chain_metadata`] for why a present signature does not
+    /// reduce it.
+    pub unverified: usize,
+}
+
 /// Extract and validate ABIs from `ChainMetadata`, if present.
 ///
 /// Navigates `ChainMetadata -> Ethereum -> abi_mappings` and registers each ABI
-/// with its contract address. Returns `None` if the metadata doesn't contain
-/// any Ethereum ABI mappings.
+/// with its contract address. Returns an [`AbiExtraction`] whose `registry` is
+/// `None` when nothing was registered; its counts say why, so total refusal is
+/// distinguishable from metadata that carried no ABI mappings at all.
 ///
 /// The `chain_id` is needed to register address-to-ABI mappings in the registry.
 ///
@@ -50,9 +85,13 @@ enum AbiSignatureError {
 ///   malformed and unauthorized signatures are all rejected. An empty allowlist
 ///   rejects everything (fail-closed).
 /// - **Under [`MetadataTrustPolicy::AcceptUnsigned`]**, an entry with
-///   `signature: None` is registered rather than dropped; unsigned entries are
-///   counted and reported in a single aggregated warning once per request (no
-///   per-entry flag or marker is stored in the registry, tracked in PRS-555). An
+///   `signature: None` is registered rather than dropped. Every accepted entry is
+///   counted as unverified in this posture, signed or not, since a signature whose
+///   signer is never checked establishes no provenance either; the count is
+///   returned in [`AbiExtraction::unverified`] and reported in a single aggregated
+///   warning once per request. No per-entry flag or marker is stored in the
+///   registry, so a decode backed by caller metadata is still indistinguishable
+///   from a built-in one in the rendered payload. An
 ///   entry that DOES carry a signature must still verify against the public key
 ///   supplied alongside it in the same (untrusted) `SignatureMetadata`, since a
 ///   present-but-invalid signature is a stronger signal of tampering than simply
@@ -91,17 +130,21 @@ pub fn try_extract_from_chain_metadata(
     chain_metadata: Option<&ChainMetadata>,
     chain_id: u64,
     policy: &MetadataTrustPolicy,
-) -> Option<AbiRegistry> {
-    let chain_metadata = chain_metadata?;
-    let chain_metadata::Metadata::Ethereum(ethereum) = chain_metadata.metadata.as_ref()? else {
-        return None;
+) -> AbiExtraction {
+    let Some(chain_metadata) = chain_metadata else {
+        return AbiExtraction::default();
+    };
+    let Some(chain_metadata::Metadata::Ethereum(ethereum)) = chain_metadata.metadata.as_ref()
+    else {
+        return AbiExtraction::default();
     };
     if ethereum.abi_mappings.is_empty() {
-        return None;
+        return AbiExtraction::default();
     }
 
     let mut registry = AbiRegistry::new();
-    let mut unsigned_count: usize = 0;
+    let mut unverified_count: usize = 0;
+    let mut rejected_by_policy: usize = 0;
     for (address, abi) in &ethereum.abi_mappings {
         // Validate address first (cheap) before expensive signature/ABI operations
         let parsed_address = match address.parse::<alloy_primitives::Address>() {
@@ -127,7 +170,14 @@ pub fn try_extract_from_chain_metadata(
         // both postures a signature that IS present must validate, since a
         // present-but-invalid signature signals tampering rather than simply an
         // unsigned source.
-        let is_unsigned = abi.signature.is_none();
+        //
+        // What gets counted as unverified is "identity was not enforced", not
+        // "signature absent". Under accept-unsigned the signer is never checked
+        // against an allowlist, so an entry an attacker signed with a key of
+        // their own is exactly as unattributed as one they left unsigned;
+        // counting only the latter would report zero unverified mappings for a
+        // request whose entire decode came from an unverified caller ABI.
+        let identity_unverified = policy.signer_allowlist().is_none() || abi.signature.is_none();
         if let Some(proto_sig) = abi.signature.as_ref() {
             let signature = convert_proto_signature(proto_sig);
             if let Err(e) = validate_abi_signature(
@@ -140,6 +190,7 @@ pub fn try_extract_from_chain_metadata(
                 log::warn!(
                     "Skipping ABI mapping for '{address}': signature validation failed: {e}"
                 );
+                rejected_by_policy += 1;
                 continue;
             }
         } else if !policy.accepts_unsigned() {
@@ -147,6 +198,7 @@ pub fn try_extract_from_chain_metadata(
                 "Skipping ABI mapping for '{address}': this deployment requires \
                  signed ABI mappings"
             );
+            rejected_by_policy += 1;
             continue;
         }
 
@@ -165,8 +217,8 @@ pub fn try_extract_from_chain_metadata(
                     abi_kind,
                     implementation,
                 );
-                if is_unsigned {
-                    unsigned_count += 1;
+                if identity_unverified {
+                    unverified_count += 1;
                 }
             }
             Err(e) => {
@@ -174,15 +226,21 @@ pub fn try_extract_from_chain_metadata(
             }
         }
     }
-    if unsigned_count > 0 {
+    if unverified_count > 0 {
         log::warn!(
-            "Accepted {unsigned_count} unsigned ABI mapping(s): integrity/provenance unverified"
+            "Accepted {unverified_count} ABI mapping(s) with no verified signer: provenance unestablished"
         );
     }
-    if registry.list_abis().is_empty() {
-        return None;
+    if rejected_by_policy > 0 {
+        log::warn!(
+            "Refused {rejected_by_policy} ABI mapping(s) under this deployment's trust posture"
+        );
     }
-    Some(registry)
+    AbiExtraction {
+        registry: (!registry.list_abis().is_empty()).then_some(registry),
+        rejected_by_policy,
+        unverified: unverified_count,
+    }
 }
 
 /// Resolve the `AbiKind` and (for proxies) the implementation address from a proto
@@ -983,7 +1041,11 @@ mod tests {
 
     #[test]
     fn test_try_extract_no_metadata() {
-        assert!(try_extract_from_chain_metadata(None, 1, &test_require_signed()).is_none());
+        assert!(
+            try_extract_from_chain_metadata(None, 1, &test_require_signed())
+                .registry
+                .is_none()
+        );
     }
 
     #[test]
@@ -996,7 +1058,9 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+                .registry
+                .is_none()
         );
     }
 
@@ -1009,7 +1073,9 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+                .registry
+                .is_none()
         );
     }
 
@@ -1027,6 +1093,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("should contain ABI");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
@@ -1059,6 +1126,7 @@ mod tests {
         };
 
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("tampering with abi_type must NOT invalidate the body signature");
         assert!(
             registry.list_abis().contains(&TEST_ADDRESS),
@@ -1077,6 +1145,7 @@ mod tests {
             1,
             &MetadataTrustPolicy::AcceptUnsigned,
         )
+        .registry
         .expect("unsigned ABI entries must be registered under accept-unsigned");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
@@ -1089,7 +1158,9 @@ mod tests {
     fn test_try_extract_unsigned_abi_rejected_under_require_signed() {
         let metadata = unsigned_metadata();
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none(),
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+                .registry
+                .is_none(),
             "require-signed must reject an unsigned ABI mapping, even though the \
              accept-unsigned posture registers the very same request"
         );
@@ -1124,6 +1195,7 @@ mod tests {
             1,
             &MetadataTrustPolicy::AcceptUnsigned,
         )
+        .registry
         .expect("should contain both entries");
         assert!(
             registry.list_abis().contains(&unsigned_address),
@@ -1159,6 +1231,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("the signed entry must still register");
         assert!(
             !registry.list_abis().contains(&unsigned_address),
@@ -1195,6 +1268,7 @@ mod tests {
                 1,
                 &MetadataTrustPolicy::AcceptUnsigned
             )
+            .registry
             .is_none(),
             "a present-but-invalid signature must be rejected even under accept-unsigned"
         );
@@ -1233,8 +1307,135 @@ mod tests {
             1,
             &MetadataTrustPolicy::AcceptUnsigned,
         )
+        .registry
         .expect("accept-unsigned checks integrity only, so this must register");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
+    }
+
+    /// Under accept-unsigned, an entry an attacker signed with a key of their own is
+    /// counted as unverified even though a signature is present.
+    ///
+    /// The signer is never checked against an allowlist in this posture, so a
+    /// self-signed entry establishes no more provenance than an unsigned one. A
+    /// predicate keyed on `signature.is_none()` reports zero unverified mappings
+    /// here, for a request whose entire decode came from an unattributed caller ABI,
+    /// which is exactly the wrong answer to hand whatever ends up rendering it.
+    ///
+    /// This state is newly reachable in production: before the posture became
+    /// explicit, the compiled-in allowlist was empty, so a signed-by-unlisted entry
+    /// was rejected and never reached the counter.
+    #[test]
+    fn test_accept_unsigned_counts_self_signed_entry_as_unverified() {
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    TEST_ADDRESS,
+                    signed_abi_with_seed(VALID_ABI, TEST_ADDRESS, &FOREIGN_SIGNER_SEED),
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            1,
+            &MetadataTrustPolicy::AcceptUnsigned,
+        );
+        assert!(
+            extraction.registry.is_some(),
+            "accept-unsigned checks integrity only, so this must register"
+        );
+        assert_eq!(
+            extraction.unverified, 1,
+            "a present signature whose signer is never checked establishes no \
+             provenance, so the entry must still count as unverified"
+        );
+        assert_eq!(extraction.rejected_by_policy, 0);
+    }
+
+    /// Require-signed accepts only entries whose signer was actually checked, so
+    /// nothing it registers is unverified. Counterpart to
+    /// `test_accept_unsigned_counts_self_signed_entry_as_unverified`: without this,
+    /// a predicate that counted every accepted entry unconditionally would pass.
+    #[test]
+    fn test_require_signed_registers_nothing_unverified() {
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    TEST_ADDRESS,
+                    signed_abi(VALID_ABI, TEST_ADDRESS),
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let extraction =
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed());
+        assert!(extraction.registry.is_some(), "the fixture is allowlisted");
+        assert_eq!(
+            extraction.unverified, 0,
+            "an allowlisted signer was verified, so nothing is unverified"
+        );
+    }
+
+    /// Total refusal must be distinguishable from metadata that carried no ABI
+    /// mappings at all.
+    ///
+    /// Both render identically (raw selector, no error, no marker), and the only
+    /// thing that used to separate them was a `log::warn!`. That is not a channel
+    /// anyone can read from the enclave: `parser_app` declares no `log` dependency
+    /// and initialises no logger, so those calls are compiled-in no-ops there. The
+    /// count is the signal, so it has to survive the return.
+    #[test]
+    fn test_total_refusal_is_distinguishable_from_absent_metadata() {
+        // Every entry the request supplied is refused by the posture.
+        let refused =
+            try_extract_from_chain_metadata(Some(&unsigned_metadata()), 1, &test_require_signed());
+        assert!(
+            refused.registry.is_none(),
+            "nothing survives require-signed"
+        );
+        assert_eq!(
+            refused.rejected_by_policy, 1,
+            "a request whose entries were all refused must say so"
+        );
+
+        // No ABI mappings were supplied at all: same empty registry, but nothing
+        // was refused.
+        let absent = try_extract_from_chain_metadata(None, 1, &test_require_signed());
+        assert!(absent.registry.is_none());
+        assert_eq!(
+            absent.rejected_by_policy, 0,
+            "absent metadata must not look like a refusal"
+        );
+    }
+
+    /// Entries dropped for the caller's own malformed input (bad address, oversized
+    /// or unparseable JSON) are not trust decisions and must not inflate
+    /// `rejected_by_policy`, or the count stops meaning "this deployment refused
+    /// you" and a follow-up cannot act on it.
+    #[test]
+    fn test_malformed_entries_are_not_counted_as_policy_rejections() {
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    "not_an_address",
+                    signed_abi(VALID_ABI, "not_an_address"),
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let extraction =
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed());
+        assert!(extraction.registry.is_none());
+        assert_eq!(
+            extraction.rejected_by_policy, 0,
+            "a malformed address is the caller's own bad input, not a refusal"
+        );
     }
 
     /// An entry that DOES carry a signature but fails validation (signer not on
@@ -1261,6 +1462,7 @@ mod tests {
         unlisted_allow.insert(pubkey_bytes_from_seed(&FOREIGN_SIGNER_SEED));
         assert!(
             try_extract_from_chain_metadata(Some(&metadata), 1, &require_signed(unlisted_allow))
+                .registry
                 .is_none(),
             "a signature present but failing validation must still be rejected"
         );
@@ -1323,6 +1525,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("should contain ABI");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
@@ -1372,6 +1575,7 @@ mod tests {
                 1,
                 &MetadataTrustPolicy::AcceptUnsigned
             )
+            .registry
             .is_none()
         );
     }
@@ -1393,7 +1597,9 @@ mod tests {
         // The signature is valid, so this exercises the JSON parse rejection path
         // rather than short-circuiting on the unsigned check.
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+                .registry
+                .is_none()
         );
     }
 
@@ -1413,6 +1619,7 @@ mod tests {
         };
         // The valid entry should be registered; the invalid one skipped
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("should contain the valid ABI");
         assert!(registry.list_abis().contains(&valid_address));
     }
@@ -1491,6 +1698,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("has ABI");
         assert_eq!(
             registry.get_abi_kind(1, parse_addr(TEST_ADDRESS)),
@@ -1519,6 +1727,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("has ABIs");
 
         assert_eq!(
@@ -1552,6 +1761,7 @@ mod tests {
             })),
         };
         let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .registry
             .expect("has ABI");
         // Entry is kept as a proxy, but with no resolvable implementation link.
         assert_eq!(
@@ -1609,6 +1819,7 @@ mod tests {
             1,
             &MetadataTrustPolicy::AcceptUnsigned,
         )
+        .registry
         .expect("has ABIs, even though neither entry is signed");
 
         assert_eq!(

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -38,12 +38,13 @@ enum AbiSignatureError {
 /// # Security notes
 ///
 /// - **Whether unsigned ABIs are accepted is a deploy-time decision, not a
-///   request-time one.** `policy` is fixed when the parser process starts (for
-///   `parser_app`, by the `--accept-unsigned-abis` / `--accept-signatures-from-pubkey`
-///   cmdline flags that land in the signed TVC manifest's `pivotArgs`). A caller
-///   cannot move the parser between postures by omitting a signature, and a signer
-///   can verify out of band which posture the deployment runs. See
-///   [`MetadataTrustPolicy`].
+///   request-time one.** `policy` is fixed by whichever constructor built the
+///   converter, not by anything in the request. Today `parser_cli` pins
+///   [`MetadataTrustPolicy::RequireAllowlistedSigner`] against its dev key; wiring
+///   `parser_app` and the gRPC server to their own cmdline flags (so the posture is
+///   fixed at deploy time and auditable in the signed TVC manifest) is planned as a
+///   follow-up and is not part of this change. A caller cannot move the parser
+///   between postures by omitting a signature. See [`MetadataTrustPolicy`].
 /// - **Under [`MetadataTrustPolicy::RequireAllowlistedSigner`]**, every entry must
 ///   carry a signature that verifies AND whose key is allowlisted. Missing,
 ///   malformed and unauthorized signatures are all rejected. An empty allowlist
@@ -127,30 +128,26 @@ pub fn try_extract_from_chain_metadata(
         // present-but-invalid signature signals tampering rather than simply an
         // unsigned source.
         let is_unsigned = abi.signature.is_none();
-        match abi.signature.as_ref() {
-            Some(proto_sig) => {
-                let signature = convert_proto_signature(proto_sig);
-                if let Err(e) = validate_abi_signature(
-                    &abi.value,
-                    &parsed_address,
-                    chain_id,
-                    &signature,
-                    policy.signer_allowlist(),
-                ) {
-                    log::warn!(
-                        "Skipping ABI mapping for '{address}': signature validation failed: {e}"
-                    );
-                    continue;
-                }
-            }
-            None if !policy.accepts_unsigned() => {
+        if let Some(proto_sig) = abi.signature.as_ref() {
+            let signature = convert_proto_signature(proto_sig);
+            if let Err(e) = validate_abi_signature(
+                &abi.value,
+                &parsed_address,
+                chain_id,
+                &signature,
+                policy.signer_allowlist(),
+            ) {
                 log::warn!(
-                    "Skipping ABI mapping for '{address}': this deployment requires \
-                     signed ABI mappings (started with --accept-signatures-from-pubkey)"
+                    "Skipping ABI mapping for '{address}': signature validation failed: {e}"
                 );
                 continue;
             }
-            None => {}
+        } else if !policy.accepts_unsigned() {
+            log::warn!(
+                "Skipping ABI mapping for '{address}': this deployment requires \
+                 signed ABI mappings"
+            );
+            continue;
         }
 
         // Determine the kind of contract this ABI describes. An unset or
@@ -386,13 +383,13 @@ fn validate_abi_signature(
 /// An empty result (no dev key, no env entries) rejects all signed ABIs
 /// (fail-closed).
 ///
-/// **This is not how a deployment picks its trust posture.** `parser_app` and the
-/// gRPC server take the posture from their cmdline
-/// (`--accept-unsigned-abis` / `--accept-signatures-from-pubkey`, parsed into a
-/// [`MetadataTrustPolicy`] via [`signer_allowlist_from_hex`]) so the choice is
-/// auditable in the signed deployment manifest and cannot be influenced per
-/// request. This function backs `parser_cli`, which signs the ABI files it loads
-/// with the dev key and therefore runs require-signed against that key.
+/// **This is not how a deployment picks its trust posture.** This function backs
+/// `parser_cli`, which signs the ABI files it loads with the dev key and
+/// therefore runs require-signed against that key. Wiring `parser_app` and the
+/// gRPC server to their own cmdline flags (parsed into a [`MetadataTrustPolicy`]
+/// via [`signer_allowlist_from_hex`], so the choice is auditable in the signed
+/// deployment manifest and cannot be influenced per request) is planned as a
+/// follow-up and is not part of this change.
 #[must_use]
 pub fn authorized_abi_signers() -> SignerAllowlist {
     let mut allow = SignerAllowlist::new();
@@ -418,8 +415,8 @@ pub fn authorized_abi_signers() -> SignerAllowlist {
 }
 
 /// Build a [`SignerAllowlist`] from deploy-time hex secp256k1 public keys (one per
-/// `--accept-signatures-from-pubkey` occurrence, any SEC1 encoding, optional `0x`
-/// prefix).
+/// occurrence of the planned per-signer cmdline flag, any SEC1 encoding, optional
+/// `0x` prefix).
 ///
 /// Unlike [`authorized_abi_signers`], a bad key is an error rather than a warning:
 /// these come from the deployment's cmdline, so a typo must stop the process at

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -444,10 +444,10 @@ fn validate_abi_signature(
 /// **This is not how a deployment picks its trust posture.** This function backs
 /// `parser_cli`, which signs the ABI files it loads with the dev key and
 /// therefore runs require-signed against that key. Wiring `parser_app` and the
-/// gRPC server to their own cmdline flags (parsed into a [`MetadataTrustPolicy`]
-/// via [`signer_allowlist_from_hex`], so the choice is auditable in the signed
-/// deployment manifest and cannot be influenced per request) is planned as a
-/// follow-up and is not part of this change.
+/// gRPC server to their own cmdline flags (so the choice is auditable in the
+/// signed deployment manifest and cannot be influenced per request) is planned as
+/// a follow-up and is not part of this change; the flag and the parser that turns
+/// its occurrences into a [`MetadataTrustPolicy`] land together in that change.
 #[must_use]
 pub fn authorized_abi_signers() -> SignerAllowlist {
     let mut allow = SignerAllowlist::new();
@@ -470,31 +470,6 @@ pub fn authorized_abi_signers() -> SignerAllowlist {
     }
 
     allow
-}
-
-/// Build a [`SignerAllowlist`] from deploy-time hex secp256k1 public keys (one per
-/// occurrence of the planned per-signer cmdline flag, any SEC1 encoding, optional
-/// `0x` prefix).
-///
-/// Unlike [`authorized_abi_signers`], a bad key is an error rather than a warning:
-/// these come from the deployment's cmdline, so a typo must stop the process at
-/// startup instead of silently producing a smaller (or empty, fail-closed)
-/// allowlist that quietly drops every caller-supplied ABI.
-///
-/// # Errors
-/// Returns `Err` if `entries` is empty, or if any entry is not a valid secp256k1
-/// public key.
-pub fn signer_allowlist_from_hex(entries: &[String]) -> Result<SignerAllowlist, String> {
-    if entries.is_empty() {
-        return Err("no authorized ABI signer public keys were provided".to_string());
-    }
-    let mut allow = SignerAllowlist::new();
-    for entry in entries {
-        let key = canonical_pubkey_from_hex(entry.trim())
-            .ok_or_else(|| format!("invalid secp256k1 public key: '{entry}'"))?;
-        allow.insert(key);
-    }
-    Ok(allow)
 }
 
 /// Parse a hex secp256k1 public key (optionally `0x`- or `0X`-prefixed, any
@@ -1622,57 +1597,6 @@ mod tests {
             .registry
             .expect("should contain the valid ABI");
         assert!(registry.list_abis().contains(&valid_address));
-    }
-
-    // --- deploy-time signer allowlist parsing ---
-
-    /// The happy path for the planned deploy-time signer flag: a hex key from the
-    /// cmdline lands in the allowlist and authorizes that signer's ABIs.
-    #[test]
-    fn signer_allowlist_from_hex_accepts_valid_key() {
-        let key = hex::encode(pubkey_bytes_from_seed(&[0x42u8; 32]));
-        let allow = signer_allowlist_from_hex(&[key]).expect("valid key must parse");
-        assert_eq!(allow.len(), 1);
-        assert!(allow.contains(&pubkey_bytes_from_seed(&[0x42u8; 32])));
-    }
-
-    /// Compressed and uncompressed encodings of the same key canonicalize to the
-    /// same allowlist entry, and both match the uncompressed form the verifier
-    /// derives from the signature.
-    #[test]
-    fn signer_allowlist_from_hex_canonicalizes_compressed_keys() {
-        let signing_key = SigningKey::from_bytes(&[0x42u8; 32]).expect("valid key");
-        let verifying_key = VerifyingKey::from(&signing_key);
-        let compressed = hex::encode(verifying_key.to_encoded_point(true).as_bytes());
-        let uncompressed = hex::encode(verifying_key.to_encoded_point(false).as_bytes());
-
-        let allow = signer_allowlist_from_hex(&[format!("0x{compressed}"), uncompressed])
-            .expect("both encodings must parse");
-        assert_eq!(
-            allow.len(),
-            1,
-            "compressed and uncompressed forms of one key must collapse to one entry"
-        );
-        assert!(allow.contains(&pubkey_bytes_from_seed(&[0x42u8; 32])));
-    }
-
-    /// A typo on the deployment cmdline must fail loudly at startup rather than
-    /// silently shrinking the allowlist (which would fail-closed and drop every
-    /// caller-supplied ABI for reasons nobody can see).
-    #[test]
-    fn signer_allowlist_from_hex_rejects_invalid_key() {
-        let valid = hex::encode(pubkey_bytes_from_seed(&[0x42u8; 32]));
-        let err = signer_allowlist_from_hex(&[valid, "not-a-key".to_string()])
-            .expect_err("an invalid key must be an error, not a skipped entry");
-        assert!(err.contains("invalid secp256k1 public key"), "error: {err}");
-    }
-
-    /// Require-signed with no keys at all is a configuration error, not an
-    /// accidentally-empty (reject-everything) allowlist.
-    #[test]
-    fn signer_allowlist_from_hex_rejects_empty_input() {
-        let err = signer_allowlist_from_hex(&[]).expect_err("empty input must be an error");
-        assert!(err.contains("no authorized ABI signer"), "error: {err}");
     }
 
     // --- proxy / abi_type tests ---

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -52,13 +52,17 @@ enum AbiSignatureError {
 ///   `signature: None` is registered rather than dropped; unsigned entries are
 ///   counted and reported in a single aggregated warning once per request (no
 ///   per-entry flag or marker is stored in the registry, tracked in PRS-555). An
-///   entry that DOES carry a signature must still verify for integrity, since a
+///   entry that DOES carry a signature must still verify against the public key
+///   supplied alongside it in the same (untrusted) `SignatureMetadata`, since a
 ///   present-but-invalid signature is a stronger signal of tampering than simply
-///   omitting one. The signer's *identity* is not checked in this posture: a
-///   deployment that accepts unsigned ABIs gains nothing from an allowlist an
-///   attacker sidesteps by dropping the signature, and the previous behaviour
-///   (accept unsigned, but reject a correctly signed entry whose signer is not
-///   allowlisted) was strictly worse than either coherent posture.
+///   omitting one; because that key is not checked against an allowlist here, this
+///   only catches a tamperer who mutates `abi.value` without also re-signing it,
+///   not one who controls the whole entry. The signer's *identity* is not checked
+///   in this posture: a deployment that accepts unsigned ABIs gains nothing from
+///   an allowlist an attacker sidesteps by dropping the signature (or re-signing
+///   with a key of their own), and the previous behaviour (accept unsigned, but
+///   reject a correctly signed entry whose signer is not allowlisted) was
+///   strictly worse than either coherent posture.
 /// - **Signature validation** uses secp256k1 over a domain-separated prehash that
 ///   binds the chain id and the contract address to the ABI JSON (see
 ///   [`visualsign::signing::ethereum_metadata_prehash`]).

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -579,14 +579,49 @@ mod tests {
         }
     ]"#;
 
+    /// A second well-formed ABI, used as the swapped-in body in tampering tests.
+    ///
+    /// It has to parse cleanly on its own, otherwise `register_embedded_abi` drops
+    /// the entry before `validate_abi_signature` ever runs and the test passes
+    /// without exercising the signature check at all.
+    const OTHER_VALID_ABI: &str = r#"[
+        {
+            "type": "function",
+            "name": "approve",
+            "inputs": [
+                {"name": "spender", "type": "address"},
+                {"name": "amount", "type": "uint256"}
+            ],
+            "outputs": [{"name": "", "type": "bool"}],
+            "stateMutability": "nonpayable"
+        }
+    ]"#;
+
+    /// A seed that is deliberately NOT the dev key and NOT in any test allowlist.
+    ///
+    /// Needed to test signer identity: [`CLI_DEV_SIGNING_KEY_SEED`] is allowlisted by
+    /// `authorized_abi_signers()` under `cfg(test)`, so a fixture signed with it is
+    /// accepted on identity grounds and cannot distinguish "identity enforced" from
+    /// "identity ignored".
+    const FOREIGN_SIGNER_SEED: [u8; 32] = [0x43u8; 32];
+
     /// Helper to create a valid signature for testing.
     ///
     /// The signature is over the domain-separated prehash binding `chain_id` and
     /// `address` to `abi_json`, matching what [`validate_abi_signature`] verifies.
     fn create_test_signature(abi_json: &str, address: &Address, chain_id: u64) -> (String, String) {
-        // Use a deterministic test seed
-        let seed: [u8; 32] = [0x42u8; 32];
-        let signing_key = SigningKey::from_bytes(&seed).expect("valid key");
+        create_test_signature_with_seed(abi_json, address, chain_id, &CLI_DEV_SIGNING_KEY_SEED)
+    }
+
+    /// [`create_test_signature`] with an explicit signing seed, so a test can sign as
+    /// a signer that no allowlist authorizes.
+    fn create_test_signature_with_seed(
+        abi_json: &str,
+        address: &Address,
+        chain_id: u64,
+        seed: &[u8; 32],
+    ) -> (String, String) {
+        let signing_key = SigningKey::from_bytes(seed).expect("valid key");
         let verifying_key = VerifyingKey::from(&signing_key);
 
         // Compute the shared domain-separated prehash.
@@ -917,8 +952,15 @@ mod tests {
     /// earlier address parse and are skipped before signature verification, so the
     /// bound address is never actually checked.
     fn signed_abi(abi_json: &str, address: &str) -> Abi {
+        signed_abi_with_seed(abi_json, address, &CLI_DEV_SIGNING_KEY_SEED)
+    }
+
+    /// [`signed_abi`] with an explicit signing seed. Pass [`FOREIGN_SIGNER_SEED`] to
+    /// build an entry whose signature verifies but whose signer no allowlist knows.
+    fn signed_abi_with_seed(abi_json: &str, address: &str, seed: &[u8; 32]) -> Abi {
         let addr = address.parse::<Address>().unwrap_or(Address::ZERO);
-        let (signature_hex, public_key_hex) = create_test_signature(abi_json, &addr, 1);
+        let (signature_hex, public_key_hex) =
+            create_test_signature_with_seed(abi_json, &addr, 1, seed);
         let proto_sig = generated::parser::SignatureMetadata {
             value: signature_hex,
             metadata: vec![
@@ -1133,9 +1175,11 @@ mod tests {
     /// present-but-invalid signature never degrades to "accept and log".
     #[test]
     fn test_accept_unsigned_still_rejects_tampered_signature() {
-        // Signature is minted over VALID_ABI, then the body is swapped out.
+        // Signature is minted over VALID_ABI, then the body is swapped out for a
+        // different ABI that is itself well-formed, so the only thing that can
+        // reject this entry is the signature check.
         let mut abi = signed_abi(VALID_ABI, TEST_ADDRESS);
-        abi.value = r#"[{"type":"function","name":"approve"}]"#.to_string();
+        abi.value = OTHER_VALID_ABI.to_string();
 
         let metadata = ChainMetadata {
             metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
@@ -1162,6 +1206,11 @@ mod tests {
     /// intentional posture so a future change that starts enforcing identity here
     /// (recreating the old incoherent "unsigned ok, signed-by-stranger rejected"
     /// behaviour) fails loudly.
+    ///
+    /// The fixture must be signed with [`FOREIGN_SIGNER_SEED`], not the dev seed:
+    /// `authorized_abi_signers()` allowlists the dev key under `cfg(test)`, so a
+    /// dev-signed fixture passes an identity check too and the test would hold even
+    /// if identity were being enforced.
     #[test]
     fn test_accept_unsigned_does_not_enforce_signer_identity() {
         let metadata = ChainMetadata {
@@ -1169,14 +1218,16 @@ mod tests {
                 network_id: Some("ETHEREUM_MAINNET".to_string()),
                 abi_mappings: make_abi_mappings(vec![(
                     TEST_ADDRESS,
-                    signed_abi(VALID_ABI, TEST_ADDRESS),
+                    signed_abi_with_seed(VALID_ABI, TEST_ADDRESS, &FOREIGN_SIGNER_SEED),
                 )])
                 .into_iter()
                 .collect(),
             })),
         };
-        // Same fixture rejected by `test_try_extract_unauthorized_signer_still_rejected`
-        // under require-signed with a foreign allowlist.
+        // This signer is in no allowlist, so require-signed would reject the same
+        // entry. `test_try_extract_unauthorized_signer_still_rejected` asserts that
+        // rejection using the mirror arrangement: a dev-signed entry against an
+        // allowlist that authorizes only FOREIGN_SIGNER_SEED.
         let registry = try_extract_from_chain_metadata(
             Some(&metadata),
             1,
@@ -1192,8 +1243,8 @@ mod tests {
     /// simply omitting one, so it must not be downgraded to "accept and log".
     #[test]
     fn test_try_extract_unauthorized_signer_still_rejected() {
-        // `signed_abi` signs with seed 0x42, so pass an allowlist that only
-        // authorizes seed 0x43: the signature verifies but the signer is
+        // `signed_abi` signs with the dev seed, so pass an allowlist that only
+        // authorizes FOREIGN_SIGNER_SEED: the signature verifies but the signer is
         // unauthorized (mirrors `validate_abi_signature_rejects_unlisted_signer`).
         let metadata = ChainMetadata {
             metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
@@ -1207,7 +1258,7 @@ mod tests {
             })),
         };
         let mut unlisted_allow = SignerAllowlist::new();
-        unlisted_allow.insert(pubkey_bytes_from_seed(&[0x43u8; 32]));
+        unlisted_allow.insert(pubkey_bytes_from_seed(&FOREIGN_SIGNER_SEED));
         assert!(
             try_extract_from_chain_metadata(Some(&metadata), 1, &require_signed(unlisted_allow))
                 .is_none(),
@@ -1291,6 +1342,12 @@ mod tests {
         assert!(local_sig.timestamp.is_none());
     }
 
+    /// An entry whose map key is not an address is dropped by the address parse,
+    /// before any signature handling.
+    ///
+    /// Runs under accept-unsigned on purpose. The fixture is unsigned, so under
+    /// require-signed the posture check would drop it too and the address parse
+    /// would stop being the reason this test passes.
     #[test]
     fn test_try_extract_invalid_address_skipped() {
         let metadata = ChainMetadata {
@@ -1310,7 +1367,12 @@ mod tests {
         };
         // Invalid entries are skipped; with no valid entries left, result is None
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
+            try_extract_from_chain_metadata(
+                Some(&metadata),
+                1,
+                &MetadataTrustPolicy::AcceptUnsigned
+            )
+            .is_none()
         );
     }
 
@@ -1357,7 +1419,7 @@ mod tests {
 
     // --- deploy-time signer allowlist parsing ---
 
-    /// The happy path for `--accept-signatures-from-pubkey`: a hex key from the
+    /// The happy path for the planned deploy-time signer flag: a hex key from the
     /// cmdline lands in the allowlist and authorizes that signer's ABIs.
     #[test]
     fn signer_allowlist_from_hex_accepts_valid_key() {

--- a/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/abi_metadata.rs
@@ -13,7 +13,7 @@ use k256::ecdsa::SigningKey;
 use k256::ecdsa::signature::hazmat::PrehashSigner;
 use k256::ecdsa::signature::hazmat::PrehashVerifier;
 use k256::ecdsa::{Signature, VerifyingKey};
-use visualsign::signing::SignerAllowlist;
+use visualsign::signing::{MetadataTrustPolicy, SignerAllowlist};
 
 /// Maximum size for ABI JSON from proto messages (1 MB).
 /// File-based ABI loading has a 10 MB cap; proto-supplied ABIs use a tighter bound
@@ -37,32 +37,41 @@ enum AbiSignatureError {
 ///
 /// # Security notes
 ///
-/// - **Unsigned ABIs are accepted, but logged as unverified.** Not every caller
-///   signs its ABI mappings yet, so an entry with `signature: None` is registered
-///   rather than dropped; unsigned entries are counted and reported in a single
-///   aggregated warning once per request (no per-entry flag or marker is stored
-///   in the registry). This is acceptable because the whole caller-supplied ABI
-///   path is display-only and untrusted regardless of signature status (see
-///   below).
-/// - **When present, a signature is validated**, using secp256k1 over a
-///   domain-separated prehash that binds the chain id and the contract address to
-///   the ABI JSON (see [`visualsign::signing::ethereum_metadata_prehash`]). An entry
-///   that carries a signature but fails validation (bad signature, or signer not in
-///   the allowlist) is still rejected outright: a present-but-invalid signature is a
-///   stronger signal of tampering than simply omitting one.
+/// - **Whether unsigned ABIs are accepted is a deploy-time decision, not a
+///   request-time one.** `policy` is fixed when the parser process starts (for
+///   `parser_app`, by the `--accept-unsigned-abis` / `--accept-signatures-from-pubkey`
+///   cmdline flags that land in the signed TVC manifest's `pivotArgs`). A caller
+///   cannot move the parser between postures by omitting a signature, and a signer
+///   can verify out of band which posture the deployment runs. See
+///   [`MetadataTrustPolicy`].
+/// - **Under [`MetadataTrustPolicy::RequireAllowlistedSigner`]**, every entry must
+///   carry a signature that verifies AND whose key is allowlisted. Missing,
+///   malformed and unauthorized signatures are all rejected. An empty allowlist
+///   rejects everything (fail-closed).
+/// - **Under [`MetadataTrustPolicy::AcceptUnsigned`]**, an entry with
+///   `signature: None` is registered rather than dropped; unsigned entries are
+///   counted and reported in a single aggregated warning once per request (no
+///   per-entry flag or marker is stored in the registry, tracked in PRS-555). An
+///   entry that DOES carry a signature must still verify for integrity, since a
+///   present-but-invalid signature is a stronger signal of tampering than simply
+///   omitting one. The signer's *identity* is not checked in this posture: a
+///   deployment that accepts unsigned ABIs gains nothing from an allowlist an
+///   attacker sidesteps by dropping the signature, and the previous behaviour
+///   (accept unsigned, but reject a correctly signed entry whose signer is not
+///   allowlisted) was strictly worse than either coherent posture.
+/// - **Signature validation** uses secp256k1 over a domain-separated prehash that
+///   binds the chain id and the contract address to the ABI JSON (see
+///   [`visualsign::signing::ethereum_metadata_prehash`]).
 /// - **Signatures bind chain id + contract address.** The prehash commits to the
 ///   resolved `chain_id` and the entry's map-key address, so a signature minted for
 ///   an ABI at one (chain, address) no longer verifies when replayed under a
 ///   different address or chain. Existing signatures must be re-issued.
-/// - **Signers are checked against an authorized allowlist.** A verified signature
-///   only proves the ABI was signed by *some* secp256k1 key. Validation additionally
-///   requires the verifying key supplied in `SignatureMetadata` (the one the
-///   signature is checked against, not a key recovered from the signature) to
-///   appear in an authorized-signer allowlist (see
-///   [`authorized_abi_signers`]); unauthorized signers are rejected even when their
-///   signature verifies. An EMPTY allowlist rejects all signed ABIs (fail-closed),
-///   which is the secure default because the whole caller-supplied ABI path is
-///   display-only and untrusted.
+/// - **Signers are checked against an authorized allowlist** (require-signed
+///   posture only). A verified signature only proves the ABI was signed by *some*
+///   secp256k1 key; validation additionally requires the verifying key supplied in
+///   `SignatureMetadata` (the one the signature is checked against, not a key
+///   recovered from the signature) to appear in the allowlist. Unauthorized signers
+///   are rejected even when their signature verifies.
 /// - **`abi_type` and `implementation_address` are NOT covered by the ABI
 ///   signature.** The signature is computed over `abi.value` (the JSON ABI string)
 ///   only, so a man-in-the-middle could flip a signed implementation ABI to
@@ -76,7 +85,7 @@ enum AbiSignatureError {
 pub fn try_extract_from_chain_metadata(
     chain_metadata: Option<&ChainMetadata>,
     chain_id: u64,
-    allowlist: &SignerAllowlist,
+    policy: &MetadataTrustPolicy,
 ) -> Option<AbiRegistry> {
     let chain_metadata = chain_metadata?;
     let chain_metadata::Metadata::Ethereum(ethereum) = chain_metadata.metadata.as_ref()? else {
@@ -107,22 +116,37 @@ pub fn try_extract_from_chain_metadata(
             continue;
         }
 
-        // Signatures aren't required to register an entry: not every caller signs
-        // its ABI mappings yet, and this whole path is display-only and untrusted
-        // regardless. An entry that DOES carry a signature must still validate,
-        // since a present-but-invalid signature signals tampering rather than
-        // simply an unsigned source.
+        // Whether an unsigned entry is acceptable is fixed by the deployment's
+        // posture, not by the request. Under require-signed, a missing signature
+        // is a rejection; under accept-unsigned it is registered and counted. In
+        // both postures a signature that IS present must validate, since a
+        // present-but-invalid signature signals tampering rather than simply an
+        // unsigned source.
         let is_unsigned = abi.signature.is_none();
-        if let Some(proto_sig) = abi.signature.as_ref() {
-            let signature = convert_proto_signature(proto_sig);
-            if let Err(e) =
-                validate_abi_signature(&abi.value, &parsed_address, chain_id, &signature, allowlist)
-            {
+        match abi.signature.as_ref() {
+            Some(proto_sig) => {
+                let signature = convert_proto_signature(proto_sig);
+                if let Err(e) = validate_abi_signature(
+                    &abi.value,
+                    &parsed_address,
+                    chain_id,
+                    &signature,
+                    policy.signer_allowlist(),
+                ) {
+                    log::warn!(
+                        "Skipping ABI mapping for '{address}': signature validation failed: {e}"
+                    );
+                    continue;
+                }
+            }
+            None if !policy.accepts_unsigned() => {
                 log::warn!(
-                    "Skipping ABI mapping for '{address}': signature validation failed: {e}"
+                    "Skipping ABI mapping for '{address}': this deployment requires \
+                     signed ABI mappings (started with --accept-signatures-from-pubkey)"
                 );
                 continue;
             }
+            None => {}
         }
 
         // Determine the kind of contract this ABI describes. An unset or
@@ -243,26 +267,33 @@ struct SignatureMetadata {
     timestamp: Option<String>,
 }
 
-/// Validate ABI using secp256k1 signature, enforcing an authorized-signer allowlist.
+/// Validate ABI using secp256k1 signature, optionally enforcing an
+/// authorized-signer allowlist.
 ///
 /// The prehash is domain-separated and binds the chain id and contract address to
 /// the ABI JSON, so a signature minted for one (chain, address) does not verify when
 /// replayed under another. See [`visualsign::signing::ethereum_metadata_prehash`].
 ///
-/// Both checks must pass: the signature must verify over the prehash AND the
-/// `public_key` it was verified against must appear in `allowlist`. An empty
-/// allowlist rejects every signed ABI (fail-closed); see
-/// [`authorized_abi_signers`].
+/// The signature must always verify over the prehash (integrity). Whether the
+/// signer's *identity* is also enforced depends on the deployment posture and is
+/// expressed by `allowlist`:
+///
+/// * `Some(allow)` - the `public_key` the signature was verified against must also
+///   appear in `allow`. An empty allowlist rejects every signed ABI (fail-closed).
+/// * `None` - integrity only. Used by the accept-unsigned posture, where an
+///   identity check would be theatre: an attacker gets a weaker requirement by
+///   dropping the signature entirely. See [`MetadataTrustPolicy`].
 ///
 /// # Arguments
 /// * `abi_json` - The ABI JSON string that was signed
 /// * `address` - The contract address the ABI is bound to (the entry's map key)
 /// * `chain_id` - The resolved chain id the ABI is bound to
 /// * `signature` - Signature and metadata for validation
-/// * `allowlist` - Authorized signer public keys (canonical uncompressed bytes)
+/// * `allowlist` - Authorized signer public keys (canonical uncompressed bytes), or
+///   `None` to check integrity without checking signer identity
 ///
 /// # Returns
-/// * `Ok(())` if the signature is valid and the signer is authorized
+/// * `Ok(())` if the signature is valid and (when enforced) the signer is authorized
 /// * `Err(AbiSignatureError)` if signature validation fails or the signer is not
 ///   in the allowlist
 fn validate_abi_signature(
@@ -270,7 +301,7 @@ fn validate_abi_signature(
     address: &alloy_primitives::Address,
     chain_id: u64,
     signature: &SignatureMetadata,
-    allowlist: &SignerAllowlist,
+    allowlist: Option<&SignerAllowlist>,
 ) -> Result<(), AbiSignatureError> {
     // 1. Get algorithm - must be secp256k1
     let algorithm = signature
@@ -320,33 +351,44 @@ fn validate_abi_signature(
         AbiSignatureError::Validation(format!("Signature verification failed: {e}"))
     })?;
 
-    // 7. Enforce the authorized-signer allowlist. A verified signature only proves
-    //    the ABI was signed by some secp256k1 key; it must also be an authorized
-    //    one. Compare on the canonical uncompressed SEC1 encoding so the lookup
-    //    matches how keys are stored in the allowlist. An empty allowlist contains
-    //    nothing, so this rejects every signed ABI (fail-closed).
-    let signer_pubkey = verifying_key.to_encoded_point(false);
-    if !allowlist.contains(signer_pubkey.as_bytes()) {
-        return Err(AbiSignatureError::Validation(
-            "signer not in allowlist".to_string(),
-        ));
+    // 7. Enforce the authorized-signer allowlist, when the posture enforces
+    //    identity. A verified signature only proves the ABI was signed by some
+    //    secp256k1 key; it must also be an authorized one. Compare on the canonical
+    //    uncompressed SEC1 encoding so the lookup matches how keys are stored in the
+    //    allowlist. An empty allowlist contains nothing, so this rejects every signed
+    //    ABI (fail-closed).
+    if let Some(allowlist) = allowlist {
+        let signer_pubkey = verifying_key.to_encoded_point(false);
+        if !allowlist.contains(signer_pubkey.as_bytes()) {
+            return Err(AbiSignatureError::Validation(
+                "signer not in allowlist".to_string(),
+            ));
+        }
     }
 
     Ok(())
 }
 
-/// Build the authorized ABI-signer allowlist from compile-time + runtime sources.
+/// Build the local-tooling ABI-signer allowlist from compile-time + runtime sources.
 ///
 /// Under the `dev-signing` feature (and in this crate's own tests) the dev key
 /// derived from [`CLI_DEV_SIGNING_KEY_SEED`] is allowlisted, so locally-signed ABIs
 /// are accepted. The env var `VISUALSIGN_ETH_ABI_SIGNERS` (comma-separated hex
-/// secp256k1 public keys, any SEC1 encoding) extends the allowlist for configured
-/// deployments. Each runtime entry is canonicalized to its uncompressed encoding so
-/// compressed and uncompressed inputs for the same key match.
+/// secp256k1 public keys, any SEC1 encoding) extends the allowlist. Each runtime
+/// entry is canonicalized to its uncompressed encoding so compressed and
+/// uncompressed inputs for the same key match; invalid entries are warned about and
+/// skipped.
 ///
 /// An empty result (no dev key, no env entries) rejects all signed ABIs
-/// (fail-closed), which is the secure default for the untrusted, display-only
-/// caller-ABI path.
+/// (fail-closed).
+///
+/// **This is not how a deployment picks its trust posture.** `parser_app` and the
+/// gRPC server take the posture from their cmdline
+/// (`--accept-unsigned-abis` / `--accept-signatures-from-pubkey`, parsed into a
+/// [`MetadataTrustPolicy`] via [`signer_allowlist_from_hex`]) so the choice is
+/// auditable in the signed deployment manifest and cannot be influenced per
+/// request. This function backs `parser_cli`, which signs the ABI files it loads
+/// with the dev key and therefore runs require-signed against that key.
 #[must_use]
 pub fn authorized_abi_signers() -> SignerAllowlist {
     let mut allow = SignerAllowlist::new();
@@ -369,6 +411,31 @@ pub fn authorized_abi_signers() -> SignerAllowlist {
     }
 
     allow
+}
+
+/// Build a [`SignerAllowlist`] from deploy-time hex secp256k1 public keys (one per
+/// `--accept-signatures-from-pubkey` occurrence, any SEC1 encoding, optional `0x`
+/// prefix).
+///
+/// Unlike [`authorized_abi_signers`], a bad key is an error rather than a warning:
+/// these come from the deployment's cmdline, so a typo must stop the process at
+/// startup instead of silently producing a smaller (or empty, fail-closed)
+/// allowlist that quietly drops every caller-supplied ABI.
+///
+/// # Errors
+/// Returns `Err` if `entries` is empty, or if any entry is not a valid secp256k1
+/// public key.
+pub fn signer_allowlist_from_hex(entries: &[String]) -> Result<SignerAllowlist, String> {
+    if entries.is_empty() {
+        return Err("no authorized ABI signer public keys were provided".to_string());
+    }
+    let mut allow = SignerAllowlist::new();
+    for entry in entries {
+        let key = canonical_pubkey_from_hex(entry.trim())
+            .ok_or_else(|| format!("invalid secp256k1 public key: '{entry}'"))?;
+        allow.insert(key);
+    }
+    Ok(allow)
 }
 
 /// Parse a hex secp256k1 public key (optionally `0x`- or `0X`-prefixed, any
@@ -555,6 +622,37 @@ mod tests {
         allow
     }
 
+    /// Require-signed posture over an explicit allowlist.
+    fn require_signed(allow: SignerAllowlist) -> MetadataTrustPolicy {
+        MetadataTrustPolicy::RequireAllowlistedSigner(allow)
+    }
+
+    /// Require-signed posture authorizing only the deterministic test signer. This is
+    /// the posture most extraction tests run under, since their fixtures are signed.
+    fn test_require_signed() -> MetadataTrustPolicy {
+        require_signed(test_signer_allowlist())
+    }
+
+    /// Metadata carrying a single valid-but-unsigned ABI at `TEST_ADDRESS`. Shared by
+    /// the two posture tests so they compare identical caller input.
+    fn unsigned_metadata() -> ChainMetadata {
+        ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    TEST_ADDRESS,
+                    Abi {
+                        value: VALID_ABI.to_string(),
+                        signature: None,
+                        ..Default::default()
+                    },
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        }
+    }
+
     #[test]
     fn test_valid_signature_verification() {
         let addr = TEST_ADDRESS.parse::<Address>().expect("valid test address");
@@ -568,7 +666,8 @@ mod tests {
             timestamp: None,
         };
 
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(
             result.is_ok(),
             "Valid signature should verify: {:?}",
@@ -599,17 +698,17 @@ mod tests {
         let allow = test_signer_allowlist();
         // Valid for the exact (chain, address) it was produced for.
         assert!(
-            validate_abi_signature(VALID_ABI, &addr_a, 1, &sig, &allow).is_ok(),
+            validate_abi_signature(VALID_ABI, &addr_a, 1, &sig, Some(&allow)).is_ok(),
             "signature must verify for the bound (chain, address)"
         );
         // Same chain, different address: rejected.
         assert!(
-            validate_abi_signature(VALID_ABI, &addr_b, 1, &sig, &allow).is_err(),
+            validate_abi_signature(VALID_ABI, &addr_b, 1, &sig, Some(&allow)).is_err(),
             "signature must not verify when replayed under a different address"
         );
         // Same address, different chain: rejected.
         assert!(
-            validate_abi_signature(VALID_ABI, &addr_a, 137, &sig, &allow).is_err(),
+            validate_abi_signature(VALID_ABI, &addr_a, 137, &sig, Some(&allow)).is_err(),
             "signature must not verify when replayed under a different chain"
         );
     }
@@ -630,7 +729,7 @@ mod tests {
         // Allowlist holds the test signer's uncompressed key bytes.
         let allow = test_signer_allowlist();
         assert!(
-            validate_abi_signature(VALID_ABI, &addr, 1, &sig, &allow).is_ok(),
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&allow)).is_ok(),
             "a verified signature from an allowlisted signer must be accepted"
         );
     }
@@ -652,7 +751,7 @@ mod tests {
         // absent even though its signature verifies.
         let mut allow = SignerAllowlist::new();
         allow.insert(pubkey_bytes_from_seed(&[0x43u8; 32]));
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &allow);
+        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&allow));
         assert!(
             result.is_err(),
             "a verified signature from an unlisted signer must be rejected"
@@ -679,7 +778,7 @@ mod tests {
 
         let empty = SignerAllowlist::new();
         assert!(empty.is_empty(), "precondition: allowlist is empty");
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &empty);
+        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&empty));
         assert!(
             result.is_err(),
             "an empty allowlist must reject all signed ABIs (fail-closed)"
@@ -701,7 +800,8 @@ mod tests {
 
         // Try to verify with tampered ABI
         let tampered_abi = r#"[{"type":"function","name":"approve"}]"#;
-        let result = validate_abi_signature(tampered_abi, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(tampered_abi, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(result.is_err(), "Tampered content should fail verification");
     }
 
@@ -716,7 +816,8 @@ mod tests {
             timestamp: None,
         };
 
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Missing algorithm"), "Error: {err}");
@@ -733,7 +834,8 @@ mod tests {
             timestamp: None,
         };
 
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Missing public_key"), "Error: {err}");
@@ -750,7 +852,8 @@ mod tests {
             timestamp: None,
         };
 
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Unsupported algorithm"), "Error: {err}");
@@ -767,7 +870,8 @@ mod tests {
             timestamp: None,
         };
 
-        let result = validate_abi_signature(VALID_ABI, &addr, 1, &sig, &test_signer_allowlist());
+        let result =
+            validate_abi_signature(VALID_ABI, &addr, 1, &sig, Some(&test_signer_allowlist()));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Invalid signature hex"), "Error: {err}");
@@ -836,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_try_extract_no_metadata() {
-        assert!(try_extract_from_chain_metadata(None, 1, &test_signer_allowlist()).is_none());
+        assert!(try_extract_from_chain_metadata(None, 1, &test_require_signed()).is_none());
     }
 
     #[test]
@@ -849,7 +953,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
         );
     }
 
@@ -862,7 +966,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
         );
     }
 
@@ -879,9 +983,8 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("should contain ABI");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("should contain ABI");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
 
@@ -912,44 +1015,46 @@ mod tests {
             })),
         };
 
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("tampering with abi_type must NOT invalidate the body signature");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("tampering with abi_type must NOT invalidate the body signature");
         assert!(
             registry.list_abis().contains(&TEST_ADDRESS),
             "entry must still be accepted: abi_type/implementation_address are outside the signed scope"
         );
     }
 
-    /// An ABI mapping that omits the signature is still registered: not every
-    /// caller signs its ABI mappings yet, and this whole path is display-only and
-    /// untrusted regardless of signature status.
+    /// Under the accept-unsigned posture an ABI mapping that omits the signature is
+    /// registered rather than dropped. That is the deployment's explicit choice, not
+    /// a per-request default.
     #[test]
-    fn test_try_extract_unsigned_abi_accepted() {
-        let metadata = ChainMetadata {
-            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
-                network_id: Some("ETHEREUM_MAINNET".to_string()),
-                abi_mappings: make_abi_mappings(vec![(
-                    TEST_ADDRESS,
-                    Abi {
-                        value: VALID_ABI.to_string(),
-                        signature: None,
-                        ..Default::default()
-                    },
-                )])
-                .into_iter()
-                .collect(),
-            })),
-        };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("unsigned ABI entries must still be registered");
+    fn test_try_extract_unsigned_abi_accepted_under_accept_unsigned() {
+        let metadata = unsigned_metadata();
+        let registry = try_extract_from_chain_metadata(
+            Some(&metadata),
+            1,
+            &MetadataTrustPolicy::AcceptUnsigned,
+        )
+        .expect("unsigned ABI entries must be registered under accept-unsigned");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
 
-    /// Mixed signed and unsigned entries: neither one blocks the other. The signed
-    /// entry is verified, the unsigned entry is accepted unverified, and both end
-    /// up in the registry.
+    /// The core of PRS-556: the SAME unsigned request that the accept-unsigned
+    /// posture registers is rejected outright under require-signed. The caller's
+    /// payload is identical in both cases, so the difference comes purely from the
+    /// deployment's cmdline.
+    #[test]
+    fn test_try_extract_unsigned_abi_rejected_under_require_signed() {
+        let metadata = unsigned_metadata();
+        assert!(
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none(),
+            "require-signed must reject an unsigned ABI mapping, even though the \
+             accept-unsigned posture registers the very same request"
+        );
+    }
+
+    /// Mixed signed and unsigned entries under accept-unsigned: neither one blocks
+    /// the other. The signed entry is verified, the unsigned entry is accepted
+    /// unverified, and both end up in the registry.
     #[test]
     fn test_try_extract_mixed_signed_and_unsigned_both_accepted() {
         let unsigned_address = "0x3333333333333333333333333333333333333333";
@@ -971,9 +1076,12 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("should contain both entries");
+        let registry = try_extract_from_chain_metadata(
+            Some(&metadata),
+            1,
+            &MetadataTrustPolicy::AcceptUnsigned,
+        )
+        .expect("should contain both entries");
         assert!(
             registry.list_abis().contains(&unsigned_address),
             "unsigned entry must be registered alongside the signed one"
@@ -982,6 +1090,99 @@ mod tests {
             registry.list_abis().contains(&TEST_ADDRESS),
             "signed entry must still be registered"
         );
+    }
+
+    /// Under require-signed, the unsigned half of a mixed request is dropped while
+    /// the properly signed half survives. Rejection is per entry, not all-or-nothing.
+    #[test]
+    fn test_try_extract_mixed_drops_only_unsigned_under_require_signed() {
+        let unsigned_address = "0x3333333333333333333333333333333333333333";
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![
+                    (
+                        unsigned_address,
+                        Abi {
+                            value: VALID_ABI.to_string(),
+                            signature: None,
+                            ..Default::default()
+                        },
+                    ),
+                    (TEST_ADDRESS, signed_abi(VALID_ABI, TEST_ADDRESS)),
+                ])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("the signed entry must still register");
+        assert!(
+            !registry.list_abis().contains(&unsigned_address),
+            "require-signed must drop the unsigned entry"
+        );
+        assert!(
+            registry.list_abis().contains(&TEST_ADDRESS),
+            "require-signed must keep the properly signed entry"
+        );
+    }
+
+    /// Accept-unsigned still checks signature INTEGRITY when a signature is present:
+    /// a tampered body is rejected even in the permissive posture, so a
+    /// present-but-invalid signature never degrades to "accept and log".
+    #[test]
+    fn test_accept_unsigned_still_rejects_tampered_signature() {
+        // Signature is minted over VALID_ABI, then the body is swapped out.
+        let mut abi = signed_abi(VALID_ABI, TEST_ADDRESS);
+        abi.value = r#"[{"type":"function","name":"approve"}]"#.to_string();
+
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(TEST_ADDRESS, abi)])
+                    .into_iter()
+                    .collect(),
+            })),
+        };
+        assert!(
+            try_extract_from_chain_metadata(
+                Some(&metadata),
+                1,
+                &MetadataTrustPolicy::AcceptUnsigned
+            )
+            .is_none(),
+            "a present-but-invalid signature must be rejected even under accept-unsigned"
+        );
+    }
+
+    /// Accept-unsigned does NOT enforce signer identity: a validly signed entry from
+    /// a signer that would fail any allowlist is accepted, because the same entry
+    /// with the signature stripped would be accepted anyway. This pins the
+    /// intentional posture so a future change that starts enforcing identity here
+    /// (recreating the old incoherent "unsigned ok, signed-by-stranger rejected"
+    /// behaviour) fails loudly.
+    #[test]
+    fn test_accept_unsigned_does_not_enforce_signer_identity() {
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: make_abi_mappings(vec![(
+                    TEST_ADDRESS,
+                    signed_abi(VALID_ABI, TEST_ADDRESS),
+                )])
+                .into_iter()
+                .collect(),
+            })),
+        };
+        // Same fixture rejected by `test_try_extract_unauthorized_signer_still_rejected`
+        // under require-signed with a foreign allowlist.
+        let registry = try_extract_from_chain_metadata(
+            Some(&metadata),
+            1,
+            &MetadataTrustPolicy::AcceptUnsigned,
+        )
+        .expect("accept-unsigned checks integrity only, so this must register");
+        assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
 
     /// An entry that DOES carry a signature but fails validation (signer not on
@@ -1007,7 +1208,8 @@ mod tests {
         let mut unlisted_allow = SignerAllowlist::new();
         unlisted_allow.insert(pubkey_bytes_from_seed(&[0x43u8; 32]));
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &unlisted_allow).is_none(),
+            try_extract_from_chain_metadata(Some(&metadata), 1, &require_signed(unlisted_allow))
+                .is_none(),
             "a signature present but failing validation must still be rejected"
         );
     }
@@ -1068,9 +1270,8 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("should contain ABI");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("should contain ABI");
         assert!(registry.list_abis().contains(&TEST_ADDRESS));
     }
 
@@ -1108,7 +1309,7 @@ mod tests {
         };
         // Invalid entries are skipped; with no valid entries left, result is None
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
         );
     }
 
@@ -1129,7 +1330,7 @@ mod tests {
         // The signature is valid, so this exercises the JSON parse rejection path
         // rather than short-circuiting on the unsigned check.
         assert!(
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist()).is_none()
+            try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed()).is_none()
         );
     }
 
@@ -1148,10 +1349,60 @@ mod tests {
             })),
         };
         // The valid entry should be registered; the invalid one skipped
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("should contain the valid ABI");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("should contain the valid ABI");
         assert!(registry.list_abis().contains(&valid_address));
+    }
+
+    // --- deploy-time signer allowlist parsing ---
+
+    /// The happy path for `--accept-signatures-from-pubkey`: a hex key from the
+    /// cmdline lands in the allowlist and authorizes that signer's ABIs.
+    #[test]
+    fn signer_allowlist_from_hex_accepts_valid_key() {
+        let key = hex::encode(pubkey_bytes_from_seed(&[0x42u8; 32]));
+        let allow = signer_allowlist_from_hex(&[key]).expect("valid key must parse");
+        assert_eq!(allow.len(), 1);
+        assert!(allow.contains(&pubkey_bytes_from_seed(&[0x42u8; 32])));
+    }
+
+    /// Compressed and uncompressed encodings of the same key canonicalize to the
+    /// same allowlist entry, and both match the uncompressed form the verifier
+    /// derives from the signature.
+    #[test]
+    fn signer_allowlist_from_hex_canonicalizes_compressed_keys() {
+        let signing_key = SigningKey::from_bytes(&[0x42u8; 32]).expect("valid key");
+        let verifying_key = VerifyingKey::from(&signing_key);
+        let compressed = hex::encode(verifying_key.to_encoded_point(true).as_bytes());
+        let uncompressed = hex::encode(verifying_key.to_encoded_point(false).as_bytes());
+
+        let allow = signer_allowlist_from_hex(&[format!("0x{compressed}"), uncompressed])
+            .expect("both encodings must parse");
+        assert_eq!(
+            allow.len(),
+            1,
+            "compressed and uncompressed forms of one key must collapse to one entry"
+        );
+        assert!(allow.contains(&pubkey_bytes_from_seed(&[0x42u8; 32])));
+    }
+
+    /// A typo on the deployment cmdline must fail loudly at startup rather than
+    /// silently shrinking the allowlist (which would fail-closed and drop every
+    /// caller-supplied ABI for reasons nobody can see).
+    #[test]
+    fn signer_allowlist_from_hex_rejects_invalid_key() {
+        let valid = hex::encode(pubkey_bytes_from_seed(&[0x42u8; 32]));
+        let err = signer_allowlist_from_hex(&[valid, "not-a-key".to_string()])
+            .expect_err("an invalid key must be an error, not a skipped entry");
+        assert!(err.contains("invalid secp256k1 public key"), "error: {err}");
+    }
+
+    /// Require-signed with no keys at all is a configuration error, not an
+    /// accidentally-empty (reject-everything) allowlist.
+    #[test]
+    fn signer_allowlist_from_hex_rejects_empty_input() {
+        let err = signer_allowlist_from_hex(&[]).expect_err("empty input must be an error");
+        assert!(err.contains("no authorized ABI signer"), "error: {err}");
     }
 
     // --- proxy / abi_type tests ---
@@ -1176,9 +1427,8 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("has ABI");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("has ABI");
         assert_eq!(
             registry.get_abi_kind(1, parse_addr(TEST_ADDRESS)),
             Some(AbiKind::Implementation)
@@ -1205,9 +1455,8 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("has ABIs");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("has ABIs");
 
         assert_eq!(
             registry.get_abi_kind(1, parse_addr(PROXY_ADDRESS)),
@@ -1239,9 +1488,8 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("has ABI");
+        let registry = try_extract_from_chain_metadata(Some(&metadata), 1, &test_require_signed())
+            .expect("has ABI");
         // Entry is kept as a proxy, but with no resolvable implementation link.
         assert_eq!(
             registry.get_abi_kind(1, parse_addr(PROXY_ADDRESS)),
@@ -1260,11 +1508,11 @@ mod tests {
         );
     }
 
-    /// End-to-end regression for the reported bug: an UNSIGNED proxy entry
-    /// pointing at an UNSIGNED implementation entry must still resolve and
-    /// register both, so the implementation ABI is available for decoding.
-    /// Previously, omitting `signature` on either entry caused it to be
-    /// dropped outright, silently breaking proxy resolution.
+    /// End-to-end regression for the bug fixed in #406: under the accept-unsigned
+    /// posture, an UNSIGNED proxy entry pointing at an UNSIGNED implementation entry
+    /// must still resolve and register both, so the implementation ABI is available
+    /// for decoding. Before #406, omitting `signature` on either entry caused it to
+    /// be dropped outright, silently breaking proxy resolution.
     #[test]
     fn test_extract_unsigned_proxy_links_to_unsigned_implementation() {
         let metadata = ChainMetadata {
@@ -1293,9 +1541,12 @@ mod tests {
                 .collect(),
             })),
         };
-        let registry =
-            try_extract_from_chain_metadata(Some(&metadata), 1, &test_signer_allowlist())
-                .expect("has ABIs, even though neither entry is signed");
+        let registry = try_extract_from_chain_metadata(
+            Some(&metadata),
+            1,
+            &MetadataTrustPolicy::AcceptUnsigned,
+        )
+        .expect("has ABIs, even though neither entry is signed");
 
         assert_eq!(
             registry.get_abi_kind(1, parse_addr(PROXY_ADDRESS)),

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -40,24 +40,27 @@ impl EthereumPlugin {
     }
 }
 
+/// The CLI's ABI trust posture: signs every ABI it loads with the local dev key
+/// (see `build_abi_mappings_from_files`), so it runs the strict posture against
+/// that key. Locally-loaded ABIs are accepted, anything unsigned is not.
+/// Deployments are meant to take their posture from their own cmdline instead;
+/// that wiring is a planned follow-up, see
+/// `abi_metadata::signer_allowlist_from_hex`.
+fn cli_trust_policy() -> visualsign::signing::MetadataTrustPolicy {
+    visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+        crate::abi_metadata::authorized_abi_signers(),
+    )
+}
+
 impl parser_cli_core::ChainPlugin for EthereumPlugin {
     fn chain(&self) -> Chain {
         Chain::Ethereum
     }
 
     fn register(&self, registry: &mut TransactionConverterRegistry) {
-        // The CLI signs every ABI it loads with the local dev key (see
-        // `build_abi_mappings_from_files`), so it runs the strict posture against
-        // that key: locally-loaded ABIs are accepted, anything unsigned is not.
-        // Deployments take their posture from their own cmdline instead; see
-        // `abi_metadata::authorized_abi_signers`.
         registry.register::<crate::EthereumTransactionWrapper, _>(
             Chain::Ethereum,
-            crate::EthereumVisualSignConverter::with_policy(
-                visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-                    crate::abi_metadata::authorized_abi_signers(),
-                ),
-            ),
+            crate::EthereumVisualSignConverter::with_policy(cli_trust_policy()),
         );
     }
 
@@ -116,15 +119,14 @@ fn build_abi_mappings_from_files(
         "ContractAddress",
         validate_eth_address,
         |components, json| {
-            // The metadata-ABI extraction path accepts unsigned entries too, but the
-            // CLI attaches an integrity signature using a deterministic local dev key
-            // so locally-loaded ABIs extract as verified rather than logged as
-            // unverified. This is integrity, not identity, the CLI is a local dev tool
-            // that already trusts its input files; production trust comes from the
-            // service running the parser, which validates the signature and checks the
-            // signer's public key against an allowlist during extraction (see
-            // `abi_metadata::try_extract_from_chain_metadata`), not from the gRPC
-            // caller.
+            // The CLI attaches an integrity signature using a deterministic local dev
+            // key, and registers its converter under the require-signed posture (see
+            // `cli_trust_policy`), so a locally-loaded ABI extracts only because it is
+            // signed. This is integrity, not identity, the CLI is a local dev tool that
+            // already trusts its input files. Whether a deployment requires signatures
+            // at all is its own posture decision, taken at construction time rather
+            // than per request (see `abi_metadata::try_extract_from_chain_metadata`),
+            // never something the gRPC caller picks.
             //
             // The signature binds the contract address and chain id, so it must be
             // produced for the same (chain, address) the parser verifies with. The
@@ -414,8 +416,8 @@ mod tests {
             .get("0xdac17f958d2ee523a2206206994597c13d831ec7")
             .expect("mapping present");
         assert!(abi.value.contains("swap"));
-        // CLI signs locally-loaded ABIs so they extract as verified rather than
-        // logged as unverified by the metadata-ABI extractor.
+        // CLI signs locally-loaded ABIs so they survive the require-signed posture
+        // the CLI registers its converter under.
         assert!(
             abi.signature.is_some(),
             "CLI should attach a dev-key signature to locally-loaded ABIs"
@@ -531,12 +533,20 @@ mod tests {
         assert_eq!(proxy_abi.value, "[]");
         assert_eq!(proxy_abi.abi_type, Some(AbiType::Proxy as i32));
         assert_eq!(proxy_abi.implementation_address.as_deref(), Some(IMPL));
-        // Regression guard: the CLI still signs the synthesized proxy ABI so it
-        // extracts as verified, even though the extractor now also accepts
-        // unsigned entries.
+        // Regression guard: the CLI still signs the synthesized proxy ABI, which is
+        // what lets it survive the require-signed posture the CLI registers under.
         assert!(
             proxy_abi.signature.is_some(),
             "synthesized proxy ABI must be signed so the extractor treats it as verified",
+        );
+
+        // Pin the CLI's posture itself. A signed entry survives under either posture
+        // (accept-unsigned still integrity-checks a signature that is present), so the
+        // extraction assertion below cannot tell the two apart. Without this, flipping
+        // `cli_trust_policy` to accept-unsigned would leave the whole suite green.
+        assert!(
+            !super::cli_trust_policy().accepts_unsigned(),
+            "the CLI must register the require-signed posture",
         );
 
         // End-to-end: the signed synthesized proxy survives extraction. `list_abis`
@@ -548,11 +558,8 @@ mod tests {
             Some(&extracted),
             1,
             // dev-signing is enabled for the CLI, so this allowlists the dev key the
-            // CLI signed the synthesized proxy with. Strict posture on purpose: the
-            // point of the assertion is that the entry survives BECAUSE it is signed.
-            &visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-                crate::abi_metadata::authorized_abi_signers(),
-            ),
+            // CLI signed the synthesized proxy with.
+            &super::cli_trust_policy(),
         )
         .expect("metadata with a signed synthesized proxy must extract");
         assert!(

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -46,9 +46,18 @@ impl parser_cli_core::ChainPlugin for EthereumPlugin {
     }
 
     fn register(&self, registry: &mut TransactionConverterRegistry) {
+        // The CLI signs every ABI it loads with the local dev key (see
+        // `build_abi_mappings_from_files`), so it runs the strict posture against
+        // that key: locally-loaded ABIs are accepted, anything unsigned is not.
+        // Deployments take their posture from their own cmdline instead; see
+        // `abi_metadata::authorized_abi_signers`.
         registry.register::<crate::EthereumTransactionWrapper, _>(
             Chain::Ethereum,
-            crate::EthereumVisualSignConverter::new(),
+            crate::EthereumVisualSignConverter::with_policy(
+                visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+                    crate::abi_metadata::authorized_abi_signers(),
+                ),
+            ),
         );
     }
 
@@ -539,8 +548,11 @@ mod tests {
             Some(&extracted),
             1,
             // dev-signing is enabled for the CLI, so this allowlists the dev key the
-            // CLI signed the synthesized proxy with.
-            &crate::abi_metadata::authorized_abi_signers(),
+            // CLI signed the synthesized proxy with. Strict posture on purpose: the
+            // point of the assertion is that the entry survives BECAUSE it is signed.
+            &visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+                crate::abi_metadata::authorized_abi_signers(),
+            ),
         )
         .expect("metadata with a signed synthesized proxy must extract");
         assert!(

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -44,8 +44,8 @@ impl EthereumPlugin {
 /// (see `build_abi_mappings_from_files`), so it runs the strict posture against
 /// that key. Locally-loaded ABIs are accepted, anything unsigned is not.
 /// Deployments are meant to take their posture from their own cmdline instead;
-/// that wiring is a planned follow-up, see
-/// `abi_metadata::signer_allowlist_from_hex`.
+/// that wiring is a planned follow-up, and the flag plus the parser that turns it
+/// into a `MetadataTrustPolicy` land together there rather than here.
 fn cli_trust_policy() -> visualsign::signing::MetadataTrustPolicy {
     visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
         crate::abi_metadata::authorized_abi_signers(),
@@ -540,17 +540,11 @@ mod tests {
             "synthesized proxy ABI must be signed so the extractor treats it as verified",
         );
 
-        // Pin the CLI's posture itself. A signed entry survives under either posture
-        // (accept-unsigned still integrity-checks a signature that is present), so the
-        // extraction assertion below cannot tell the two apart. Without this, flipping
-        // `cli_trust_policy` to accept-unsigned would leave the whole suite green.
-        assert!(
-            !super::cli_trust_policy().accepts_unsigned(),
-            "the CLI must register the require-signed posture",
-        );
-
-        // End-to-end: the signed synthesized proxy survives extraction. `list_abis`
-        // returns each registered entry's address string.
+        // End-to-end: the signed synthesized proxy survives extraction under the
+        // CLI's posture. This is about proxy synthesis, not about which posture
+        // `register` installs: a signed entry is accepted under either posture, so
+        // it cannot tell them apart. `test_register_installs_require_signed_posture`
+        // is what pins the posture. `list_abis` returns each entry's address string.
         let extracted = ChainMetadata {
             metadata: Some(Metadata::Ethereum(eth)),
         };
@@ -561,6 +555,7 @@ mod tests {
             // CLI signed the synthesized proxy with.
             &super::cli_trust_policy(),
         )
+        .registry
         .expect("metadata with a signed synthesized proxy must extract");
         assert!(
             registry.list_abis().contains(&PROXY),

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -346,6 +346,12 @@ pub(crate) fn create_chain_metadata(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use alloy_consensus::TxEip1559;
+    use alloy_primitives::U256;
+    use alloy_rlp::Encodable;
+    use alloy_sol_types::{SolCall, sol};
+    use parser_cli_core::ChainPlugin;
+    use visualsign::vsptrait::VisualSignOptions;
 
     fn write_temp_json(name: &str, content: &str) -> std::path::PathBuf {
         parser_cli_core::test_utils::write_temp_json("vsp_eth_tests", name, content)
@@ -560,6 +566,116 @@ mod tests {
         assert!(
             registry.list_abis().contains(&PROXY),
             "signed synthesized proxy must survive extraction",
+        );
+    }
+
+    /// The posture must be pinned through `register`, not through the helper that
+    /// feeds it.
+    ///
+    /// Asserting on `cli_trust_policy()` in isolation proves nothing about what the
+    /// CLI actually runs: editing `register` back to
+    /// `EthereumVisualSignConverter::new()` leaves such an assertion passing and
+    /// silently reverts the CLI to accept-unsigned. So this goes through the plugin,
+    /// converts a real transaction, and observes the decode.
+    ///
+    /// `customFoo` is deliberately a function no built-in visualizer knows, so the
+    /// unsigned metadata ABI is the only thing that could decode it. The
+    /// accept-unsigned control converter proves the fixture is good, so the
+    /// registered converter's refusal cannot be a false negative.
+    #[test]
+    fn test_register_installs_require_signed_posture() {
+        sol! {
+            function customFoo(uint256 x) external;
+        }
+
+        let contract: alloy_primitives::Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let calldata = customFooCall {
+            x: U256::from(7u64),
+        }
+        .abi_encode();
+        let selector_hex = hex::encode(&calldata[..4]);
+
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 100_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000,
+            to: alloy_primitives::TxKind::Call(contract),
+            input: calldata.into(),
+            ..Default::default()
+        };
+        let mut buf = vec![0x02]; // EIP-1559 type byte
+        tx.encode(&mut buf);
+        let tx_hex = format!("0x{}", hex::encode(&buf));
+
+        // Deliberately unsigned: this is the entry the CLI's posture must refuse.
+        let build_options = || {
+            let mut abi_mappings = BTreeMap::new();
+            abi_mappings.insert(
+                contract.to_string(),
+                Abi {
+                    value: r#"[{
+                        "type": "function",
+                        "name": "customFoo",
+                        "inputs": [{"name": "x", "type": "uint256"}],
+                        "outputs": [],
+                        "stateMutability": "nonpayable"
+                    }]"#
+                    .to_string(),
+                    signature: None,
+                    ..Default::default()
+                },
+            );
+            VisualSignOptions {
+                include_intermediate_output: false,
+                decode_transfers: true,
+                transaction_name: None,
+                metadata: Some(ChainMetadata {
+                    metadata: Some(Metadata::Ethereum(EthereumMetadata {
+                        network_id: Some("ETHEREUM_MAINNET".to_string()),
+                        abi_mappings: abi_mappings.into_iter().collect(),
+                    })),
+                }),
+                developer_config: None,
+            }
+        };
+
+        // Control: a converter on the permissive posture decodes the same fixture.
+        let mut permissive_registry = TransactionConverterRegistry::new();
+        permissive_registry.register::<crate::EthereumTransactionWrapper, _>(
+            Chain::Ethereum,
+            crate::EthereumVisualSignConverter::new(),
+        );
+        let permissive = permissive_registry
+            .convert_transaction(&Chain::Ethereum, &tx_hex, build_options())
+            .unwrap()
+            .payload
+            .to_json()
+            .unwrap();
+        assert!(
+            permissive.contains("customFoo"),
+            "accept-unsigned must decode the unsigned metadata ABI, got: {permissive}"
+        );
+
+        // The converter the CLI plugin actually installs must refuse it.
+        let mut registry = TransactionConverterRegistry::new();
+        EthereumPlugin::new(EthereumArgs::default()).register(&mut registry);
+        let rendered = registry
+            .convert_transaction(&Chain::Ethereum, &tx_hex, build_options())
+            .unwrap()
+            .payload
+            .to_json()
+            .unwrap();
+        assert!(
+            !rendered.contains("customFoo"),
+            "the converter `register` installs must not decode an unsigned metadata ABI, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(&selector_hex),
+            "dropping the unsigned ABI must leave the raw selector {selector_hex}, got: {rendered}"
         );
     }
 

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -16,7 +16,7 @@ use visualsign::{
     SignablePayloadFieldAmountV2, SignablePayloadFieldCommon, SignablePayloadFieldTextV2,
     encodings::SupportedEncodings,
     registry::LayeredRegistry,
-    signing::SignerAllowlist,
+    signing::MetadataTrustPolicy,
     vsptrait::{
         ConversionResult, DeveloperConfig, Transaction, TransactionParseError, VisualSignConverter,
         VisualSignConverterFromString, VisualSignError, VisualSignOptions,
@@ -165,60 +165,58 @@ impl EthereumTransactionWrapper {
 pub struct EthereumVisualSignConverter {
     registry: Arc<registry::ContractRegistry>,
     visualizer_registry: visualizer::EthereumVisualizerRegistry,
-    abi_signers: SignerAllowlist,
+    abi_trust: MetadataTrustPolicy,
 }
 
 impl EthereumVisualSignConverter {
     /// Creates a new converter with a custom registry wrapped in Arc.
     ///
-    /// The ABI-signer allowlist is the default from
-    /// [`abi_metadata::authorized_abi_signers`]. Use [`Self::with_registry_and_signers`]
-    /// to inject an explicit allowlist.
+    /// Uses the permissive [`MetadataTrustPolicy::AcceptUnsigned`] posture. See
+    /// [`Self::new`] for why, and use [`Self::with_registry_and_policy`] to pin an
+    /// explicit posture.
     pub fn with_registry(registry: Arc<registry::ContractRegistry>) -> Self {
-        Self {
-            registry,
-            visualizer_registry: visualizer::EthereumVisualizerRegistryBuilder::new().build(),
-            abi_signers: abi_metadata::authorized_abi_signers(),
-        }
+        Self::with_registry_and_policy(registry, MetadataTrustPolicy::AcceptUnsigned)
     }
 
-    /// Creates a converter with a custom registry and an explicit ABI-signer
-    /// allowlist. Intended for tests and configured deployments that need to control
-    /// which signers are authorized rather than relying on the compile-time/env
-    /// defaults.
-    pub fn with_registry_and_signers(
+    /// Creates a converter with a custom registry and an explicit caller-metadata
+    /// trust posture.
+    pub fn with_registry_and_policy(
         registry: Arc<registry::ContractRegistry>,
-        abi_signers: SignerAllowlist,
+        abi_trust: MetadataTrustPolicy,
     ) -> Self {
         Self {
             registry,
             visualizer_registry: visualizer::EthereumVisualizerRegistryBuilder::new().build(),
-            abi_signers,
+            abi_trust,
         }
     }
 
     /// Creates a converter with the default registry (all known protocols) and an
-    /// explicit ABI-signer allowlist. Mirrors [`Self::new`] but overrides the signer
-    /// allowlist.
-    pub fn with_signers(abi_signers: SignerAllowlist) -> Self {
+    /// explicit caller-metadata trust posture. Mirrors [`Self::new`] but pins the
+    /// posture instead of taking the permissive default.
+    ///
+    /// This is the constructor a deployment should use: `parser_app` and the gRPC
+    /// server build the posture from their cmdline so it is fixed at deploy time and
+    /// auditable, rather than implied by what each request happens to contain.
+    pub fn with_policy(abi_trust: MetadataTrustPolicy) -> Self {
         let (contract_registry, visualizer_builder) =
             registry::ContractRegistry::with_default_protocols();
         Self {
             registry: Arc::new(contract_registry),
             visualizer_registry: visualizer_builder.build(),
-            abi_signers,
+            abi_trust,
         }
     }
 
-    /// Creates a new converter with a default registry including all known protocols.
+    /// Creates a new converter with a default registry including all known protocols
+    /// and the permissive [`MetadataTrustPolicy::AcceptUnsigned`] posture.
+    ///
+    /// This is the library/embedding default and preserves the behaviour every
+    /// in-process caller had before the posture became explicit. Deployments must
+    /// NOT rely on it: they choose a posture on the cmdline and construct via
+    /// [`Self::with_policy`], so a signer can check which mode the deployment runs.
     pub fn new() -> Self {
-        let (contract_registry, visualizer_builder) =
-            registry::ContractRegistry::with_default_protocols();
-        Self {
-            registry: Arc::new(contract_registry),
-            visualizer_registry: visualizer_builder.build(),
-            abi_signers: abi_metadata::authorized_abi_signers(),
-        }
+        Self::with_policy(MetadataTrustPolicy::AcceptUnsigned)
     }
 
     /// Creates a layered registry for the current request.
@@ -267,7 +265,7 @@ impl EthereumVisualSignConverter {
 
         // Resolve chain_id: metadata > transaction > default (1 for legacy).
         let chain_id = resolve_chain_id(&transaction, &options)?;
-        let metadata_abi = extract_metadata_abi(&options, chain_id, &self.abi_signers);
+        let metadata_abi = extract_metadata_abi(&options, chain_id, &self.abi_trust);
 
         convert_to_visual_sign_payload(
             transaction,
@@ -480,9 +478,9 @@ fn resolve_chain_id(
 fn extract_metadata_abi(
     options: &VisualSignOptions,
     chain_id: u64,
-    allowlist: &SignerAllowlist,
+    policy: &MetadataTrustPolicy,
 ) -> Option<abi_registry::AbiRegistry> {
-    abi_metadata::try_extract_from_chain_metadata(options.metadata.as_ref(), chain_id, allowlist)
+    abi_metadata::try_extract_from_chain_metadata(options.metadata.as_ref(), chain_id, policy)
 }
 
 /// Known-token short-circuit: if the destination is a token registered in the
@@ -880,7 +878,7 @@ mod tests {
 
     // Test-only adapter: call the converter and unwrap the `ConversionResult`
     // to the `SignablePayload` these tests assert against, while preserving the
-    // specific converter instance (e.g. `with_signers`).
+    // specific converter instance (e.g. `with_policy`).
     trait TestConvertExt {
         fn to_payload(
             &self,

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -195,9 +195,11 @@ impl EthereumVisualSignConverter {
     /// explicit caller-metadata trust posture. Mirrors [`Self::new`] but pins the
     /// posture instead of taking the permissive default.
     ///
-    /// This is the constructor a deployment should use: `parser_app` and the gRPC
-    /// server build the posture from their cmdline so it is fixed at deploy time and
-    /// auditable, rather than implied by what each request happens to contain.
+    /// This is the constructor a deployment should use to pin an explicit posture
+    /// at construction time, fixed for the process rather than implied by what
+    /// each request happens to contain. `parser_cli` already does this against its
+    /// dev key; wiring `parser_app` and the gRPC server to build their posture from
+    /// their own cmdline is planned as a follow-up and is not part of this change.
     pub fn with_policy(abi_trust: MetadataTrustPolicy) -> Self {
         let (contract_registry, visualizer_builder) =
             registry::ContractRegistry::with_default_protocols();
@@ -211,10 +213,15 @@ impl EthereumVisualSignConverter {
     /// Creates a new converter with a default registry including all known protocols
     /// and the permissive [`MetadataTrustPolicy::AcceptUnsigned`] posture.
     ///
-    /// This is the library/embedding default and preserves the behaviour every
-    /// in-process caller had before the posture became explicit. Deployments must
-    /// NOT rely on it: they choose a posture on the cmdline and construct via
-    /// [`Self::with_policy`], so a signer can check which mode the deployment runs.
+    /// This is the library/embedding default. Unsigned caller metadata is accepted
+    /// exactly as it was before the posture became explicit; a present signature is
+    /// still verified for integrity, but its signer is deliberately no longer
+    /// checked against an allowlist, so an entry signed by an unlisted key is now
+    /// accepted where it used to be rejected. See [`MetadataTrustPolicy`] for why
+    /// that pairing was incoherent. Deployments that want an auditable, non-default
+    /// posture must NOT rely on this constructor: they should construct via
+    /// [`Self::with_policy`] with an explicit
+    /// [`MetadataTrustPolicy::RequireAllowlistedSigner`] instead.
     pub fn new() -> Self {
         Self::with_policy(MetadataTrustPolicy::AcceptUnsigned)
     }

--- a/src/chain_parsers/visualsign-ethereum/src/lib.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/lib.rs
@@ -272,6 +272,11 @@ impl EthereumVisualSignConverter {
 
         // Resolve chain_id: metadata > transaction > default (1 for legacy).
         let chain_id = resolve_chain_id(&transaction, &options)?;
+        // `rejected_by_policy` and `unverified` are deliberately not consumed here:
+        // rendering them needs a field on the payload (the follow-up to PRS-555,
+        // which shipped without one), which is out of scope for this change. They
+        // are carried this far so that follow-up has something to read instead of a
+        // `log::warn!` the enclave binary compiles away.
         let metadata_abi = extract_metadata_abi(&options, chain_id, &self.abi_trust);
 
         convert_to_visual_sign_payload(
@@ -280,7 +285,7 @@ impl EthereumVisualSignConverter {
             chain_id,
             &layered_registry,
             &self.visualizer_registry,
-            metadata_abi.as_ref(),
+            metadata_abi.registry.as_ref(),
         )
     }
 }
@@ -482,11 +487,17 @@ fn resolve_chain_id(
 }
 
 /// Extract ABI from wallet-provided metadata with graceful degradation.
+///
+/// Returns the whole [`abi_metadata::AbiExtraction`] rather than just the registry
+/// so the caller keeps the counts that separate "the request supplied no ABI
+/// mappings" from "this deployment refused every mapping it supplied". Both render
+/// identically (raw selector), so collapsing them here would throw away the only
+/// in-process signal that distinguishes them.
 fn extract_metadata_abi(
     options: &VisualSignOptions,
     chain_id: u64,
     policy: &MetadataTrustPolicy,
-) -> Option<abi_registry::AbiRegistry> {
+) -> abi_metadata::AbiExtraction {
     abi_metadata::try_extract_from_chain_metadata(options.metadata.as_ref(), chain_id, policy)
 }
 

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -383,6 +383,111 @@ fn test_abi_from_metadata_decodes_function() {
     );
 }
 
+/// The converter must honour the posture it was CONSTRUCTED with.
+///
+/// Feeds the same UNSIGNED mapping to both postures and asserts they diverge:
+/// accept-unsigned decodes it, require-signed drops it and leaves the raw selector.
+///
+/// This is what pins the policy actually reaching extraction. Every other metadata-ABI
+/// test here supplies a correctly signed mapping, which is accepted under either
+/// posture, so a converter that ignored its stored policy and always accepted unsigned
+/// metadata would keep the whole suite green.
+///
+/// `customFoo` is deliberately a function no built-in visualizer knows, so the metadata
+/// ABI is the only thing that can decode it. A built-in-decodable selector (an ERC-20
+/// `transfer`, say) renders the same under both postures and would prove nothing.
+#[test]
+fn test_converter_honours_stored_require_signed_posture() {
+    sol! {
+        function customFoo(uint256 x) external;
+    }
+
+    let calldata = customFooCall {
+        x: U256::from(7u64),
+    }
+    .abi_encode();
+    let selector_hex = hex::encode(&calldata[..4]);
+
+    let unknown_contract: alloy_primitives::Address = "0x1111111111111111111111111111111111111111"
+        .parse()
+        .unwrap();
+
+    let tx = TxEip1559 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 100_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 1_000_000,
+        to: alloy_primitives::TxKind::Call(unknown_contract),
+        input: calldata.into(),
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    buf.push(0x02); // EIP-1559 type byte
+    tx.encode(&mut buf);
+    let tx_hex = format!("0x{}", hex::encode(&buf));
+
+    let abi_json = r#"[{
+        "type": "function",
+        "name": "customFoo",
+        "inputs": [{"name": "x", "type": "uint256"}],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    }]"#;
+
+    // Deliberately unsigned: this is the entry the strict posture has to reject.
+    let build_options = || {
+        let mut abi_mappings = BTreeMap::new();
+        abi_mappings.insert(
+            unknown_contract.to_string(),
+            Abi {
+                value: abi_json.to_string(),
+                signature: None,
+                ..Default::default()
+            },
+        );
+        VisualSignOptions {
+            include_intermediate_output: false,
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: Some(ChainMetadata {
+                metadata: Some(Metadata::Ethereum(EthereumMetadata {
+                    network_id: Some("ETHEREUM_MAINNET".to_string()),
+                    abi_mappings: abi_mappings.into_iter().collect(),
+                })),
+            }),
+            developer_config: None,
+        }
+    };
+
+    // Control: the permissive posture accepts the unsigned mapping and decodes it, so
+    // the fixture is known-good and the strict result below cannot be a false negative.
+    let permissive = EthereumVisualSignConverter::new()
+        .to_payload_from_string(&tx_hex, build_options())
+        .unwrap()
+        .to_json()
+        .unwrap();
+    assert!(
+        permissive.contains("customFoo"),
+        "accept-unsigned must decode the unsigned metadata ABI, got: {permissive}"
+    );
+
+    let strict = require_signed_converter()
+        .to_payload_from_string(&tx_hex, build_options())
+        .unwrap()
+        .to_json()
+        .unwrap();
+    assert!(
+        !strict.contains("customFoo"),
+        "require-signed must not decode an unsigned metadata ABI, got: {strict}"
+    );
+    assert!(
+        strict.contains(&selector_hex),
+        "dropping the unsigned ABI must leave the raw selector {selector_hex}, got: {strict}"
+    );
+}
+
 #[test]
 fn test_proxy_decodes_via_implementation_abi() {
     // A transaction to a proxy address should be decoded against the linked

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -82,7 +82,7 @@ fn sign_abi_for_test(abi_json: &str, address: &alloy_primitives::Address) -> Sig
 /// (seed `[0x42u8; 32]`). In the integration-test build the `dev-signing` feature is
 /// off and no env var is set, so `authorized_abi_signers()` is empty (fail-closed).
 /// Tests that submit a signed ABI and expect it to be accepted inject this explicit
-/// allowlist via `EthereumVisualSignConverter::with_signers`.
+/// allowlist via `EthereumVisualSignConverter::with_policy`.
 fn test_abi_signer_allowlist() -> visualsign::signing::SignerAllowlist {
     let seed: [u8; 32] = [0x42u8; 32];
     let signing_key = k256::ecdsa::SigningKey::from_bytes(&seed).expect("valid key");
@@ -358,7 +358,11 @@ fn test_abi_from_metadata_decodes_function() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_signers(test_abi_signer_allowlist());
+    let converter = EthereumVisualSignConverter::with_policy(
+        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+            test_abi_signer_allowlist(),
+        ),
+    );
     let result = converter.to_payload_from_string(&tx_hex, options).unwrap();
 
     // The ABI from metadata should decode the function name.
@@ -459,7 +463,11 @@ fn test_proxy_decodes_via_implementation_abi() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_signers(test_abi_signer_allowlist());
+    let converter = EthereumVisualSignConverter::with_policy(
+        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+            test_abi_signer_allowlist(),
+        ),
+    );
     let json = converter
         .to_payload_from_string(&tx_hex, options)
         .unwrap()
@@ -552,7 +560,11 @@ fn test_proxy_entry_cannot_override_canonical_token() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_signers(test_abi_signer_allowlist());
+    let converter = EthereumVisualSignConverter::with_policy(
+        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+            test_abi_signer_allowlist(),
+        ),
+    );
     let json = converter
         .to_payload_from_string(&tx_hex, options)
         .unwrap()
@@ -667,7 +679,11 @@ fn test_chain_id_matching_metadata_succeeds() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_signers(test_abi_signer_allowlist());
+    let converter = EthereumVisualSignConverter::with_policy(
+        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+            test_abi_signer_allowlist(),
+        ),
+    );
     let payload = converter
         .to_payload_from_string(&tx_hex, options)
         .expect("matching network_id and chain_id should parse cleanly");

--- a/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
+++ b/src/chain_parsers/visualsign-ethereum/tests/lib_test.rs
@@ -93,6 +93,15 @@ fn test_abi_signer_allowlist() -> visualsign::signing::SignerAllowlist {
     allow
 }
 
+/// Converter configured to require a signature from `test_abi_signer_allowlist`.
+fn require_signed_converter() -> EthereumVisualSignConverter {
+    EthereumVisualSignConverter::with_policy(
+        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
+            test_abi_signer_allowlist(),
+        ),
+    )
+}
+
 // Helper function to get fixture path
 fn fixture_path(name: &str) -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -358,11 +367,7 @@ fn test_abi_from_metadata_decodes_function() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_policy(
-        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-            test_abi_signer_allowlist(),
-        ),
-    );
+    let converter = require_signed_converter();
     let result = converter.to_payload_from_string(&tx_hex, options).unwrap();
 
     // The ABI from metadata should decode the function name.
@@ -463,11 +468,7 @@ fn test_proxy_decodes_via_implementation_abi() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_policy(
-        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-            test_abi_signer_allowlist(),
-        ),
-    );
+    let converter = require_signed_converter();
     let json = converter
         .to_payload_from_string(&tx_hex, options)
         .unwrap()
@@ -560,11 +561,7 @@ fn test_proxy_entry_cannot_override_canonical_token() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_policy(
-        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-            test_abi_signer_allowlist(),
-        ),
-    );
+    let converter = require_signed_converter();
     let json = converter
         .to_payload_from_string(&tx_hex, options)
         .unwrap()
@@ -679,11 +676,7 @@ fn test_chain_id_matching_metadata_succeeds() {
         developer_config: None,
     };
 
-    let converter = EthereumVisualSignConverter::with_policy(
-        visualsign::signing::MetadataTrustPolicy::RequireAllowlistedSigner(
-            test_abi_signer_allowlist(),
-        ),
-    );
+    let converter = require_signed_converter();
     let payload = converter
         .to_payload_from_string(&tx_hex, options)
         .expect("matching network_id and chain_id should parse cleanly");

--- a/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/visualsign.rs
@@ -139,7 +139,8 @@ impl SolanaTransactionWrapper {
 ///
 /// # Security
 ///
-/// Mirrors `visualsign-ethereum::abi_metadata::try_extract_from_chain_metadata`:
+/// Structured after `visualsign-ethereum::abi_metadata::try_extract_from_chain_metadata`,
+/// but no longer at parity with it on trust posture: see step 4.
 /// 1. The program_id must be a valid base58 Solana `Pubkey`; otherwise the
 ///    entry is skipped.
 /// 2. Mappings whose `program_id` is a trusted built-in (i.e.
@@ -169,6 +170,17 @@ impl SolanaTransactionWrapper {
 ///    IDLs are still accepted so the feature degrades gracefully; callers that
 ///    need mandatory signatures must enforce that at the API boundary. This
 ///    check refuses to plumb attacker-tampered IDL bodies into the registry.
+///
+///    **This pairing is not deliberate, and Ethereum no longer matches it.**
+///    Accepting unsigned IDLs while rejecting a correctly signed one from an
+///    unlisted signer means an attacker gets a weaker requirement by dropping the
+///    signature than by supplying one, so the identity check buys nothing while
+///    making the strictly worse input the accepted one. PRS-556 removed exactly
+///    this combination on the Ethereum ABI path (see
+///    `visualsign::signing::MetadataTrustPolicy`), which is chain-neutral so
+///    extending it here is mechanical. Doing so is out of scope for that change
+///    and wants its own ticket; until then, treat this as a known gap rather than
+///    as the intended design.
 /// 5. The resolved `program_name` (from proto, IDL metadata, or fallback)
 ///    must not be a reserved canonical name. Step 2 already rejects when
 ///    the *program_id* is trusted, so by this step `program_id` has no
@@ -255,8 +267,10 @@ fn extract_idl_mappings_with_signers(
         }
 
         // 4. If a signature is provided it must verify AND the signer must be
-        //    allowlisted; unsigned IDLs are accepted (parity with the Ethereum
-        //    ABI path).
+        //    allowlisted; unsigned IDLs are accepted. This is the pairing PRS-556
+        //    removed from the Ethereum ABI path for being strictly worse than
+        //    either coherent posture, so it is a known gap here, NOT parity with
+        //    Ethereum. See the security notes on this function.
         if let Some(proto_sig) = idl.signature.as_ref() {
             let local_sig = convert_proto_signature(proto_sig);
             if let Err(e) =
@@ -1782,9 +1796,14 @@ mod tests {
         }
     }
 
-    /// Unsigned IDL mappings are still accepted (parity with the Ethereum ABI
-    /// path). The trusted-builtin-name protection in `IdlRegistry` is what
-    /// stops the attacker-controlled name from being rendered.
+    /// Unsigned IDL mappings are still accepted. The trusted-builtin-name
+    /// protection in `IdlRegistry` is what stops the attacker-controlled name from
+    /// being rendered.
+    ///
+    /// Note this is no longer parity with the Ethereum ABI path: Ethereum accepts
+    /// unsigned metadata only under an explicit `AcceptUnsigned` posture, and it
+    /// stopped pairing that with an identity check. This path still does both. See
+    /// the security notes on `extract_idl_mappings`.
     #[test]
     fn test_extract_idl_mappings_accepts_unsigned_idl() {
         let options = make_options_with_idl_mapping(

--- a/src/parser/app/src/registry.rs
+++ b/src/parser/app/src/registry.rs
@@ -41,3 +41,92 @@ pub fn create_registry() -> visualsign::registry::TransactionConverterRegistry {
     );
     registry
 }
+
+#[cfg(all(test, feature = "ethereum"))]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use generated::parser::{Abi, ChainMetadata, EthereumMetadata, chain_metadata};
+    use std::collections::BTreeMap;
+    use visualsign::registry::Chain;
+    use visualsign::vsptrait::VisualSignOptions;
+
+    /// EIP-1559 transaction to `0x1111..1111` calling `customFoo(uint256)` with
+    /// `x = 7`, chain 1, unsigned. `customFoo` is deliberately a function no
+    /// built-in visualizer knows, so a caller-supplied metadata ABI is the only
+    /// thing that can decode it: whether the selector or the function name renders
+    /// is a direct read of the trust posture. RLP is deterministic, so this is a
+    /// fixed string rather than a reason to pull alloy into this crate's dev-deps.
+    const CUSTOM_FOO_TX_HEX: &str = "0x02f84b0180830f4240843b9aca00830186a094111111111111111111111111111111111111111180a46ab6fefe0000000000000000000000000000000000000000000000000000000000000007c0";
+    const CUSTOM_FOO_SELECTOR: &str = "6ab6fefe";
+
+    fn options_with_unsigned_abi() -> VisualSignOptions {
+        let mut abi_mappings = BTreeMap::new();
+        abi_mappings.insert(
+            "0x1111111111111111111111111111111111111111".to_string(),
+            Abi {
+                value: r#"[{
+                    "type": "function",
+                    "name": "customFoo",
+                    "inputs": [{"name": "x", "type": "uint256"}],
+                    "outputs": [],
+                    "stateMutability": "nonpayable"
+                }]"#
+                .to_string(),
+                signature: None,
+                ..Default::default()
+            },
+        );
+        VisualSignOptions {
+            include_intermediate_output: false,
+            decode_transfers: true,
+            transaction_name: None,
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Ethereum(EthereumMetadata {
+                    network_id: Some("ETHEREUM_MAINNET".to_string()),
+                    abi_mappings: abi_mappings.into_iter().collect(),
+                })),
+            }),
+            developer_config: None,
+        }
+    }
+
+    /// Pins the ABI trust posture the deployed binary actually runs.
+    ///
+    /// `create_registry` is the only production construction site for the Ethereum
+    /// converter, and which posture it installs is decided purely by which
+    /// constructor this file calls. Moving between `new()` (accept-unsigned) and
+    /// `with_policy(RequireAllowlistedSigner(..))` compiles clean and, without this
+    /// test, leaves the whole suite green, so nothing would tell a reviewer that the
+    /// production posture had changed.
+    ///
+    /// Today it is accept-unsigned, deliberately: this is the posture the enclave
+    /// binary has always effectively run, since the compiled-in allowlist is empty
+    /// there and an unsigned entry was already accepted. The deploy-time flag that
+    /// lets an operator choose require-signed is a follow-up; when it lands, this
+    /// assertion is the one that has to be updated on purpose, which is the point.
+    #[test]
+    fn create_registry_runs_the_accept_unsigned_abi_posture() {
+        let rendered = super::create_registry()
+            .convert_transaction(
+                &Chain::Ethereum,
+                CUSTOM_FOO_TX_HEX,
+                options_with_unsigned_abi(),
+            )
+            .expect("fixture transaction must convert")
+            .payload
+            .to_json()
+            .expect("payload must serialize");
+
+        assert!(
+            rendered.contains("customFoo"),
+            "create_registry is expected to run accept-unsigned, so the unsigned \
+             caller ABI must decode. If this now fails because the posture was \
+             tightened on purpose, update this test; if it fails unexpectedly, the \
+             production posture moved without anyone deciding to. Got: {rendered}"
+        );
+        assert!(
+            !rendered.contains(CUSTOM_FOO_SELECTOR),
+            "a decoded call must not fall back to the raw selector, got: {rendered}"
+        );
+    }
+}

--- a/src/visualsign/src/signing.rs
+++ b/src/visualsign/src/signing.rs
@@ -120,6 +120,71 @@ impl FromIterator<Vec<u8>> for SignerAllowlist {
     }
 }
 
+/// Deploy-time trust posture for caller-supplied metadata (Ethereum ABI
+/// mappings today; the Solana IDL path still uses a bare [`SignerAllowlist`]).
+///
+/// The posture is picked once by whoever deploys the parser and is fixed for the
+/// life of the process. Nothing in a request can move the parser between the two
+/// variants: a caller cannot opt itself into leniency by omitting a signature,
+/// and cannot opt itself into strictness either. That is the point of the type.
+/// Because the choice lives on the parser's cmdline (for the enclave binary, in
+/// the `pivotArgs` of the signed TVC manifest), a signer can verify out of band
+/// which posture the deployment they are signing against actually runs, instead
+/// of trusting a per-request signal or a log line that no one sees.
+///
+/// The two variants are mutually exclusive by construction:
+///
+/// - [`Self::AcceptUnsigned`]: metadata with no signature is accepted. A
+///   signature that IS present must still verify (integrity), but the signer's
+///   identity is not checked, because a deployment that accepts unsigned
+///   metadata gains nothing from an identity check an attacker can sidestep by
+///   simply dropping the signature.
+/// - [`Self::RequireAllowlistedSigner`]: every entry must carry a signature that
+///   verifies AND whose key is in the allowlist. Missing, malformed, and
+///   unauthorized signatures are all rejected. An empty allowlist rejects
+///   everything (fail-closed).
+///
+/// There is deliberately no `Default`: a deployment has to say which posture it
+/// runs.
+#[derive(Debug, Clone)]
+pub enum MetadataTrustPolicy {
+    /// Accept unsigned metadata; verify integrity only when a signature is present.
+    AcceptUnsigned,
+    /// Reject any metadata not signed by one of the allowlisted keys.
+    RequireAllowlistedSigner(SignerAllowlist),
+}
+
+impl MetadataTrustPolicy {
+    /// Returns `true` if metadata with no signature at all is accepted.
+    #[must_use]
+    pub fn accepts_unsigned(&self) -> bool {
+        matches!(self, Self::AcceptUnsigned)
+    }
+
+    /// The allowlist a present signature's signer must appear in, or `None` when
+    /// the posture only checks signature integrity (see [`Self::AcceptUnsigned`]).
+    #[must_use]
+    pub fn signer_allowlist(&self) -> Option<&SignerAllowlist> {
+        match self {
+            Self::AcceptUnsigned => None,
+            Self::RequireAllowlistedSigner(allow) => Some(allow),
+        }
+    }
+}
+
+impl std::fmt::Display for MetadataTrustPolicy {
+    /// Human-readable posture, for the one-line startup log that tells an
+    /// operator which mode the process came up in.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AcceptUnsigned => write!(f, "accept-unsigned"),
+            Self::RequireAllowlistedSigner(allow) => {
+                write!(f, "require-signed ({} authorized signer(s))", allow.len())
+            }
+        }
+    }
+}
+
 /// Domain separation tag for the v1 metadata signing prehash.
 ///
 /// Version-stamps the construction so prehashes from different format versions
@@ -301,6 +366,60 @@ mod tests {
         assert!(allow.contains(b"key-a"));
         assert!(allow.contains(b"key-b"));
         assert!(!allow.contains(b"key-c"));
+    }
+
+    #[test]
+    fn test_accept_unsigned_policy_skips_signer_identity() {
+        let policy = MetadataTrustPolicy::AcceptUnsigned;
+        assert!(policy.accepts_unsigned());
+        assert!(
+            policy.signer_allowlist().is_none(),
+            "accept-unsigned must not enforce signer identity: an attacker can \
+             always drop the signature instead"
+        );
+    }
+
+    #[test]
+    fn test_require_signed_policy_exposes_allowlist() {
+        let mut allow = SignerAllowlist::new();
+        allow.insert(b"key-a".to_vec());
+        let policy = MetadataTrustPolicy::RequireAllowlistedSigner(allow);
+
+        assert!(
+            !policy.accepts_unsigned(),
+            "require-signed must reject unsigned metadata"
+        );
+        let enforced = policy.signer_allowlist().expect("allowlist is enforced");
+        assert!(enforced.contains(b"key-a"));
+        assert!(!enforced.contains(b"key-b"));
+    }
+
+    #[test]
+    fn test_policy_display_names_the_posture() {
+        assert_eq!(
+            MetadataTrustPolicy::AcceptUnsigned.to_string(),
+            "accept-unsigned"
+        );
+
+        let mut allow = SignerAllowlist::new();
+        allow.insert(b"key-a".to_vec());
+        allow.insert(b"key-b".to_vec());
+        assert_eq!(
+            MetadataTrustPolicy::RequireAllowlistedSigner(allow).to_string(),
+            "require-signed (2 authorized signer(s))"
+        );
+    }
+
+    /// An empty allowlist under require-signed authorizes nothing, so the posture
+    /// rejects every entry (fail-closed) rather than degrading to accept-unsigned.
+    #[test]
+    fn test_require_signed_with_empty_allowlist_authorizes_nothing() {
+        let policy = MetadataTrustPolicy::RequireAllowlistedSigner(SignerAllowlist::new());
+        assert!(!policy.accepts_unsigned());
+        assert!(policy
+            .signer_allowlist()
+            .expect("allowlist is enforced")
+            .is_empty());
     }
 
     #[test]

--- a/src/visualsign/src/signing.rs
+++ b/src/visualsign/src/signing.rs
@@ -127,10 +127,12 @@ impl FromIterator<Vec<u8>> for SignerAllowlist {
 /// life of the process. Nothing in a request can move the parser between the two
 /// variants: a caller cannot opt itself into leniency by omitting a signature,
 /// and cannot opt itself into strictness either. That is the point of the type.
-/// Because the choice lives on the parser's cmdline (for the enclave binary, in
-/// the `pivotArgs` of the signed TVC manifest), a signer can verify out of band
-/// which posture the deployment they are signing against actually runs, instead
-/// of trusting a per-request signal or a log line that no one sees.
+/// The intent is for the choice to live on the parser's cmdline (for the
+/// enclave binary, in the `pivotArgs` of the signed TVC manifest), so a signer
+/// can verify out of band which posture the deployment they are signing against
+/// actually runs, instead of trusting a per-request signal or a log line that no
+/// one sees. Wiring the enclave binary and gRPC server to a cmdline flag is a
+/// planned follow-up; today only `parser_cli` constructs an explicit posture.
 ///
 /// The two variants are mutually exclusive by construction:
 ///

--- a/src/visualsign/src/signing.rs
+++ b/src/visualsign/src/signing.rs
@@ -135,10 +135,13 @@ impl FromIterator<Vec<u8>> for SignerAllowlist {
 /// The two variants are mutually exclusive by construction:
 ///
 /// - [`Self::AcceptUnsigned`]: metadata with no signature is accepted. A
-///   signature that IS present must still verify (integrity), but the signer's
-///   identity is not checked, because a deployment that accepts unsigned
-///   metadata gains nothing from an identity check an attacker can sidestep by
-///   simply dropping the signature.
+///   signature that IS present must still verify against the public key carried
+///   alongside it in the same untrusted metadata (so a mutated payload under an
+///   unchanged signature/key pair is still rejected), but that key's identity is
+///   not checked against an allowlist, because a deployment that accepts
+///   unsigned metadata gains nothing from an identity check an attacker can
+///   sidestep by simply dropping the signature (or re-signing with a key of
+///   their own choosing).
 /// - [`Self::RequireAllowlistedSigner`]: every entry must carry a signature that
 ///   verifies AND whose key is in the allowlist. Missing, malformed, and
 ///   unauthorized signatures are all rejected. An empty allowlist rejects


### PR DESCRIPTION
## Why

[PRS-556](https://linear.app/anchorlabs/issue/PRS-556/move-abi-trust-posture-from-per-request-behavior-to-a-deploy-time-flag), part 1 of 2. Library groundwork only, no flags and no deployment changes here. #421 stacks on top of this and adds the deploy-time flags.

Split out because this half carries the one real behaviour change in PRS-556, and it deserves reading on its own rather than buried under a PR whose headline is "add two cmdline flags".

Today the parser's willingness to honour caller-supplied ABI mappings that carry no signature is an unconditional property of the code. #406 made unsigned acceptance the default to fix a real bug (unsigned proxy to unsigned implementation was silently dropped), but that left every caller able to omit the signature and get an unverified ABI decoded and rendered, with no way for anyone to choose otherwise.

Making that choice explicit needs a type to represent it first. That is all this PR does.

## What

`visualsign::signing::MetadataTrustPolicy`, a chain-neutral XOR enum:

```rust
pub enum MetadataTrustPolicy {
    AcceptUnsigned,
    RequireAllowlistedSigner(SignerAllowlist),
}
```

No `Default` impl, deliberately. A default is exactly the implicit choice PRS-556 exists to remove, so the type refuses to let a caller skip the decision.

`EthereumVisualSignConverter::with_policy` takes it, and `try_extract_from_chain_metadata` threads it down to `validate_abi_signature`, which now takes `Option<&SignerAllowlist>` instead of a bare allowlist.

Every existing caller passes the equivalent of today's behaviour, so this PR is behaviour-preserving except for the one item below. `parser_cli` moves to require-signed against the local dev key it already signs its own ABI files with.

`try_extract_from_chain_metadata` now returns `AbiExtraction` (registry plus counts) instead of `Option<AbiRegistry>`. A request whose every mapping the posture refused used to be byte-identical to a request that supplied no mappings at all: both return no registry, both render the raw selector, and the only thing separating them was a `log::warn!`. That is not a channel anyone can read from the enclave, since `parser_app` declares no `log` dependency and initialises no logger, so those calls are compiled-in no-ops there rather than log lines nobody reads. The counts now survive the return so the follow-up that renders them has something to read.

### The one behaviour change

Under accept-unsigned, a signature that *is* present is still verified, but its signer is no longer checked against an allowlist.

The old combination was incoherent. In production (no `dev-signing` feature, no env var) the allowlist is empty, so a correctly signed ABI was rejected while the same ABI with the signature stripped was accepted. An attacker facing an identity check just drops the signature, so the check bought nothing while making the strictly worse input the accepted one. Pinned by a test so a change back to the old behaviour fails loudly.

Being precise about what the surviving integrity check buys, because an earlier draft of these doc comments overstated it: the signature is verified against the public key carried alongside it in the same untrusted `SignatureMetadata`. It catches a tamperer who mutates `abi.value` and leaves the signature and key alone. It does not catch one who controls the whole entry and re-signs with a key of their own. Worth keeping, but it is not provenance, and the comments now say so.

Because identity is no longer enforced in that posture, the aggregated unverified counter now counts "identity was not enforced" rather than "signature absent". Under accept-unsigned a self-signed entry is exactly as unattributed as an unsigned one, and counting only the latter would report zero unverified mappings for a request whose entire decode came from an unattributed caller ABI.

### The intermediate state is deliberate

`parser_app` builds its converter through `EthereumVisualSignConverter::new()`, which is accept-unsigned, and this PR does not change `parser/app/src/registry.rs`. Merging this alone therefore moves the production enclave binary from rejecting an ABI entry signed by a non-allowlisted key to accepting it, with no flag to opt out until #421 lands.

This is not an escalation of attacker capability: the same render was already reachable on `main` by omitting the signature, which is the whole reason the old pairing was incoherent. But it is a real change to what the deployed binary does, so it should not be discovered later:

- Merging both PRs together is fine, and #421 targets this branch.
- Merging this one alone is also fine, and lands the accept-unsigned posture explicitly rather than by accident.

Either way, `create_registry_runs_the_accept_unsigned_abi_posture` in `parser/app/src/registry.rs` now pins which posture the deployed binary runs, so moving it takes a deliberate test edit instead of compiling clean and leaving the suite green.

## Testing

`make lint`, `make test`, and `cargo fmt --all -- --check` all clean on this branch alone:

```
FMT_EXIT=0     cargo fmt --all -- --check
LINT_EXIT=0    make lint    (clippy -D warnings, incl. parser_cli + diagnostics variants)
TEST_EXIT=0    make test    (38 suites, 0 failures)
```

Unit coverage in `abi_metadata` for both postures on the same fixture: unsigned accepted under `AcceptUnsigned` and rejected under `RequireAllowlistedSigner`, a mixed request dropping only the unsigned half, and a tampered signature rejected under both postures.

Each of the four assertions this PR relies on was mutation-checked (revert the production line, confirm the test goes red):

| Test | Mutation it catches |
|---|---|
| `create_registry_runs_the_accept_unsigned_abi_posture` | `create_registry` switching posture |
| `test_register_installs_require_signed_posture` | `EthereumPlugin::register` reverting to `new()` |
| `test_accept_unsigned_counts_self_signed_entry_as_unverified` | counter going back to `signature.is_none()` |
| `test_total_refusal_is_distinguishable_from_absent_metadata` | rejection count not being carried out |

The first two go through the registry rather than through the helper that feeds it. Asserting on a `cli_trust_policy()`-shaped helper in isolation proves nothing about what gets registered: editing the `register` call back to `new()` leaves such an assertion passing.

The end-to-end evidence (identical request against two `parser_app` instances differing only in cmdline) lands in #421, since it needs the flags.

## Rollback

Plain revert. No state, schema, wire-format, or deployment changes.

Correcting an earlier claim in this section: this is **not** invisible from outside the library. `parser_app` picks up the accept-unsigned posture described above, so reverting after deploy means redeploying the enclave binary to restore the previous (incoherent) rejection of signed-by-unlisted entries. Nothing persists, so the revert is otherwise clean.

## Backwards compatibility

No proto or payload changes. Behaviour-preserving apart from the allowlist-identity item called out above, which is a deliberate correction of an incoherent combination rather than a regression.

Breaking for out-of-tree embedders of `visualsign-ethereum`, none known in the tree:

- `EthereumVisualSignConverter::with_signers` and `with_registry_and_signers` are removed. Replaced by `with_policy` and `with_registry_and_policy`, which take a `MetadataTrustPolicy` instead of a bare `SignerAllowlist`. Migration is `with_signers(allow)` to `with_policy(RequireAllowlistedSigner(allow))`.
- `with_registry` and `Default`/`new` keep compiling unchanged but now resolve to `AcceptUnsigned`, so an embedder that was relying on identity enforcement loses it silently. Those call sites should move to `with_registry_and_policy` / `with_policy`.
- `try_extract_from_chain_metadata` returns `AbiExtraction` rather than `Option<AbiRegistry>`. The registry is now `.registry`.

## Not in scope

The deploy-time flags, `tvc-deploy` manifest changes, and the workflow changes are in #421, which targets this branch. The cmdline parser that turns flag occurrences into a `MetadataTrustPolicy` moves there too, so the flag and its parser land together and the empty-allowlist contract gets settled where it is actually observable, rather than shipping a parser here with no non-test caller.

Solana IDL mappings still carry the exact pairing this PR removes from Ethereum (unsigned IDLs accepted, correctly signed IDLs from unlisted signers rejected). `MetadataTrustPolicy` is chain-neutral so extending it is mechanical, but it is out of scope here and wants its own ticket. The comments in `visualsign-solana` that described this as "parity with the Ethereum ABI path" are corrected here to say it is a known gap, so a Solana reader does not conclude the pairing is deliberate.

Surfacing verified/unverified status in the rendered payload is still not done. PRS-555 was closed Done on 2026-07-14, but `abi_registry.rs` carries no verified or unsigned field, so the gap it described is real and now has no open ticket pointing at it. This PR carries the counts out of the extractor so the eventual fix has something to read, and does not add a payload field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
