### PR TITLE
feat(near): add NEAR Intents preset (decode + render) and merge converters

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -45,7 +45,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
  "cpufeatures",
 ]
@@ -121,7 +121,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -389,7 +389,7 @@ checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
 dependencies = [
  "alloy-rlp",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
@@ -1186,6 +1186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-util"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e509844de8f09b90a2c3444684a2b6695f4071360e13d2fda0af9f749cc2ed6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,7 +1811,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "constant_time_eq",
  "digest 0.10.7",
 ]
@@ -1867,6 +1876,15 @@ name = "bnum"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+
+[[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+dependencies = [
+ "borsh 1.6.0",
+]
 
 [[package]]
 name = "borsh"
@@ -2120,6 +2138,12 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -2359,7 +2383,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
 
@@ -2379,7 +2403,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "proptest",
  "serde_core",
@@ -2513,7 +2537,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2630,7 +2654,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2778,7 +2802,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -2791,7 +2815,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -2823,6 +2847,256 @@ checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "defuse-auth-call"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-bitmap"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-map-utils",
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-borsh-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "array-util",
+ "chrono",
+ "defuse-io-utils",
+ "impl-tools",
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-core"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "chrono",
+ "defuse-auth-call",
+ "defuse-bitmap",
+ "defuse-borsh-utils",
+ "defuse-crypto",
+ "defuse-deadline",
+ "defuse-erc191",
+ "defuse-fees",
+ "defuse-map-utils",
+ "defuse-near-utils",
+ "defuse-nep245",
+ "defuse-nep413",
+ "defuse-num-utils",
+ "defuse-sep53",
+ "defuse-serde-utils",
+ "defuse-tip191",
+ "defuse-token-id",
+ "defuse-ton-connect",
+ "defuse-webauthn",
+ "derive_more 2.1.1",
+ "hex",
+ "hex-literal 1.1.0",
+ "impl-tools",
+ "near-contract-standards",
+ "near-sdk",
+ "serde_with",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "defuse-crypto"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "ed25519-dalek 2.2.0",
+ "generic-array 1.3.5",
+ "hex",
+ "near-sdk",
+ "p256",
+ "serde_with",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "defuse-deadline"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "chrono",
+ "defuse-borsh-utils",
+ "defuse-near-utils",
+ "defuse-num-utils",
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-erc191"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-crypto",
+ "impl-tools",
+ "near-sdk",
+ "serde_with",
+]
+
+[[package]]
+name = "defuse-fees"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-num-utils",
+ "near-sdk",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "defuse-io-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+
+[[package]]
+name = "defuse-map-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "impl-tools",
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-near-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "chrono",
+ "defuse-borsh-utils",
+ "digest 0.10.7",
+ "impl-tools",
+ "near-sdk",
+]
+
+[[package]]
+name = "defuse-nep245"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-near-utils",
+ "derive_more 2.1.1",
+ "near-sdk",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "defuse-nep413"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-crypto",
+ "defuse-near-utils",
+ "defuse-nep461",
+ "defuse-serde-utils",
+ "impl-tools",
+ "near-sdk",
+ "serde_with",
+]
+
+[[package]]
+name = "defuse-nep461"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+
+[[package]]
+name = "defuse-num-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "bnum 0.13.0",
+]
+
+[[package]]
+name = "defuse-sep53"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-crypto",
+ "impl-tools",
+ "near-sdk",
+ "serde_with",
+]
+
+[[package]]
+name = "defuse-serde-utils"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "derive_more 2.1.1",
+ "near-sdk",
+ "serde_with",
+ "tlb-ton",
+]
+
+[[package]]
+name = "defuse-tip191"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-crypto",
+ "impl-tools",
+ "near-sdk",
+ "serde_with",
+]
+
+[[package]]
+name = "defuse-token-id"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-nep245",
+ "derive_more 2.1.1",
+ "near-contract-standards",
+ "near-sdk",
+ "serde_with",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "defuse-ton-connect"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "chrono",
+ "defuse-crypto",
+ "defuse-near-utils",
+ "defuse-serde-utils",
+ "impl-tools",
+ "near-sdk",
+ "schemars 0.8.22",
+ "serde_with",
+ "tlb-ton",
+]
+
+[[package]]
+name = "defuse-webauthn"
+version = "0.1.0"
+source = "git+https://github.com/near/intents.git?tag=defuse%2Fv0.4.2#6dad94cf8a9cf3083d9c1cf6c052ef8cdde0d473"
+dependencies = [
+ "defuse-crypto",
+ "defuse-serde-utils",
+ "near-sdk",
+ "serde_with",
 ]
 
 [[package]]
@@ -3047,7 +3321,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dirs-sys-next",
 ]
 
@@ -3306,7 +3580,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -3535,7 +3809,7 @@ dependencies = [
  "fastcrypto-derive",
  "generic-array 0.14.7",
  "hex",
- "hex-literal",
+ "hex-literal 0.4.1",
  "hkdf",
  "lazy_static",
  "num-bigint 0.4.6",
@@ -3993,6 +4267,7 @@ version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
 dependencies = [
+ "generic-array 0.14.7",
  "rustversion",
  "typenum",
 ]
@@ -4013,7 +4288,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
@@ -4026,7 +4301,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4039,7 +4314,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi",
@@ -4069,7 +4344,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "dashmap 5.5.3",
  "futures",
  "futures-timer",
@@ -4157,7 +4432,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "zerocopy",
 ]
@@ -4300,6 +4575,12 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "histogram"
@@ -4758,6 +5039,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-tools"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae314a99afb5821e2fda288387546d4a04aace674551e854e6216b892ec3208"
+dependencies = [
+ "autocfg",
+ "impl-tools-lib",
+ "proc-macro-error2",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "impl-tools-lib"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab699036df31c1f7d3561bfa6e9cb9bc3bb0fd2e2cd9bf121c31cb961d049ddf"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,7 +5246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -5052,7 +5357,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92a55e0ff3b72c262bcf041d9e97f1b84492b68f1c1a384de2323d3dc9403397"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
  "sha2 0.10.9",
@@ -5064,7 +5369,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
@@ -5137,7 +5442,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -5436,6 +5741,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -6047,6 +6358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-contract-standards"
+version = "5.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b20cc8f3dd3696dff11ee70e168b2bf957b6e9d1d0730c9b80c1c66cdc3a3b"
+dependencies = [
+ "near-sdk",
+]
+
+[[package]]
 name = "near-crypto"
 version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6073,6 +6393,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-crypto-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c203dab49864dd98bb39a849ff78a2191415f2c287b5a1c0845d7ab743539d9"
+dependencies = [
+ "borsh 1.6.0",
+ "bs58 0.5.1",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "near-fmt"
 version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6089,6 +6421,24 @@ checksum = "559c33c9c86e05da946358485fa6e7e881a09726f909fbd8bcf357f998d7d03d"
 dependencies = [
  "borsh 1.6.0",
  "serde",
+]
+
+[[package]]
+name = "near-global-contracts"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf48643e6c1915cbd0858ba6cad70bf6436ee9ff67d311cbb192b258ac87978"
+dependencies = [
+ "borsh 1.6.0",
+ "cfg_eval",
+ "hex",
+ "near-account-id",
+ "near-crypto-hash",
+ "near-primitives-core",
+ "near-sdk-env",
+ "serde",
+ "serde_with",
+ "sha3",
 ]
 
 [[package]]
@@ -6198,10 +6548,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee4669ee1f3f8d0fe467c367188d6bf7ba17c215f5b2c0edec593cf4b76bbb3"
 
 [[package]]
+name = "near-sdk"
+version = "5.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b26762e22529b71ee7b8b4381ce384663a6bc4972f21f5a3d14fdacdfd1e9e"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.6.0",
+ "bs58 0.5.1",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "near-account-id",
+ "near-crypto",
+ "near-gas",
+ "near-global-contracts",
+ "near-primitives-core",
+ "near-sdk-core",
+ "near-sdk-env",
+ "near-sdk-macros",
+ "near-sys",
+ "near-token",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "unicode-segmentation",
+ "wee_alloc",
+]
+
+[[package]]
+name = "near-sdk-core"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b3ae894bb8c7e3526e999a9f85d5b06c25230a36606ad176ec5c5d782b67fa"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 1.6.0",
+ "bs58 0.5.1",
+ "hex",
+ "near-account-id",
+ "near-crypto",
+ "near-crypto-hash",
+ "near-gas",
+ "near-primitives-core",
+ "near-sdk-env",
+ "near-token",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "near-sdk-env"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f4bf153cf88eadafff20c6d82b16e3cab3fc4d636d3530473079044ddb9bf3"
+dependencies = [
+ "near-sys",
+ "ripemd",
+ "sha2 0.10.9",
+ "sha3",
+]
+
+[[package]]
+name = "near-sdk-macros"
+version = "5.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11aae1b7786dd9d15b8fe5e94756412236e7b3fe31ab2f3bc1e0f54041f463a2"
+dependencies = [
+ "Inflector",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "near-stdx"
 version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "586d4ca605c2540a158a4c89d46de0d2649fe52bb94db6a0ddff42a243d37d04"
+
+[[package]]
+name = "near-sys"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c212278351251aa342eab33a9d64f99294bc5784cda10107867a72dda699bb"
 
 [[package]]
 name = "near-time"
@@ -6250,7 +6687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -6263,7 +6700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
@@ -6276,7 +6713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
@@ -6565,7 +7002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
 dependencies = [
  "alloy-rlp",
- "cfg-if",
+ "cfg-if 1.0.4",
  "proptest",
  "ruint",
  "serde",
@@ -6624,7 +7061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.10.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "once_cell",
@@ -6845,7 +7282,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -7239,7 +7676,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -7429,7 +7866,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "fnv",
  "lazy_static",
  "memchr",
@@ -8208,7 +8645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.16",
  "libc",
  "untrusted",
@@ -8560,6 +8997,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "either",
  "schemars_derive",
@@ -8989,7 +9427,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -9001,7 +9439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -9013,7 +9451,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -9035,7 +9473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -13012,7 +13450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.59.0",
@@ -13067,6 +13505,12 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -13094,6 +13538,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -13297,7 +13754,7 @@ dependencies = [
  "base64ct",
  "bcs",
  "blake2",
- "bnum",
+ "bnum 0.12.1",
  "bs58 0.5.1",
  "hex",
  "itertools 0.13.0",
@@ -13586,7 +14043,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -13662,6 +14119,58 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tlb"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc025689fc2fd8b88fd53d112f865ffc84ac920dd06e88da3bde9afaa4a8bc3"
+dependencies = [
+ "array-util",
+ "bitvec 1.0.1",
+ "crc",
+ "digest 0.10.7",
+ "hex",
+ "impl-tools",
+ "sha2 0.10.9",
+ "tlbits",
+]
+
+[[package]]
+name = "tlb-ton"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783a2fd0d92b0439b67e4f0f8ae2395edf91adc3bf5e188fb58b251d7a3ba3f9"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "hex",
+ "impl-tools",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "serde_with",
+ "strum 0.25.0",
+ "tlb",
+]
+
+[[package]]
+name = "tlbits"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037d1fa9c669c3adb766dc471691cfb6626ea9467dcac206f6473cf0dbcf3d4b"
+dependencies = [
+ "array-util",
+ "bitvec 1.0.1",
+ "either",
+ "impl-tools",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rustversion",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "tokio"
@@ -14475,12 +14984,19 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",
+ "bs58 0.5.1",
+ "chrono",
+ "defuse-core",
+ "defuse-crypto",
+ "defuse-deadline",
  "generated",
  "hex",
  "near-crypto",
  "near-primitives",
+ "near-sdk",
  "serde",
  "serde_json",
+ "thiserror 2.0.17",
  "tracing",
  "visualsign",
 ]
@@ -14648,7 +15164,7 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -14661,7 +15177,7 @@ version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -14784,6 +15300,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -75,6 +75,12 @@ tracing = "0.1.41"
 # Pin visualsign dependencies
 visualsign = { path = "./visualsign" }
 
+near-sdk = { version = "5.27", features = ["non-contract-usage"] }
+
+defuse-core     = { git = "https://github.com/near/intents.git", tag = "defuse/v0.4.2" }
+defuse-crypto   = { git = "https://github.com/near/intents.git", tag = "defuse/v0.4.2" }
+defuse-deadline = { git = "https://github.com/near/intents.git", tag = "defuse/v0.4.2" }
+
 [workspace.lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"

--- a/src/chain_parsers/visualsign-near/Cargo.toml
+++ b/src/chain_parsers/visualsign-near/Cargo.toml
@@ -6,18 +6,30 @@ edition = "2024"
 [dependencies]
 base64 = "0.22.1"
 borsh = "1.5"
+bs58 = "0.5.1"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 generated = { path = "../../generated" }
 # Pulls in ~34 transitive crates as mandatory (non-dev) dependencies, including
 # serde_yaml 0.9 (unsafe-libyaml) and the arbitrary fuzzing derive.
 near-primitives = "0.35.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "2.0.12"
 tracing = { workspace = true }
 visualsign = { workspace = true }
+
+near-sdk = { workspace = true }
+
+defuse-core = { workspace = true }
+defuse-crypto = { workspace = true }
+defuse-deadline = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4.3"
 near-crypto = "0.35.1"
+
+[features]
+diagnostics = ["visualsign/diagnostics"]
 
 [lints]
 workspace = true

--- a/src/chain_parsers/visualsign-near/Cargo.toml
+++ b/src/chain_parsers/visualsign-near/Cargo.toml
@@ -9,6 +9,7 @@ borsh = "1.5"
 bs58 = "0.5.1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 generated = { path = "../../generated" }
+hex = "0.4.3"
 # Pulls in ~34 transitive crates as mandatory (non-dev) dependencies, including
 # serde_yaml 0.9 (unsafe-libyaml) and the arbitrary fuzzing derive.
 near-primitives = "0.35.1"
@@ -25,7 +26,6 @@ defuse-crypto = { workspace = true }
 defuse-deadline = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4.3"
 near-crypto = "0.35.1"
 
 [features]

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -1,8 +1,12 @@
-//! `NearVisualSignConverter`: NEAR transaction -> VisualSign payload.
+//! `NearVisualSignConverter`: NEAR input -> VisualSign payload.
+
+use std::sync::Arc;
 
 use near_primitives::action::Action;
+use near_primitives::transaction::Transaction;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_address_field, create_text_field};
+use visualsign::registry::LayeredRegistry;
 use visualsign::vsptrait::{
     ConversionResult, VisualSignConverter, VisualSignConverterFromString, VisualSignOptions,
 };
@@ -10,11 +14,12 @@ use visualsign::{SignablePayload, SignablePayloadField};
 
 use crate::actions::render_action;
 use crate::networks::{NearNetwork, extract_network_from_metadata};
+use crate::presets::intents::NearTokenRegistry;
 use crate::tx::NearTransaction;
 
-/// Payload version emitted for NEAR transactions.
+/// Payload version emitted for NEAR payloads.
 const PAYLOAD_VERSION: i64 = 0;
-/// Payload type tag emitted for NEAR transactions, matching the other chain
+/// Payload type tag emitted for NEAR payloads, matching the other chain
 /// crates' convention (`"SolanaTx"`, `"TronTx"`).
 const PAYLOAD_TYPE: &str = "NearTx";
 
@@ -44,8 +49,19 @@ impl VisualSignConverter<NearTransaction> for NearVisualSignConverter {
         transaction: NearTransaction,
         options: VisualSignOptions,
     ) -> Result<ConversionResult, VisualSignError> {
-        let tx = transaction.inner();
+        match transaction {
+            NearTransaction::OnChain(tx) => self.render_on_chain(&tx, &options),
+            NearTransaction::Intent(json) => render_intent_envelope(&json, &options),
+        }
+    }
+}
 
+impl NearVisualSignConverter {
+    fn render_on_chain(
+        &self,
+        tx: &Transaction,
+        options: &VisualSignOptions,
+    ) -> Result<ConversionResult, VisualSignError> {
         if tx.actions().is_empty() {
             return Err(VisualSignError::ValidationError(
                 "NEAR transaction has no actions".to_string(),
@@ -78,6 +94,7 @@ impl VisualSignConverter<NearTransaction> for NearVisualSignConverter {
         let total_actions = tx.actions().len();
         for action in tx.actions() {
             fields.extend(render_action(action, total_actions)?);
+            fields.extend(decode_intents(tx.receiver_id().as_str(), action, options)?);
         }
 
         Ok(ConversionResult::new(SignablePayload::new(
@@ -103,6 +120,48 @@ impl VisualSignConverterFromString<NearTransaction> for NearVisualSignConverter 
         .map_err(VisualSignError::ParseError)?;
         self.to_validated_visual_sign_payload(transaction, options)
     }
+}
+
+/// Decode an `execute_intents` call to `intents.near` and render the signed
+/// intent batch. Any other action or receiver yields no extra fields. A
+/// decode failure surfaces as a conversion error rather than silently
+/// dropping the intents.
+fn decode_intents(
+    receiver_id: &str,
+    action: &Action,
+    options: &VisualSignOptions,
+) -> Result<Vec<SignablePayloadField>, VisualSignError> {
+    if receiver_id != "intents.near" {
+        return Ok(vec![]);
+    }
+    let Action::FunctionCall(fc) = action else {
+        return Ok(vec![]);
+    };
+    if fc.method_name != "execute_intents" {
+        return Ok(vec![]);
+    }
+    let registry = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+    crate::presets::intents::try_decode_execute_intents(&fc.args, &registry, options)
+        .map_err(|e| VisualSignError::ConversionError(e.to_string()))
+}
+
+/// Render the pre-signature intents envelope a user is about to sign: no
+/// signature exists yet, so this is a confirmation view only.
+fn render_intent_envelope(
+    json: &str,
+    options: &VisualSignOptions,
+) -> Result<ConversionResult, VisualSignError> {
+    let registry = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+    let fields =
+        crate::presets::intents::try_render_single_intent(json.as_bytes(), &registry, options)
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?;
+    Ok(ConversionResult::new(SignablePayload::new(
+        PAYLOAD_VERSION,
+        "NEAR Intent".to_string(),
+        None,
+        fields,
+        PAYLOAD_TYPE.to_string(),
+    )))
 }
 
 /// Title for the payload: a single action names itself, otherwise a generic
@@ -139,10 +198,10 @@ mod tests {
     use super::*;
     use generated::parser::{ChainMetadata, NearMetadata, chain_metadata};
     use near_crypto::{KeyType, PublicKey, Signature};
-    use near_primitives::action::{CreateAccountAction, TransferAction};
+    use near_primitives::action::{CreateAccountAction, FunctionCallAction, TransferAction};
     use near_primitives::hash::CryptoHash;
     use near_primitives::transaction::{SignedTransaction, TransactionV0};
-    use near_primitives::types::Balance;
+    use near_primitives::types::{Balance, Gas};
     use visualsign::vsptrait::DeveloperConfig;
 
     fn transfer() -> Action {
@@ -156,16 +215,14 @@ mod tests {
     }
 
     fn near_tx_as(signer_id: &str, receiver_id: &str, actions: Vec<Action>) -> NearTransaction {
-        NearTransaction::new(near_primitives::transaction::Transaction::V0(
-            TransactionV0 {
-                signer_id: signer_id.parse().expect("valid account id"),
-                public_key: PublicKey::empty(KeyType::ED25519),
-                nonce: 0,
-                receiver_id: receiver_id.parse().expect("valid account id"),
-                block_hash: CryptoHash::default(),
-                actions,
-            },
-        ))
+        NearTransaction::OnChain(Transaction::V0(TransactionV0 {
+            signer_id: signer_id.parse().expect("valid account id"),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 0,
+            receiver_id: receiver_id.parse().expect("valid account id"),
+            block_hash: CryptoHash::default(),
+            actions,
+        }))
     }
 
     #[test]
@@ -290,7 +347,10 @@ mod tests {
     }
 
     fn signed_transfer_hex() -> String {
-        let unsigned = near_tx(vec![transfer()]).inner().clone();
+        let unsigned = match near_tx(vec![transfer()]) {
+            NearTransaction::OnChain(tx) => tx,
+            NearTransaction::Intent(_) => panic!("expected OnChain"),
+        };
         let signed = SignedTransaction::new(Signature::empty(KeyType::ED25519), unsigned);
         hex::encode(borsh::to_vec(&signed).expect("borsh encode"))
     }
@@ -316,5 +376,61 @@ mod tests {
         };
         let result = converter.to_visual_sign_payload_from_string(&signed_transfer_hex(), options);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_intents_call_renders_intents() {
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+
+        let txv0 = TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"
+                .parse()
+                .unwrap(),
+            nonce: 1,
+            receiver_id: "intents.near".parse().unwrap(),
+            block_hash: CryptoHash::default(),
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_intents".to_string(),
+                args: serde_json::to_vec(&args).unwrap(),
+                gas: Gas::from_gas(30_000_000_000_000),
+                deposit: Balance::from_yoctonear(0),
+            }))],
+        };
+        let near_tx = NearTransaction::OnChain(Transaction::V0(txv0));
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(near_tx, VisualSignOptions::default())
+            .expect("convert");
+        let json = payload.payload.to_json().expect("json");
+
+        // Generic FunctionCall view + decoded intents both present.
+        assert!(json.contains("execute_intents"), "method missing: {json}");
+        assert!(json.contains("Signer"), "intents envelope missing: {json}");
+        assert!(
+            json.contains("wNEAR"),
+            "resolved ft_withdraw amount missing: {json}"
+        );
+    }
+
+    #[test]
+    fn intent_envelope_renders_without_signature_section() {
+        let swap = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2100-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(
+                NearTransaction::Intent(swap.to_string()),
+                VisualSignOptions::default(),
+            )
+            .expect("convert");
+        let json = payload.payload.to_json().expect("json");
+        for expected in ["Signer", "alice.near", "wNEAR"] {
+            assert!(json.contains(expected), "missing {expected}: {json}");
+        }
+        assert!(!json.contains("Standard"), "unexpected signature section");
     }
 }

--- a/src/chain_parsers/visualsign-near/src/lib.rs
+++ b/src/chain_parsers/visualsign-near/src/lib.rs
@@ -7,6 +7,7 @@ pub mod actions;
 pub mod convert;
 pub mod fmt;
 pub mod networks;
+pub mod presets;
 pub mod tx;
 
 pub use convert::NearVisualSignConverter;

--- a/src/chain_parsers/visualsign-near/src/presets/intents/args.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/args.rs
@@ -1,0 +1,40 @@
+//! JSON deserialization of execute_intents args.
+
+use defuse_core::payload::multi::MultiPayload;
+
+use super::NearIntentsError;
+
+/// The `execute_intents(signed: Vec<MultiPayload>)` argument object. NEAR
+/// serializes method args as a JSON object keyed by parameter name, so the raw
+/// args bytes are `{ "signed": [ ... ] }`.
+#[derive(serde::Deserialize)]
+struct ExecuteIntentsArgs {
+    signed: Vec<MultiPayload>,
+}
+
+/// Decode raw `execute_intents` args into the signed payload list.
+///
+/// `MultiPayload` is a defuse type; it stays `pub(crate)` and never crosses the
+/// public crate boundary.
+pub(crate) fn decode_args(args: &[u8]) -> Result<Vec<MultiPayload>, NearIntentsError> {
+    let parsed: ExecuteIntentsArgs =
+        serde_json::from_slice(args).map_err(|e| NearIntentsError::ArgsNotJson(e.to_string()))?;
+    Ok(parsed.signed)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_json() {
+        assert!(decode_args(b"not json").is_err());
+    }
+
+    #[test]
+    fn decodes_empty_signed_array() {
+        let payloads = decode_args(br#"{"signed":[]}"#).expect("decode");
+        assert!(payloads.is_empty());
+    }
+}

--- a/src/chain_parsers/visualsign-near/src/presets/intents/args.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/args.rs
@@ -18,7 +18,7 @@ struct ExecuteIntentsArgs {
 /// public crate boundary.
 pub(crate) fn decode_args(args: &[u8]) -> Result<Vec<MultiPayload>, NearIntentsError> {
     let parsed: ExecuteIntentsArgs =
-        serde_json::from_slice(args).map_err(|e| NearIntentsError::ArgsNotJson(e.to_string()))?;
+        serde_json::from_slice(args).map_err(|e| NearIntentsError::InputNotJson(e.to_string()))?;
     Ok(parsed.signed)
 }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -19,10 +19,6 @@ pub(crate) const NEAR_DECIMALS: u8 = 24;
 pub enum NearIntentsError {
     #[error("input was not valid JSON: {0}")]
     InputNotJson(String),
-    #[error("Unknown intent action variant: {0}")]
-    UnknownAction(String),
-    #[error("Malformed asset identifier: {0}")]
-    MalformedAssetId(String),
     #[error("Failed to render intents: {0}")]
     Render(String),
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -1,0 +1,241 @@
+//! NEAR Intents protocol decoder.
+//!
+//! Public API uses only `visualsign` types + plain primitives. The defuse-*
+//! and near-sdk transitive dependencies are confined to this module's
+//! internals.
+
+mod args;
+mod render;
+mod tokens;
+mod verify;
+
+use thiserror::Error;
+
+/// NEAR's native token symbol and decimal scale (yoctoNEAR = 10^-24 NEAR).
+pub(crate) const NEAR_SYMBOL: &str = "NEAR";
+pub(crate) const NEAR_DECIMALS: u8 = 24;
+
+#[derive(Debug, Error)]
+pub enum NearIntentsError {
+    #[error("execute_intents args were not valid JSON: {0}")]
+    ArgsNotJson(String),
+    #[error("Unknown intent action variant: {0}")]
+    UnknownAction(String),
+    #[error("Malformed asset identifier: {0}")]
+    MalformedAssetId(String),
+    #[error("Failed to render intents: {0}")]
+    Render(String),
+}
+
+/// Plain NEP-141 token metadata. The lean baseline chain parser constructs
+/// the registry; this module consumes it via `LayeredRegistry<NearTokenRegistry>`.
+#[derive(Debug, Default)]
+pub struct NearTokenRegistry {
+    pub by_asset_id: std::collections::BTreeMap<String, TokenMeta>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenMeta {
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Decode `execute_intents` args and render them as `SignablePayloadField`s.
+///
+/// This is the sole public entry point for the signed-envelope batch.
+pub fn try_decode_execute_intents(
+    args: &[u8],
+    token_registry: &visualsign::registry::LayeredRegistry<NearTokenRegistry>,
+    _options: &visualsign::vsptrait::VisualSignOptions,
+) -> Result<Vec<visualsign::SignablePayloadField>, NearIntentsError> {
+    let payloads = args::decode_args(args)?;
+    let total = payloads.len();
+    let mut fields = Vec::new();
+    for (i, mp) in payloads.iter().enumerate() {
+        fields.extend(
+            render::section(i + 1, total, mp, token_registry)
+                .map_err(|e| NearIntentsError::Render(e.to_string()))?,
+        );
+    }
+    Ok(fields)
+}
+
+/// Render the single intent a user is about to sign, from the JSON of its
+/// `DefusePayload` message (the inner message that gets signed, independent of
+/// which signature standard later wraps it).
+///
+/// This is the user-signing view: it reuses the envelope + per-intent rendering
+/// but skips signature verification (no signature exists at signing time).
+pub fn try_render_single_intent(
+    payload_json: &[u8],
+    token_registry: &visualsign::registry::LayeredRegistry<NearTokenRegistry>,
+    _options: &visualsign::vsptrait::VisualSignOptions,
+) -> Result<Vec<visualsign::SignablePayloadField>, NearIntentsError> {
+    let payload: defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents> =
+        serde_json::from_slice(payload_json)
+            .map_err(|e| NearIntentsError::ArgsNotJson(e.to_string()))?;
+    render::render_single(&payload, token_registry)
+        .map_err(|e| NearIntentsError::Render(e.to_string()))
+}
+
+/// Test-only matcher shared across this module's test submodules.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use visualsign::SignablePayloadField;
+
+    /// Matches the soft-finding field for `rule` in whichever shape the build
+    /// emits: the structured `Diagnostic` (diagnostics feature) or the
+    /// `Warning`-labelled text fallback.
+    pub(crate) fn is_warning_diagnostic(field: &SignablePayloadField, rule: &str) -> bool {
+        #[cfg(feature = "diagnostics")]
+        {
+            matches!(field, SignablePayloadField::Diagnostic { diagnostic, .. }
+                if diagnostic.rule == rule && diagnostic.level == "warn")
+        }
+        #[cfg(not(feature = "diagnostics"))]
+        {
+            matches!(field, SignablePayloadField::TextV2 { common, text_v2 }
+                if common.label == "Warning" && text_v2.text.starts_with(rule))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use visualsign::SignablePayloadField;
+    use visualsign::registry::LayeredRegistry;
+    use visualsign::vsptrait::VisualSignOptions;
+
+    fn label_of(f: &SignablePayloadField) -> Option<&str> {
+        match f {
+            SignablePayloadField::TextV2 { common, .. }
+            | SignablePayloadField::AmountV2 { common, .. }
+            | SignablePayloadField::AddressV2 { common, .. } => Some(common.label.as_str()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn pipeline_decodes_and_renders_intent_section() {
+        // Current-format inner payload (ISO-8601 deadline). The key/signature are
+        // well-formed but do not match, so the signature reads INVALID while the
+        // intents still decode and render.
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let bytes = serde_json::to_vec(&args).unwrap();
+        let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+
+        let fields =
+            try_decode_execute_intents(&bytes, &reg, &VisualSignOptions::default()).unwrap();
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+
+        for expected in [
+            "Signed Intent",
+            "Standard",
+            "Signer",
+            "Verifying Contract",
+            "Deadline",
+            "Nonce",
+            "Token",
+            "To",
+            "Amount",
+        ] {
+            assert!(labels.contains(&expected), "missing field: {expected}");
+        }
+        // Signature did not match the payload -> a signature warning.
+        let has_sig_warning = fields
+            .iter()
+            .any(|f| super::test_support::is_warning_diagnostic(f, "signature"));
+        assert!(has_sig_warning, "expected a signature warning");
+        // wrap.near resolved -> 1 wNEAR.
+        let amount = fields
+            .iter()
+            .find(|f| label_of(f) == Some("Amount"))
+            .unwrap();
+        match amount {
+            SignablePayloadField::AmountV2 { amount_v2, .. } => {
+                assert_eq!(amount_v2.amount, "1");
+                assert_eq!(amount_v2.abbreviation.as_deref(), Some("wNEAR"));
+            }
+            other => panic!("expected AmountV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_intent_renders_envelope_and_intent_without_signature() {
+        // The pre-signature signing view: a bare DefusePayload (no MultiPayload
+        // wrapper, no signature). Envelope + intent render; no signature section.
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+        let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+
+        let fields =
+            try_render_single_intent(inner.as_bytes(), &reg, &VisualSignOptions::default())
+                .unwrap();
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+
+        for expected in [
+            "Signer",
+            "Verifying Contract",
+            "Deadline",
+            "Nonce",
+            "Token",
+            "To",
+            "Amount",
+        ] {
+            assert!(labels.contains(&expected), "missing field: {expected}");
+        }
+        // Pre-signature view: no signature section header or standard field.
+        assert!(
+            !labels.contains(&"Signed Intent"),
+            "unexpected signature section"
+        );
+        assert!(!labels.contains(&"Standard"), "unexpected signature field");
+        // wrap.near resolves to 1 wNEAR.
+        let amount = fields
+            .iter()
+            .find(|f| label_of(f) == Some("Amount"))
+            .unwrap();
+        match amount {
+            SignablePayloadField::AmountV2 { amount_v2, .. } => {
+                assert_eq!(amount_v2.amount, "1");
+                assert_eq!(amount_v2.abbreviation.as_deref(), Some("wNEAR"));
+            }
+            other => panic!("expected AmountV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_intent_rejects_malformed_json() {
+        let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+        let err = try_render_single_intent(b"not json", &reg, &VisualSignOptions::default())
+            .expect_err("malformed JSON should error");
+        assert!(matches!(err, NearIntentsError::ArgsNotJson(_)));
+    }
+
+    #[test]
+    fn pipeline_flags_expired_deadline() {
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2020-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let bytes = serde_json::to_vec(&args).unwrap();
+        let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+        let fields =
+            try_decode_execute_intents(&bytes, &reg, &VisualSignOptions::default()).unwrap();
+        let has_deadline_warning = fields
+            .iter()
+            .any(|f| super::test_support::is_warning_diagnostic(f, "deadline"));
+        assert!(has_deadline_warning, "expected a deadline warning");
+    }
+}

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -17,8 +17,8 @@ pub(crate) const NEAR_DECIMALS: u8 = 24;
 
 #[derive(Debug, Error)]
 pub enum NearIntentsError {
-    #[error("execute_intents args were not valid JSON: {0}")]
-    ArgsNotJson(String),
+    #[error("input was not valid JSON: {0}")]
+    InputNotJson(String),
     #[error("Unknown intent action variant: {0}")]
     UnknownAction(String),
     #[error("Malformed asset identifier: {0}")]
@@ -73,7 +73,7 @@ pub fn try_render_single_intent(
 ) -> Result<Vec<visualsign::SignablePayloadField>, NearIntentsError> {
     let payload: defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents> =
         serde_json::from_slice(payload_json)
-            .map_err(|e| NearIntentsError::ArgsNotJson(e.to_string()))?;
+            .map_err(|e| NearIntentsError::InputNotJson(e.to_string()))?;
     render::render_single(&payload, token_registry)
         .map_err(|e| NearIntentsError::Render(e.to_string()))
 }
@@ -217,7 +217,7 @@ mod tests {
         let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
         let err = try_render_single_intent(b"not json", &reg, &VisualSignOptions::default())
             .expect_err("malformed JSON should error");
-        assert!(matches!(err, NearIntentsError::ArgsNotJson(_)));
+        assert!(matches!(err, NearIntentsError::InputNotJson(_)));
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -238,6 +238,13 @@ fn render_nft_withdraw(w: &NftWithdraw) -> Result<Fields, VisualSignError> {
 }
 
 fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
+    if w.token_ids.len() != w.amounts.len() {
+        return Err(VisualSignError::ValidationError(format!(
+            "mt_withdraw token_ids/amounts length mismatch: {} token_ids vs {} amounts",
+            w.token_ids.len(),
+            w.amounts.len()
+        )));
+    }
     let mut fields = vec![
         create_text_field("Token", w.token.as_str())?.signable_payload_field,
         create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
@@ -266,8 +273,11 @@ pub(crate) fn render_signature(
     let mut fields = vec![create_text_field("Standard", standard)?.signable_payload_field];
     match check {
         SignatureCheck::Valid { recovered_key } => fields.push(
-            create_text_field("Signature", &format!("valid (recovered {recovered_key})"))?
-                .signable_payload_field,
+            create_text_field(
+                "Signature",
+                &format!("valid for key {recovered_key} (key-to-account binding not verified)"),
+            )?
+            .signable_payload_field,
         ),
         SignatureCheck::Invalid => {
             fields.push(diagnostic("signature", "signature verification failed")?);
@@ -523,6 +533,20 @@ mod tests {
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(labels.contains(&"Message"), "labels: {labels:?}");
         assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    // Regression coverage for a signing-integrity gap: token_ids/amounts are
+    // two independent vectors with no length agreement enforced at deserialize
+    // time, and `zip` silently drops the extras rather than erroring -- the
+    // same class of gap as the storage_deposit/message tests above, but here
+    // attacker-controlled input rather than an oversight.
+    #[test]
+    fn mt_withdraw_rejects_token_ids_amounts_length_mismatch() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["gold","silver","bronze"],"amounts":["5"]}"#,
+        );
+        let result = render_intent(&intent, &empty_reg());
+        assert!(matches!(result, Err(VisualSignError::ValidationError(_))));
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -97,10 +97,11 @@ pub(crate) fn section(
     registry: &Reg,
 ) -> Result<Fields, VisualSignError> {
     let (check, extracted) = super::verify::verify_and_extract(mp);
+    let signer_id = extracted.as_ref().ok().map(|p| p.signer_id.as_str());
     let mut fields = vec![
         create_text_field("Signed Intent", &format!("{index} of {total}"))?.signable_payload_field,
     ];
-    fields.extend(render_signature(standard_name(mp), &check)?);
+    fields.extend(render_signature(standard_name(mp), &check, signer_id)?);
     match &extracted {
         Ok(payload) => fields.extend(render_single(payload, registry)?),
         Err(e) => fields.push(diagnostic(
@@ -265,20 +266,74 @@ fn render_native_withdraw(w: &NativeWithdraw) -> Result<Fields, VisualSignError>
     ])
 }
 
+/// Whether `signer_id` has the shape of a key-derived implicit account --
+/// NEAR's 64-hex-char convention, or defuse's own `"0x"` + 40-hex convention
+/// for EVM-style signers -- rather than a human-chosen named account (e.g.
+/// `alice.near`). Only for these shapes is key-to-account binding checkable
+/// offline: a named account's access keys are registered on-chain, decoupled
+/// from any implicit derivation, so comparing against one would produce
+/// false-positive mismatches on entirely legitimate transactions.
+fn looks_like_implicit_account(signer_id: &str) -> bool {
+    let is_hex = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_hexdigit());
+    (signer_id.len() == 64 && is_hex(signer_id))
+        || signer_id
+            .strip_prefix("0x")
+            .is_some_and(|rest| rest.len() == 40 && is_hex(rest))
+}
+
 /// Render the standard + signature-status fields for one signed payload.
+///
+/// `signer_id` is the payload's claimed signer, when extraction succeeded.
+/// When it has an implicit-account shape, the recovered key's own implied
+/// account id is compared against it -- a real pass/fail check, not a hedge.
+/// For any other shape (a named account) the binding genuinely requires
+/// chain access this parser doesn't have, so it stays a hedge.
 pub(crate) fn render_signature(
     standard: &str,
     check: &SignatureCheck,
+    signer_id: Option<&str>,
 ) -> Result<Vec<SignablePayloadField>, VisualSignError> {
     let mut fields = vec![create_text_field("Standard", standard)?.signable_payload_field];
     match check {
-        SignatureCheck::Valid { recovered_key } => fields.push(
-            create_text_field(
-                "Signature",
-                &format!("valid for key {recovered_key} (key-to-account binding not verified)"),
-            )?
-            .signable_payload_field,
-        ),
+        SignatureCheck::Valid {
+            recovered_key,
+            implied_account_id,
+        } => match signer_id.filter(|id| looks_like_implicit_account(id)) {
+            Some(id) if id == implied_account_id => {
+                fields.push(
+                        create_text_field(
+                            "Signature",
+                            &format!(
+                                "valid for key {recovered_key} (account binding confirmed: matches {id})"
+                            ),
+                        )?
+                        .signable_payload_field,
+                    );
+            }
+            Some(id) => {
+                fields.push(
+                    create_text_field("Signature", &format!("valid for key {recovered_key}"))?
+                        .signable_payload_field,
+                );
+                fields.push(diagnostic(
+                        "account-binding",
+                        &format!(
+                            "signer_id {id} does not match the key that signed this payload (implies {implied_account_id})"
+                        ),
+                    )?);
+            }
+            None => {
+                fields.push(
+                    create_text_field(
+                        "Signature",
+                        &format!(
+                            "valid for key {recovered_key} (key-to-account binding not verified)"
+                        ),
+                    )?
+                    .signable_payload_field,
+                );
+            }
+        },
         SignatureCheck::Invalid => {
             fields.push(diagnostic("signature", "signature verification failed")?);
         }
@@ -348,26 +403,153 @@ mod tests {
     }
 
     #[test]
+    fn looks_like_implicit_account_accepts_both_recognized_shapes() {
+        assert!(looks_like_implicit_account(
+            "74affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d53751"
+        ));
+        assert!(looks_like_implicit_account(
+            "0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"
+        ));
+    }
+
+    #[test]
+    fn looks_like_implicit_account_rejects_named_and_malformed_ids() {
+        assert!(!looks_like_implicit_account("alice.near"));
+        assert!(!looks_like_implicit_account(""));
+        // 63 hex chars: one short of the implicit-account length.
+        assert!(!looks_like_implicit_account(
+            "4affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d53751"
+        ));
+        // 64 chars but not all hex.
+        assert!(!looks_like_implicit_account(
+            "74affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d5375g"
+        ));
+        // 0x + 39 hex chars: one short of the EVM-address length.
+        assert!(!looks_like_implicit_account(
+            "0x7c5185167401ed00cf5f5b2fc97d9bbfdb7d025"
+        ));
+        // 0x + 40 chars but not all hex.
+        assert!(!looks_like_implicit_account(
+            "0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d0zz"
+        ));
+        // No 0x prefix at all, despite being 40 hex chars.
+        assert!(!looks_like_implicit_account(
+            "17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"
+        ));
+    }
+
+    fn valid_check(implied_account_id: &str) -> SignatureCheck {
+        SignatureCheck::Valid {
+            recovered_key: "ed25519:abc".to_string(),
+            implied_account_id: implied_account_id.to_string(),
+        }
+    }
+
+    #[test]
     fn signature_fields_present_for_valid() {
-        let fields = render_signature(
-            "nep413",
-            &SignatureCheck::Valid {
-                recovered_key: "ed25519:abc".to_string(),
-            },
-        )
-        .expect("render");
+        // signer_id is a named account: binding genuinely isn't checkable,
+        // so this stays the two-field (Standard, Signature) hedge shape.
+        let fields = render_signature("nep413", &valid_check("64hex..."), Some("alice.near"))
+            .expect("render");
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert_eq!(labels, ["Standard", "Signature"]);
     }
 
     #[test]
     fn invalid_signature_renders_warning() {
-        let fields = render_signature("erc191", &SignatureCheck::Invalid).expect("render");
+        let fields = render_signature("erc191", &SignatureCheck::Invalid, None).expect("render");
         assert!(
             super::super::test_support::is_warning_diagnostic(&fields[1], "signature"),
             "expected a signature warning, got {:?}",
             fields[1]
         );
+    }
+
+    #[test]
+    fn signature_binding_confirmed_when_implicit_signer_matches() {
+        let id = "74affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d53751";
+        let fields = render_signature("raw_ed25519", &valid_check(id), Some(id)).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Standard", "Signature"]);
+        match &fields[1] {
+            SignablePayloadField::TextV2 { text_v2, .. } => {
+                assert!(
+                    text_v2.text.contains("account binding confirmed"),
+                    "{}",
+                    text_v2.text
+                );
+            }
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signature_binding_confirmed_when_evm_style_signer_matches() {
+        // Real signer_id from the pinned _vector_erc191.input fixture.
+        let id = "0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d025";
+        let fields = render_signature("erc191", &valid_check(id), Some(id)).expect("render");
+        match &fields[1] {
+            SignablePayloadField::TextV2 { text_v2, .. } => {
+                assert!(
+                    text_v2.text.contains("account binding confirmed"),
+                    "{}",
+                    text_v2.text
+                );
+            }
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signature_binding_mismatch_is_a_diagnostic_not_a_hedge() {
+        // The key recovers to the pinned fixture's real address, but the
+        // payload claims an unrelated one -- e.g. attacker.near substituting
+        // their own signer_id onto someone else's signature.
+        let fields = render_signature(
+            "erc191",
+            &valid_check("0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"),
+            Some("0x00000000000000000000000000000000000000ff"),
+        )
+        .expect("render");
+        assert!(
+            super::super::test_support::is_warning_diagnostic(&fields[2], "account-binding"),
+            "expected an account-binding warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn signature_binding_mismatch_detected_for_implicit_ed25519_signer() {
+        let fields = render_signature(
+            "raw_ed25519",
+            &valid_check("74affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d53751"),
+            Some("000000000000000000000000000000000000000000000000000000000000dead"),
+        )
+        .expect("render");
+        assert!(
+            super::super::test_support::is_warning_diagnostic(&fields[2], "account-binding"),
+            "expected an account-binding warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn signature_binding_not_checked_for_named_account_even_with_valid_key() {
+        // Named accounts' keys are registered on-chain; an implicit-derived
+        // id has nothing to compare against, so this must stay a hedge, not
+        // a false mismatch.
+        let fields = render_signature(
+            "nep413",
+            &valid_check("74affa71ab030d400fdfa1bed033dfa6fd3ae34f92d17c046ebe368e80d53751"),
+            Some("alice.near"),
+        )
+        .expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Standard", "Signature"]);
+        match &fields[1] {
+            SignablePayloadField::TextV2 { text_v2, .. } => {
+                assert!(text_v2.text.contains("not verified"), "{}", text_v2.text);
+            }
+            other => panic!("expected TextV2, got {other:?}"),
+        }
     }
 
     /// When the inner `payload` string doesn't parse as a `DefusePayload`,

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -7,6 +7,7 @@ use defuse_core::intents::{DefuseIntents, Intent};
 use defuse_core::payload::DefusePayload;
 use defuse_core::payload::multi::MultiPayload;
 use visualsign::SignablePayloadField;
+use visualsign::encodings::split_hex_prefix;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_amount_field, create_text_field};
 use visualsign::registry::LayeredRegistry;
@@ -164,9 +165,26 @@ fn state_init_field() -> Result<SignablePayloadField, VisualSignError> {
     Ok(create_text_field("State Init", "(not fully decoded)")?.signable_payload_field)
 }
 
+/// Renders a token diff as one signed `Send`/`Receive` line per entry.
+///
+/// An empty diff, or an entry whose delta is zero, is refused rather than
+/// rendered: the contract refuses both itself (`DefuseError::InvalidIntent`,
+/// `defuse_core::intents::token_diff`), so such an intent cannot execute, and
+/// a zero delta would otherwise render as `Receive 0 <token>` -- a line
+/// claiming a movement that does not happen.
 fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSignError> {
+    if td.diff.is_empty() {
+        return Err(VisualSignError::ValidationError(
+            "token_diff carries no entries".to_string(),
+        ));
+    }
     let mut fields = Fields::new();
     for (token_id, delta) in td.diff.iter() {
+        if *delta == 0 {
+            return Err(VisualSignError::ValidationError(format!(
+                "token_diff entry for {token_id} has a zero delta"
+            )));
+        }
         let label = if *delta < 0 { "Send" } else { "Receive" };
         fields.push(token_amount_field(
             label,
@@ -293,8 +311,9 @@ fn render_native_withdraw(w: &NativeWithdraw) -> Result<Fields, VisualSignError>
 }
 
 /// Whether `signer_id` has the shape of a key-derived implicit account --
-/// NEAR's 64-hex-char convention, or defuse's own `"0x"` + 40-hex convention
-/// for EVM-style signers -- rather than a human-chosen named account (e.g.
+/// NEAR's 64-hex-char convention, or defuse's own `0x`/`0X` + 40-hex
+/// convention for EVM-style signers -- rather than a human-chosen named
+/// account (e.g.
 /// `alice.near`). Only for these shapes is key-to-account binding checkable
 /// offline: a named account's access keys are registered on-chain, decoupled
 /// from any implicit derivation, so comparing against one would produce
@@ -302,9 +321,7 @@ fn render_native_withdraw(w: &NativeWithdraw) -> Result<Fields, VisualSignError>
 fn looks_like_implicit_account(signer_id: &str) -> bool {
     let is_hex = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_hexdigit());
     (signer_id.len() == 64 && is_hex(signer_id))
-        || signer_id
-            .strip_prefix("0x")
-            .is_some_and(|rest| rest.len() == 40 && is_hex(rest))
+        || split_hex_prefix(signer_id).is_some_and(|rest| rest.len() == 40 && is_hex(rest))
 }
 
 /// Render the standard + signature-status fields for one signed payload.
@@ -331,7 +348,11 @@ pub(crate) fn render_signature(
             recovered_key,
             implied_account_id,
         } => match signer_id.filter(|id| looks_like_implicit_account(id)) {
-            Some(id) if id == implied_account_id => {
+            // Hex digit case is not part of the identity: both shapes this arm
+            // accepts are hex, and `to_implicit_account_id` emits lowercase, so
+            // a differently-cased spelling of the same account is a match, not
+            // a failed derivation.
+            Some(id) if id.eq_ignore_ascii_case(implied_account_id) => {
                 fields.push(
                     create_text_field(
                         "Signature",
@@ -443,6 +464,43 @@ mod tests {
         assert!(looks_like_implicit_account(
             "0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"
         ));
+    }
+
+    #[test]
+    fn looks_like_implicit_account_accepts_an_uppercase_hex_prefix() {
+        assert!(looks_like_implicit_account(
+            "0X17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"
+        ));
+    }
+
+    #[test]
+    fn a_differently_cased_signer_id_still_counts_as_derived() {
+        // `to_implicit_account_id` emits lowercase; an equal account id spelled
+        // with any other hex case must not read as a failed derivation.
+        let fields = render_signature(
+            "erc191",
+            &valid_check("0x17c5185167401ed00cf5f5b2fc97d9bbfdb7d025"),
+            Some("0X17C5185167401ED00CF5F5B2FC97D9BBFDB7D025"),
+        )
+        .expect("render");
+        let text = fields
+            .iter()
+            .filter_map(|f| match f {
+                SignablePayloadField::TextV2 { text_v2, common } if common.label == "Signature" => {
+                    Some(text_v2.text.as_str())
+                }
+                _ => None,
+            })
+            .next()
+            .expect("signature field");
+        assert!(text.contains("derives signer_id"), "{text}");
+        // Holds whether or not the `diagnostics` feature is on: the finding
+        // carries this wording as a structured message or as `Warning` text.
+        let rendered = format!("{fields:?}");
+        assert!(
+            !rendered.contains("does not derive"),
+            "a case difference must not raise an account-binding finding: {rendered}"
+        );
     }
 
     #[test]
@@ -678,6 +736,24 @@ mod tests {
         let wnear = wnear.expect("a resolved AmountV2");
         assert_eq!(wnear.amount, "1");
         assert_eq!(wnear.abbreviation.as_deref(), Some("wNEAR"));
+    }
+
+    #[test]
+    fn token_diff_refuses_a_zero_delta_entry() {
+        let intent = intent_from(
+            r#"{"intent":"token_diff","diff":{"nep141:wrap.near":"-1000000000000000000000000","nep141:usdc.near":"0"}}"#,
+        );
+        let err = render_intent(&intent, &empty_reg()).expect_err("zero delta must be refused");
+        let message = err.to_string();
+        assert!(message.contains("zero delta"), "{message}");
+        assert!(message.contains("nep141:usdc.near"), "{message}");
+    }
+
+    #[test]
+    fn token_diff_refuses_an_empty_diff() {
+        let intent = intent_from(r#"{"intent":"token_diff","diff":{}}"#);
+        let err = render_intent(&intent, &empty_reg()).expect_err("empty diff must be refused");
+        assert!(err.to_string().contains("no entries"), "{err}");
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -367,6 +367,9 @@ pub(crate) fn render_signature(
         SignatureCheck::Invalid => {
             fields.push(diagnostic("signature", "signature verification failed")?);
         }
+        SignatureCheck::MalformedEncoding(reason) => {
+            fields.push(diagnostic("signature", reason)?);
+        }
     }
     Ok(fields)
 }
@@ -488,6 +491,30 @@ mod tests {
     #[test]
     fn invalid_signature_renders_warning() {
         let fields = render_signature("erc191", &SignatureCheck::Invalid, None).expect("render");
+        assert!(
+            super::super::test_support::is_warning_diagnostic(&fields[1], "signature"),
+            "expected a signature warning, got {:?}",
+            fields[1]
+        );
+    }
+
+    /// A malformed recovery-id encoding has to reach the screen as its own
+    /// finding. Without this, the arm could be dropped or mislabelled and a
+    /// cryptographically-sound wallet signature would render no signature
+    /// field at all -- `verify`'s reason string alone proves nothing about
+    /// what a signer sees.
+    #[test]
+    fn malformed_encoding_renders_its_reason_as_a_warning() {
+        let check = SignatureCheck::MalformedEncoding(
+            "malformed signature encoding: recovery id 28, expected 0-3 (Ethereum v=27/28 must be normalized)"
+                .to_string(),
+        );
+        let fields = render_signature("erc191", &check, None).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(
+            !labels.contains(&"Signature"),
+            "a malformed encoding must not claim a Signature field: {labels:?}"
+        );
         assert!(
             super::super::test_support::is_warning_diagnostic(&fields[1], "signature"),
             "expected a signature warning, got {:?}",

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -141,12 +141,27 @@ pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, V
                 .signable_payload_field,
             near_amount_field("Amount", s.amount.as_yoctonear())?,
         ]),
-        Intent::AuthCall(c) => Ok(vec![
-            create_text_field("Contract", c.contract_id.as_str())?.signable_payload_field,
-            create_text_field("Message", &c.msg)?.signable_payload_field,
-            near_amount_field("Attached Deposit", c.attached_deposit.as_yoctonear())?,
-        ]),
+        Intent::AuthCall(c) => {
+            let mut fields = vec![
+                create_text_field("Contract", c.contract_id.as_str())?.signable_payload_field,
+                create_text_field("Message", &c.msg)?.signable_payload_field,
+                near_amount_field("Attached Deposit", c.attached_deposit.as_yoctonear())?,
+            ];
+            if c.state_init.is_some() {
+                fields.push(state_init_field()?);
+            }
+            Ok(fields)
+        }
     }
+}
+
+/// Flags an attached NEP-616 `state_init`: a global-contract id plus initial
+/// state, which initializes the callee's contract in the same receipt. The
+/// code/data have no cheap field-level render, so surface that the attachment
+/// exists rather than let the other fields imply the whole picture -- the same
+/// treatment `actions.rs` gives NEAR's own `DeterministicStateInit` action.
+fn state_init_field() -> Result<SignablePayloadField, VisualSignError> {
+    Ok(create_text_field("State Init", "(not fully decoded)")?.signable_payload_field)
 }
 
 fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSignError> {
@@ -181,6 +196,17 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     }
     if let Some(memo) = &t.memo {
         fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+    }
+    // A `Transfer`'s optional notification changes what the transfer does
+    // beyond moving the named tokens: `msg` calls `mt_on_transfer` on
+    // `receiver_id` (the internal-transfer counterpart of the withdraws'
+    // `_transfer_call` form), and `state_init` initializes the receiver's
+    // contract in the same receipt.
+    if let Some(notification) = &t.notification {
+        fields.push(create_text_field("Message", &notification.msg)?.signable_payload_field);
+        if notification.state_init.is_some() {
+            fields.push(state_init_field()?);
+        }
     }
     Ok(fields)
 }
@@ -285,9 +311,15 @@ fn looks_like_implicit_account(signer_id: &str) -> bool {
 ///
 /// `signer_id` is the payload's claimed signer, when extraction succeeded.
 /// When it has an implicit-account shape, the recovered key's own implied
-/// account id is compared against it -- a real pass/fail check, not a hedge.
-/// For any other shape (a named account) the binding genuinely requires
-/// chain access this parser doesn't have, so it stays a hedge.
+/// account id is compared against it and the outcome stated literally: the key
+/// either derives `signer_id` or it doesn't. Neither outcome settles
+/// authorization, because the contract accepts a key that either derives the
+/// account id *or* sits in the account's on-chain key set
+/// (`Account::has_public_key`, `defuse/v0.4.2`): a derivation match can still
+/// be rejected on-chain (an account may remove its implicit key), and a
+/// non-match is expected for any account that added keys via `AddPublicKey`.
+/// For any other shape (a named account) there is nothing to compare against
+/// at all, so no claim is made.
 pub(crate) fn render_signature(
     standard: &str,
     check: &SignatureCheck,
@@ -301,14 +333,12 @@ pub(crate) fn render_signature(
         } => match signer_id.filter(|id| looks_like_implicit_account(id)) {
             Some(id) if id == implied_account_id => {
                 fields.push(
-                        create_text_field(
-                            "Signature",
-                            &format!(
-                                "valid for key {recovered_key} (account binding confirmed: matches {id})"
-                            ),
-                        )?
-                        .signable_payload_field,
-                    );
+                    create_text_field(
+                        "Signature",
+                        &format!("valid for key {recovered_key} (derives signer_id {id})"),
+                    )?
+                    .signable_payload_field,
+                );
             }
             Some(id) => {
                 fields.push(
@@ -318,7 +348,7 @@ pub(crate) fn render_signature(
                 fields.push(diagnostic(
                         "account-binding",
                         &format!(
-                            "signer_id {id} does not match the key that signed this payload (implies {implied_account_id})"
+                            "the signing key does not derive signer_id {id} (it derives {implied_account_id}); the account may still have authorized this key on-chain, which this parser cannot check"
                         ),
                     )?);
             }
@@ -474,7 +504,7 @@ mod tests {
         match &fields[1] {
             SignablePayloadField::TextV2 { text_v2, .. } => {
                 assert!(
-                    text_v2.text.contains("account binding confirmed"),
+                    text_v2.text.contains("derives signer_id"),
                     "{}",
                     text_v2.text
                 );
@@ -491,7 +521,7 @@ mod tests {
         match &fields[1] {
             SignablePayloadField::TextV2 { text_v2, .. } => {
                 assert!(
-                    text_v2.text.contains("account binding confirmed"),
+                    text_v2.text.contains("derives signer_id"),
                     "{}",
                     text_v2.text
                 );
@@ -740,6 +770,71 @@ mod tests {
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(labels.contains(&"Message"), "labels: {labels:?}");
         assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    /// A NEP-616 `state_init` attached to an intent, in defuse's JSON shape:
+    /// an externally-tagged `StateInit::V1` wrapping a global-contract id.
+    const STATE_INIT: &str =
+        r#"{"V1":{"code":{"hash":"11111111111111111111111111111111"},"data":{}}}"#;
+
+    // Regression coverage for a signing-integrity gap: `Transfer` carries an
+    // optional flattened notification whose `msg` calls `mt_on_transfer` on the
+    // receiver, and whose `state_init` initializes the receiver's contract in
+    // the same receipt. Neither is implied by the To/Amount fields, so both
+    // must reach the screen -- the same class of gap as the withdraws'
+    // storage_deposit/msg coverage above.
+    #[test]
+    fn transfer_renders_notification_message_and_state_init() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"transfer","receiver_id":"attacker.near","tokens":{{"nep141:wrap.near":"1000000000000000000000000"}},"msg":"notify","state_init":{STATE_INIT}}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(labels.contains(&"State Init"), "labels: {labels:?}");
+    }
+
+    #[test]
+    fn transfer_renders_notification_message_without_state_init() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"attacker.near","tokens":{"nep141:wrap.near":"1"},"msg":"notify"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(!labels.contains(&"State Init"), "labels: {labels:?}");
+    }
+
+    #[test]
+    fn transfer_omits_notification_fields_when_absent() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep141:wrap.near":"1"}}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["To", "Amount"]);
+    }
+
+    #[test]
+    fn auth_call_renders_state_init() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"auth_call","contract_id":"evil.near","msg":"{{}}","state_init":{STATE_INIT}}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(
+            labels,
+            ["Contract", "Message", "Attached Deposit", "State Init"]
+        );
+    }
+
+    #[test]
+    fn auth_call_omits_state_init_when_absent() {
+        let intent =
+            intent_from(r#"{"intent":"auth_call","contract_id":"callee.near","msg":"{}"}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Contract", "Message", "Attached Deposit"]);
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -101,8 +101,12 @@ pub(crate) fn section(
         create_text_field("Signed Intent", &format!("{index} of {total}"))?.signable_payload_field,
     ];
     fields.extend(render_signature(standard_name(mp), &check)?);
-    if let Some(payload) = &extracted {
-        fields.extend(render_single(payload, registry)?);
+    match &extracted {
+        Ok(payload) => fields.extend(render_single(payload, registry)?),
+        Err(e) => fields.push(diagnostic(
+            "extraction",
+            &format!("could not extract the envelope/intents: {e}"),
+        )?),
     }
     Ok(fields)
 }
@@ -353,6 +357,32 @@ mod tests {
             super::super::test_support::is_warning_diagnostic(&fields[1], "signature"),
             "expected a signature warning, got {:?}",
             fields[1]
+        );
+    }
+
+    /// When the inner `payload` string doesn't parse as a `DefusePayload`,
+    /// `section()` must surface why nothing rendered rather than silently
+    /// omitting the envelope/intents.
+    #[test]
+    fn section_surfaces_extraction_failure_instead_of_silently_omitting_envelope() {
+        let mp: MultiPayload = serde_json::from_str(
+            r#"{"standard":"raw_ed25519","payload":"not a valid defuse payload","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN","signature":"ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"}"#,
+        )
+        .expect("multi payload json");
+
+        let fields = section(1, 1, &mp, &empty_reg()).expect("render");
+
+        let has_extraction_warning = fields
+            .iter()
+            .any(|f| super::super::test_support::is_warning_diagnostic(f, "extraction"));
+        assert!(
+            has_extraction_warning,
+            "expected an extraction warning, got {fields:?}"
+        );
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(
+            !labels.contains(&"Signer"),
+            "envelope must not render when extraction failed: {labels:?}"
         );
     }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -1,0 +1,519 @@
+//! Render decoded intents into `visualsign` fields. Only this module reads
+//! defuse types and emits `visualsign` types.
+
+use defuse_core::intents::token_diff::TokenDiff;
+use defuse_core::intents::tokens::{FtWithdraw, MtWithdraw, NativeWithdraw, NftWithdraw, Transfer};
+use defuse_core::intents::{DefuseIntents, Intent};
+use defuse_core::payload::DefusePayload;
+use defuse_core::payload::multi::MultiPayload;
+use visualsign::SignablePayloadField;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_amount_field, create_text_field};
+use visualsign::registry::LayeredRegistry;
+
+use super::tokens;
+use super::verify::SignatureCheck;
+use super::{NEAR_DECIMALS, NEAR_SYMBOL, NearTokenRegistry};
+
+type Reg = LayeredRegistry<NearTokenRegistry>;
+type Fields = Vec<SignablePayloadField>;
+
+/// Surfaces a soft finding: the intents still render, and the problem is
+/// reported alongside them. With the `diagnostics` feature this is the
+/// structured [`SignablePayloadField::Diagnostic`]; the default build carries
+/// the same information as a `Warning`-labelled text field, keeping the
+/// production payload shape unchanged.
+#[cfg(feature = "diagnostics")]
+fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
+    Ok(visualsign::field_builders::create_diagnostic_field(
+        rule,
+        "near-intents",
+        visualsign::lint::Severity::Warn,
+        message,
+        None,
+    )
+    .signable_payload_field)
+}
+
+/// See the `diagnostics`-enabled twin above.
+#[cfg(not(feature = "diagnostics"))]
+fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
+    Ok(create_text_field("Warning", &format!("{rule}: {message}"))?.signable_payload_field)
+}
+
+/// Render one token amount, resolving symbol/decimals when the asset is known;
+/// otherwise show the raw base-unit amount tagged with the unresolved asset id.
+fn token_amount_field(
+    label: &str,
+    asset_id: &str,
+    raw: u128,
+    registry: &Reg,
+) -> Result<SignablePayloadField, VisualSignError> {
+    match tokens::resolve(asset_id, registry) {
+        Some(meta) => Ok(create_amount_field(
+            label,
+            &tokens::format_units(raw, meta.decimals),
+            &meta.symbol,
+        )?
+        .signable_payload_field),
+        None => Ok(
+            create_text_field(label, &format!("{raw} (unresolved {asset_id})"))?
+                .signable_payload_field,
+        ),
+    }
+}
+
+/// Format a yoctoNEAR balance as a `<amount> NEAR` text field.
+fn near_amount_field(label: &str, yocto: u128) -> Result<SignablePayloadField, VisualSignError> {
+    Ok(create_amount_field(
+        label,
+        &tokens::format_units(yocto, NEAR_DECIMALS),
+        NEAR_SYMBOL,
+    )?
+    .signable_payload_field)
+}
+
+/// Wire-standard name for a signed payload variant.
+pub(crate) fn standard_name(mp: &MultiPayload) -> &'static str {
+    match mp {
+        MultiPayload::Nep413(_) => "nep413",
+        MultiPayload::Erc191(_) => "erc191",
+        MultiPayload::Tip191(_) => "tip191",
+        MultiPayload::RawEd25519(_) => "raw_ed25519",
+        MultiPayload::WebAuthn(_) => "webauthn",
+        MultiPayload::TonConnect(_) => "ton_connect",
+        MultiPayload::Sep53(_) => "sep53",
+    }
+}
+
+/// Render one signed payload as a section: header + signature + envelope +
+/// per-intent fields. Verification and structural decode are independent, so a
+/// bad signature still renders the decoded intents (flagged at the signature
+/// line).
+pub(crate) fn section(
+    index: usize,
+    total: usize,
+    mp: &MultiPayload,
+    registry: &Reg,
+) -> Result<Fields, VisualSignError> {
+    let (check, extracted) = super::verify::verify_and_extract(mp);
+    let mut fields = vec![
+        create_text_field("Signed Intent", &format!("{index} of {total}"))?.signable_payload_field,
+    ];
+    fields.extend(render_signature(standard_name(mp), &check)?);
+    if let Some(payload) = &extracted {
+        fields.extend(render_single(payload, registry)?);
+    }
+    Ok(fields)
+}
+
+/// Render the fields intrinsic to a single intent.
+pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, VisualSignError> {
+    match intent {
+        Intent::TokenDiff(td) => render_token_diff(td, registry),
+        Intent::Transfer(t) => render_transfer(t, registry),
+        Intent::FtWithdraw(w) => render_ft_withdraw(w, registry),
+        Intent::NftWithdraw(w) => render_nft_withdraw(w),
+        Intent::MtWithdraw(w) => render_mt_withdraw(w),
+        Intent::NativeWithdraw(w) => render_native_withdraw(w),
+        Intent::AddPublicKey(a) => Ok(vec![
+            create_text_field("Add Public Key", &a.public_key.to_string())?.signable_payload_field,
+        ]),
+        Intent::RemovePublicKey(a) => Ok(vec![
+            create_text_field("Remove Public Key", &a.public_key.to_string())?
+                .signable_payload_field,
+        ]),
+        Intent::SetAuthByPredecessorId(s) => Ok(vec![
+            create_text_field(
+                "Auth By Predecessor",
+                if s.enabled { "enabled" } else { "disabled" },
+            )?
+            .signable_payload_field,
+        ]),
+        Intent::StorageDeposit(s) => Ok(vec![
+            create_text_field("Contract", s.contract_id.as_str())?.signable_payload_field,
+            create_text_field("For Account", s.deposit_for_account_id.as_str())?
+                .signable_payload_field,
+            near_amount_field("Amount", s.amount.as_yoctonear())?,
+        ]),
+        Intent::AuthCall(c) => Ok(vec![
+            create_text_field("Contract", c.contract_id.as_str())?.signable_payload_field,
+            create_text_field("Message", &c.msg)?.signable_payload_field,
+            near_amount_field("Attached Deposit", c.attached_deposit.as_yoctonear())?,
+        ]),
+    }
+}
+
+fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSignError> {
+    let mut fields = Fields::new();
+    for (token_id, delta) in td.diff.iter() {
+        let label = if *delta < 0 { "Send" } else { "Receive" };
+        fields.push(token_amount_field(
+            label,
+            &token_id.to_string(),
+            (*delta).unsigned_abs(),
+            registry,
+        )?);
+    }
+    if let Some(memo) = &td.memo {
+        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+    }
+    if let Some(referral) = &td.referral {
+        fields.push(create_text_field("Referral", referral.as_str())?.signable_payload_field);
+    }
+    Ok(fields)
+}
+
+fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignError> {
+    let mut fields = vec![create_text_field("To", t.receiver_id.as_str())?.signable_payload_field];
+    for (token_id, amount) in t.tokens.iter() {
+        fields.push(token_amount_field(
+            "Amount",
+            &token_id.to_string(),
+            *amount,
+            registry,
+        )?);
+    }
+    if let Some(memo) = &t.memo {
+        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+    }
+    Ok(fields)
+}
+
+/// A withdraw's optional `msg` (switches the call into its `_transfer_call`
+/// form, passing this to the receiver) and `storage_deposit` (a separate,
+/// unconditional wNEAR debit for the receiver's storage on `token`, never
+/// refunded on failure) -- both must render, since either changes what the
+/// withdraw actually does beyond moving the named token/amount.
+fn push_withdraw_call_details(
+    fields: &mut Fields,
+    msg: &Option<String>,
+    storage_deposit: Option<near_sdk::NearToken>,
+) -> Result<(), VisualSignError> {
+    if let Some(msg) = msg.as_deref().filter(|m| !m.is_empty()) {
+        fields.push(create_text_field("Message", msg)?.signable_payload_field);
+    }
+    if let Some(deposit) = storage_deposit {
+        fields.push(near_amount_field(
+            "Storage Deposit",
+            deposit.as_yoctonear(),
+        )?);
+    }
+    Ok(())
+}
+
+fn render_ft_withdraw(w: &FtWithdraw, registry: &Reg) -> Result<Fields, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Token", w.token.as_str())?.signable_payload_field,
+        create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
+        token_amount_field(
+            "Amount",
+            &format!("nep141:{}", w.token),
+            w.amount.0,
+            registry,
+        )?,
+    ];
+    if let Some(memo) = &w.memo {
+        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+    }
+    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    Ok(fields)
+}
+
+fn render_nft_withdraw(w: &NftWithdraw) -> Result<Fields, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Token", w.token.as_str())?.signable_payload_field,
+        create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
+        create_text_field("NFT Token Id", w.token_id.as_str())?.signable_payload_field,
+    ];
+    if let Some(memo) = &w.memo {
+        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+    }
+    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    Ok(fields)
+}
+
+fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
+    let mut fields = vec![
+        create_text_field("Token", w.token.as_str())?.signable_payload_field,
+        create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
+    ];
+    for (id, amount) in w.token_ids.iter().zip(w.amounts.iter()) {
+        fields.push(
+            create_text_field("MT Token", &format!("{} x{}", id, amount.0))?.signable_payload_field,
+        );
+    }
+    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    Ok(fields)
+}
+
+fn render_native_withdraw(w: &NativeWithdraw) -> Result<Fields, VisualSignError> {
+    Ok(vec![
+        create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
+        near_amount_field("Amount", w.amount.as_yoctonear())?,
+    ])
+}
+
+/// Render the standard + signature-status fields for one signed payload.
+pub(crate) fn render_signature(
+    standard: &str,
+    check: &SignatureCheck,
+) -> Result<Vec<SignablePayloadField>, VisualSignError> {
+    let mut fields = vec![create_text_field("Standard", standard)?.signable_payload_field];
+    match check {
+        SignatureCheck::Valid { recovered_key } => fields.push(
+            create_text_field("Signature", &format!("valid (recovered {recovered_key})"))?
+                .signable_payload_field,
+        ),
+        SignatureCheck::Invalid => {
+            fields.push(diagnostic("signature", "signature verification failed")?);
+        }
+    }
+    Ok(fields)
+}
+
+/// Render the envelope fields shared by every signed payload: who signed, the
+/// contract being authorized, the deadline, and the nonce.
+pub(crate) fn render_envelope(
+    payload: &DefusePayload<DefuseIntents>,
+) -> Result<Vec<SignablePayloadField>, VisualSignError> {
+    Ok(vec![
+        create_text_field("Signer", payload.signer_id.as_str())?.signable_payload_field,
+        create_text_field("Verifying Contract", payload.verifying_contract.as_str())?
+            .signable_payload_field,
+        create_text_field("Deadline", &payload.deadline.into_timestamp().to_rfc3339())?
+            .signable_payload_field,
+        create_text_field("Nonce", &format!("0x{}", hex::encode(payload.nonce)))?
+            .signable_payload_field,
+    ])
+}
+
+/// Render the envelope + per-intent fields for a single payload the user is
+/// about to sign -- the pre-signature signing view. No signature exists at
+/// signing time, so verification is skipped (unlike [`section`], which renders
+/// a signed `MultiPayload`).
+pub(crate) fn render_single(
+    payload: &DefusePayload<DefuseIntents>,
+    registry: &Reg,
+) -> Result<Fields, VisualSignError> {
+    let mut fields = render_envelope(payload)?;
+    if payload.deadline.has_expired() {
+        fields.push(diagnostic(
+            "deadline",
+            "deadline has passed; the intents would be rejected",
+        )?);
+    }
+    for intent in &payload.intents {
+        fields.extend(render_intent(intent, registry)?);
+    }
+    Ok(fields)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    fn label_of(f: &SignablePayloadField) -> Option<&str> {
+        match f {
+            SignablePayloadField::TextV2 { common, .. }
+            | SignablePayloadField::AmountV2 { common, .. }
+            | SignablePayloadField::AddressV2 { common, .. } => Some(common.label.as_str()),
+            _ => None,
+        }
+    }
+
+    fn empty_reg() -> Reg {
+        LayeredRegistry::new(Arc::new(NearTokenRegistry::default()))
+    }
+
+    fn intent_from(json: &str) -> Intent {
+        serde_json::from_str(json).expect("intent json")
+    }
+
+    #[test]
+    fn signature_fields_present_for_valid() {
+        let fields = render_signature(
+            "nep413",
+            &SignatureCheck::Valid {
+                recovered_key: "ed25519:abc".to_string(),
+            },
+        )
+        .expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Standard", "Signature"]);
+    }
+
+    #[test]
+    fn invalid_signature_renders_warning() {
+        let fields = render_signature("erc191", &SignatureCheck::Invalid).expect("render");
+        assert!(
+            super::super::test_support::is_warning_diagnostic(&fields[1], "signature"),
+            "expected a signature warning, got {:?}",
+            fields[1]
+        );
+    }
+
+    fn sample_payload() -> DefusePayload<DefuseIntents> {
+        DefusePayload {
+            signer_id: "alice.near".parse().expect("account"),
+            verifying_contract: "intents.near".parse().expect("account"),
+            deadline: defuse_deadline::Deadline::new(
+                chrono::DateTime::from_timestamp(1_900_000_000, 0).expect("timestamp"),
+            ),
+            nonce: [0u8; 32],
+            message: DefuseIntents { intents: vec![] },
+        }
+    }
+
+    #[test]
+    fn envelope_emits_signer_verifying_deadline_nonce() {
+        let fields = render_envelope(&sample_payload()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(
+            labels,
+            ["Signer", "Verifying Contract", "Deadline", "Nonce"]
+        );
+        match &fields[0] {
+            SignablePayloadField::TextV2 { text_v2, .. } => assert_eq!(text_v2.text, "alice.near"),
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn token_diff_renders_send_and_receive_resolving_known_token() {
+        let intent = intent_from(
+            r#"{"intent":"token_diff","diff":{"nep141:wrap.near":"-1000000000000000000000000","nep141:usdc.near":"5000000"}}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Send"));
+        assert!(labels.contains(&"Receive"));
+        // wrap.near is seeded -> rendered as an AmountV2 of "1" wNEAR.
+        let wnear = fields.iter().find_map(|f| match f {
+            SignablePayloadField::AmountV2 { amount_v2, .. } => Some(amount_v2),
+            _ => None,
+        });
+        let wnear = wnear.expect("a resolved AmountV2");
+        assert_eq!(wnear.amount, "1");
+        assert_eq!(wnear.abbreviation.as_deref(), Some("wNEAR"));
+    }
+
+    #[test]
+    fn add_public_key_renders_key() {
+        let intent = intent_from(
+            r#"{"intent":"add_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        match &fields[0] {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                assert_eq!(common.label, "Add Public Key");
+                assert_eq!(
+                    text_v2.text,
+                    "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"
+                );
+            }
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_auth_renders_enabled() {
+        let intent = intent_from(r#"{"intent":"set_auth_by_predecessor_id","enabled":true}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        match &fields[0] {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                assert_eq!(common.label, "Auth By Predecessor");
+                assert_eq!(text_v2.text, "enabled");
+            }
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_deposit_renders_contract_account_amount() {
+        let intent = intent_from(
+            r#"{"intent":"storage_deposit","contract_id":"wrap.near","deposit_for_account_id":"alice.near","amount":"1250000000000000000000"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Contract", "For Account", "Amount"]);
+    }
+
+    #[test]
+    fn ft_withdraw_renders_token_receiver_amount() {
+        let intent = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"2000000000000000000000000"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(labels, ["Token", "To", "Amount"]);
+        match fields.iter().find(|f| label_of(f) == Some("Amount")) {
+            Some(SignablePayloadField::AmountV2 { amount_v2, .. }) => {
+                assert_eq!(amount_v2.amount, "2");
+                assert_eq!(amount_v2.abbreviation.as_deref(), Some("wNEAR"));
+            }
+            other => panic!("expected resolved AmountV2, got {other:?}"),
+        }
+    }
+
+    // Regression coverage for a signing-integrity gap: storage_deposit is an
+    // unconditional, unrefundable wNEAR debit alongside the withdraw, and msg
+    // switches the call into its `_transfer_call` form -- both must render or
+    // the user signs a debit they never saw.
+    #[test]
+    fn ft_withdraw_renders_storage_deposit_and_message() {
+        let intent = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"2000000000000000000000000","storage_deposit":"1250000000000000000000","msg":"do-something"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+        match fields
+            .iter()
+            .find(|f| label_of(f) == Some("Storage Deposit"))
+        {
+            Some(SignablePayloadField::AmountV2 { amount_v2, .. }) => {
+                assert_eq!(amount_v2.amount, "0.00125");
+                assert_eq!(amount_v2.abbreviation.as_deref(), Some("NEAR"));
+            }
+            other => panic!("expected resolved AmountV2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nft_withdraw_renders_storage_deposit_and_message() {
+        let intent = intent_from(
+            r#"{"intent":"nft_withdraw","token":"nft.near","receiver_id":"alice.near","token_id":"1","storage_deposit":"1250000000000000000000","msg":"do-something"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    #[test]
+    fn mt_withdraw_renders_storage_deposit_and_message() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["1"],"amounts":["5"],"storage_deposit":"1250000000000000000000","msg":"do-something"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    #[test]
+    fn ft_withdraw_omits_message_and_storage_deposit_when_absent() {
+        let intent = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(!labels.contains(&"Message"), "labels: {labels:?}");
+        assert!(!labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+}

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -1,0 +1,75 @@
+//! Seeded NEP-141 token table + amount formatting.
+
+use visualsign::registry::LayeredRegistry;
+
+use super::{NearTokenRegistry, TokenMeta};
+
+/// Compiled-in mainnet seeds: `(asset_id, symbol, decimals)`.
+///
+/// Each entry MUST be verified against the token contract's `ft_metadata`
+/// before being added; a wrong `decimals` silently misrenders amounts, so
+/// anything not confidently verified is omitted and falls back to the raw
+/// asset id. `wrap.near` is the canonical wrapped-NEAR contract (24 decimals,
+/// matching native NEAR).
+const SEEDS: &[(&str, &str, u8)] = &[("nep141:wrap.near", "wNEAR", 24)];
+
+/// Resolve an asset id to its metadata: request-scoped override layer first
+/// (via the registry), then the compiled-in seed table.
+pub(crate) fn resolve(
+    asset_id: &str,
+    registry: &LayeredRegistry<NearTokenRegistry>,
+) -> Option<TokenMeta> {
+    if let Some(meta) = registry.lookup(|r| r.by_asset_id.get(asset_id).cloned()) {
+        return Some(meta);
+    }
+    SEEDS
+        .iter()
+        .find(|(id, _, _)| *id == asset_id)
+        .map(|(_, symbol, decimals)| TokenMeta {
+            symbol: (*symbol).to_string(),
+            decimals: *decimals,
+        })
+}
+
+/// Format `units / 10^decimals` as an exact decimal string, trailing zeros
+/// trimmed (e.g. `1_500_000` @ 6 -> `"1.5"`, `0` -> `"0"`).
+pub(crate) fn format_units(units: u128, decimals: u8) -> String {
+    let scale = 10u128.pow(u32::from(decimals));
+    let whole = units / scale;
+    let frac = units % scale;
+    if frac == 0 {
+        return whole.to_string();
+    }
+    let frac_str = format!("{frac:0width$}", width = decimals as usize);
+    format!("{whole}.{}", frac_str.trim_end_matches('0'))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use visualsign::registry::LayeredRegistry;
+
+    fn empty() -> LayeredRegistry<NearTokenRegistry> {
+        LayeredRegistry::new(Arc::new(NearTokenRegistry::default()))
+    }
+
+    #[test]
+    fn seeded_token_resolves() {
+        let meta = resolve("nep141:wrap.near", &empty()).expect("seeded");
+        assert_eq!(meta.symbol, "wNEAR");
+        assert_eq!(meta.decimals, 24);
+    }
+
+    #[test]
+    fn unknown_token_is_none() {
+        assert!(resolve("nep141:not-a-real-token.near", &empty()).is_none());
+    }
+
+    #[test]
+    fn format_with_decimals_trims() {
+        assert_eq!(format_units(1_500_000, 6), "1.5");
+        assert_eq!(format_units(0, 6), "0");
+    }
+}

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -13,6 +13,17 @@ use super::{NearTokenRegistry, TokenMeta};
 /// matching native NEAR).
 const SEEDS: &[(&str, &str, u8)] = &[("nep141:wrap.near", "wNEAR", 24)];
 
+/// Largest `decimals` [`format_units`] can scale by: `10^39` exceeds `u128`.
+const MAX_DECIMALS: u8 = 38;
+
+/// Metadata whose `decimals` [`format_units`] cannot scale by. Refusing it here
+/// keeps that overflow unreachable, and renders the amount in its honest
+/// unresolved form (raw base units plus the asset id) rather than scaled by a
+/// wrapped-around divisor.
+fn usable(meta: TokenMeta) -> Option<TokenMeta> {
+    (meta.decimals <= MAX_DECIMALS).then_some(meta)
+}
+
 /// Resolve an asset id to its metadata: request-scoped override layer first
 /// (via the registry), then the compiled-in seed table.
 pub(crate) fn resolve(
@@ -20,7 +31,7 @@ pub(crate) fn resolve(
     registry: &LayeredRegistry<NearTokenRegistry>,
 ) -> Option<TokenMeta> {
     if let Some(meta) = registry.lookup(|r| r.by_asset_id.get(asset_id).cloned()) {
-        return Some(meta);
+        return usable(meta);
     }
     SEEDS
         .iter()
@@ -29,10 +40,14 @@ pub(crate) fn resolve(
             symbol: (*symbol).to_string(),
             decimals: *decimals,
         })
+        .and_then(usable)
 }
 
 /// Format `units / 10^decimals` as an exact decimal string, trailing zeros
 /// trimmed (e.g. `1_500_000` @ 6 -> `"1.5"`, `0` -> `"0"`).
+///
+/// `decimals` must be within [`MAX_DECIMALS`]; [`resolve`] is the only source
+/// of registry-supplied values and refuses anything larger.
 pub(crate) fn format_units(units: u128, decimals: u8) -> String {
     let scale = 10u128.pow(u32::from(decimals));
     let whole = units / scale;
@@ -65,6 +80,46 @@ mod tests {
     #[test]
     fn unknown_token_is_none() {
         assert!(resolve("nep141:not-a-real-token.near", &empty()).is_none());
+    }
+
+    // `format_units` scales by `10^decimals`, which overflows `u128` above 38.
+    // An override carrying such a value must not resolve: the amount then
+    // renders as raw base units plus the asset id, rather than overflowing (or,
+    // with overflow checks off, dividing by a wrapped-around scale and
+    // misrendering the amount being signed).
+    #[test]
+    fn override_with_unscalable_decimals_does_not_resolve() {
+        let asset_id = "nep141:broken.near";
+        let mut request = NearTokenRegistry::default();
+        request.by_asset_id.insert(
+            asset_id.to_string(),
+            TokenMeta {
+                symbol: "BROKEN".to_string(),
+                decimals: 39,
+            },
+        );
+        let registry =
+            LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request);
+        assert!(resolve(asset_id, &registry).is_none());
+    }
+
+    #[test]
+    fn override_at_the_decimals_bound_resolves() {
+        let asset_id = "nep141:wide.near";
+        let mut request = NearTokenRegistry::default();
+        request.by_asset_id.insert(
+            asset_id.to_string(),
+            TokenMeta {
+                symbol: "WIDE".to_string(),
+                decimals: MAX_DECIMALS,
+            },
+        );
+        let registry =
+            LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request);
+        let meta = resolve(asset_id, &registry).expect("resolves at the bound");
+        assert_eq!(meta.decimals, MAX_DECIMALS);
+        // The bound is exactly what `format_units` can scale by.
+        assert_eq!(format_units(0, MAX_DECIMALS), "0");
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
@@ -7,6 +7,7 @@ use defuse_core::payload::{DefusePayload, ExtractDefusePayload};
 use defuse_crypto::SignedPayload;
 
 /// Outcome of verifying one payload's signature.
+#[derive(Debug)]
 pub(crate) enum SignatureCheck {
     /// Signature is cryptographically valid.
     Valid {
@@ -23,6 +24,12 @@ pub(crate) enum SignatureCheck {
     },
     /// Signature did not verify.
     Invalid,
+    /// Cryptographically well-formed but encodes a recovery-id convention
+    /// this wire format doesn't accept (e.g. Ethereum's v=27/28 instead of
+    /// the 0-3 this format expects). Not a proof of tampering -- rendered
+    /// with its own diagnostic rather than folded into `Invalid`, whose
+    /// wording implies the cryptography itself failed.
+    MalformedEncoding(String),
 }
 
 /// Verify the signature and extract the inner intents payload.
@@ -36,16 +43,15 @@ pub(crate) enum SignatureCheck {
 pub(crate) fn verify_and_extract(
     payload: &MultiPayload,
 ) -> (SignatureCheck, Result<DefusePayload<DefuseIntents>, String>) {
-    let check = if has_invalid_secp256k1_recovery_id(payload) {
-        SignatureCheck::Invalid
-    } else {
-        match payload.verify() {
+    let check = match invalid_secp256k1_recovery_id_reason(payload) {
+        Some(reason) => SignatureCheck::MalformedEncoding(reason),
+        None => match payload.verify() {
             Some(key) => SignatureCheck::Valid {
                 recovered_key: key.to_string(),
                 implied_account_id: key.to_implicit_account_id().to_string(),
             },
             None => SignatureCheck::Invalid,
-        }
+        },
     };
     let extracted = payload
         .clone()
@@ -58,7 +64,14 @@ pub(crate) fn verify_and_extract(
 /// they reach `verify()`: near-crypto's native `ecrecover` backend panics on
 /// an invalid recovery id rather than returning `None`, and a signing service
 /// must treat a malformed payload as invalid input, never as a crash.
-fn has_invalid_secp256k1_recovery_id(payload: &MultiPayload) -> bool {
+///
+/// Returns the human-readable reason when rejected, `None` when the
+/// signature's recovery id is in range (or the standard has none). The most
+/// common out-of-range case is Ethereum's v=27/28 convention (`recovery_id +
+/// 27`, per MetaMask/`personal_sign`) landing on a wire format that expects
+/// the raw 0-3 recovery id -- flagged with a specific hint, since that's a
+/// wrong encoding, not a broken signature.
+fn invalid_secp256k1_recovery_id_reason(payload: &MultiPayload) -> Option<String> {
     let signature = match payload {
         MultiPayload::Erc191(signed) => &signed.signature,
         MultiPayload::Tip191(signed) => &signed.signature,
@@ -68,7 +81,18 @@ fn has_invalid_secp256k1_recovery_id(payload: &MultiPayload) -> bool {
         | MultiPayload::RawEd25519(_)
         | MultiPayload::WebAuthn(_)
         | MultiPayload::TonConnect(_)
-        | MultiPayload::Sep53(_) => return false,
+        | MultiPayload::Sep53(_) => return None,
     };
-    signature[64] >= 4
+    let recovery_id = signature[64];
+    if recovery_id < 4 {
+        return None;
+    }
+    let hint = if recovery_id == 27 || recovery_id == 28 {
+        " (Ethereum v=27/28 must be normalized)"
+    } else {
+        ""
+    };
+    Some(format!(
+        "malformed signature encoding: recovery id {recovery_id}, expected 0-3{hint}"
+    ))
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
@@ -51,7 +51,13 @@ fn has_invalid_secp256k1_recovery_id(payload: &MultiPayload) -> bool {
     let signature = match payload {
         MultiPayload::Erc191(signed) => &signed.signature,
         MultiPayload::Tip191(signed) => &signed.signature,
-        _ => return false,
+        // Ed25519/P256 standards have no recovery id, so ecrecover's
+        // out-of-range panic path cannot be reached for these variants.
+        MultiPayload::Nep413(_)
+        | MultiPayload::RawEd25519(_)
+        | MultiPayload::WebAuthn(_)
+        | MultiPayload::TonConnect(_)
+        | MultiPayload::Sep53(_) => return false,
     };
     signature[64] >= 4
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
@@ -8,9 +8,19 @@ use defuse_crypto::SignedPayload;
 
 /// Outcome of verifying one payload's signature.
 pub(crate) enum SignatureCheck {
-    /// Signature is cryptographically valid; `recovered_key` is the public key
-    /// the signature recovers to (NOT a proof of account binding).
-    Valid { recovered_key: String },
+    /// Signature is cryptographically valid.
+    Valid {
+        /// The public key the signature recovers to.
+        recovered_key: String,
+        /// The account id `recovered_key` implies under NEAR's (or defuse's
+        /// EVM-style) implicit-account convention. Comparable against a
+        /// payload's `signer_id` when that id has the same shape -- see
+        /// `render.rs::looks_like_implicit_account`. For a named account
+        /// (e.g. `alice.near`), this comparison says nothing: named accounts'
+        /// access keys are registered on-chain, decoupled from any implicit
+        /// derivation.
+        implied_account_id: String,
+    },
     /// Signature did not verify.
     Invalid,
 }
@@ -32,6 +42,7 @@ pub(crate) fn verify_and_extract(
         match payload.verify() {
             Some(key) => SignatureCheck::Valid {
                 recovered_key: key.to_string(),
+                implied_account_id: key.to_implicit_account_id().to_string(),
             },
             None => SignatureCheck::Invalid,
         }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
@@ -19,10 +19,13 @@ pub(crate) enum SignatureCheck {
 ///
 /// `verify()` and `extract_defuse_payload()` are independent: a payload with an
 /// invalid signature or an unparseable inner body can still yield the other
-/// half, so both are attempted and reported separately.
+/// half, so both are attempted and reported separately. Extraction failure
+/// keeps its error message (rather than collapsing to `None`) so the caller
+/// can surface *why* no envelope/intents rendered instead of silently
+/// omitting them.
 pub(crate) fn verify_and_extract(
     payload: &MultiPayload,
-) -> (SignatureCheck, Option<DefusePayload<DefuseIntents>>) {
+) -> (SignatureCheck, Result<DefusePayload<DefuseIntents>, String>) {
     let check = if has_invalid_secp256k1_recovery_id(payload) {
         SignatureCheck::Invalid
     } else {
@@ -33,7 +36,10 @@ pub(crate) fn verify_and_extract(
             None => SignatureCheck::Invalid,
         }
     };
-    let extracted = payload.clone().extract_defuse_payload().ok();
+    let extracted = payload
+        .clone()
+        .extract_defuse_payload()
+        .map_err(|e| e.to_string());
     (check, extracted)
 }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/verify.rs
@@ -1,0 +1,51 @@
+//! Signature verification + payload extraction. Defuse types stay internal;
+//! results are normalized to `String`/`visualsign` shapes by `render.rs`.
+
+use defuse_core::intents::DefuseIntents;
+use defuse_core::payload::multi::MultiPayload;
+use defuse_core::payload::{DefusePayload, ExtractDefusePayload};
+use defuse_crypto::SignedPayload;
+
+/// Outcome of verifying one payload's signature.
+pub(crate) enum SignatureCheck {
+    /// Signature is cryptographically valid; `recovered_key` is the public key
+    /// the signature recovers to (NOT a proof of account binding).
+    Valid { recovered_key: String },
+    /// Signature did not verify.
+    Invalid,
+}
+
+/// Verify the signature and extract the inner intents payload.
+///
+/// `verify()` and `extract_defuse_payload()` are independent: a payload with an
+/// invalid signature or an unparseable inner body can still yield the other
+/// half, so both are attempted and reported separately.
+pub(crate) fn verify_and_extract(
+    payload: &MultiPayload,
+) -> (SignatureCheck, Option<DefusePayload<DefuseIntents>>) {
+    let check = if has_invalid_secp256k1_recovery_id(payload) {
+        SignatureCheck::Invalid
+    } else {
+        match payload.verify() {
+            Some(key) => SignatureCheck::Valid {
+                recovered_key: key.to_string(),
+            },
+            None => SignatureCheck::Invalid,
+        }
+    };
+    let extracted = payload.clone().extract_defuse_payload().ok();
+    (check, extracted)
+}
+
+/// Rejects secp256k1 signatures whose recovery byte is out of range before
+/// they reach `verify()`: near-crypto's native `ecrecover` backend panics on
+/// an invalid recovery id rather than returning `None`, and a signing service
+/// must treat a malformed payload as invalid input, never as a crash.
+fn has_invalid_secp256k1_recovery_id(payload: &MultiPayload) -> bool {
+    let signature = match payload {
+        MultiPayload::Erc191(signed) => &signed.signature,
+        MultiPayload::Tip191(signed) => &signed.signature,
+        _ => return false,
+    };
+    signature[64] >= 4
+}

--- a/src/chain_parsers/visualsign-near/src/presets/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/mod.rs
@@ -1,0 +1,3 @@
+//! Application-layer decoders for protocols that run on top of NEAR.
+
+pub mod intents;

--- a/src/chain_parsers/visualsign-near/src/tx.rs
+++ b/src/chain_parsers/visualsign-near/src/tx.rs
@@ -1,26 +1,25 @@
-//! NEAR transaction envelope decoding.
+//! NEAR input decoding: a borsh transaction, or a pre-signature NEAR Intents
+//! envelope (`DefusePayload` JSON, the `near::sign_intent` payload).
+//!
+//! Borsh bytes are never valid JSON, so the two formats are distinguished
+//! unambiguously: a successful borsh decode is a transaction, otherwise the
+//! input is validated as an envelope. Input that is neither is rejected.
 
 use near_primitives::transaction::{SignedTransaction, Transaction};
 use visualsign::encodings::SupportedEncodings;
 use visualsign::vsptrait::{DeveloperConfig, TransactionParseError};
 
-/// VSP wrapper over `near-primitives` Transaction. Owns the borsh decoding logic.
+/// A NEAR input: an on-chain transaction, or a pre-signature intents envelope.
 #[derive(Debug, Clone)]
-pub struct NearTransaction {
-    inner: Transaction,
+pub enum NearTransaction {
+    /// A borsh-decoded NEAR transaction (`near::sign_transaction`).
+    OnChain(Transaction),
+    /// A pre-signature `DefusePayload` JSON envelope (`near::sign_intent`),
+    /// kept as the validated raw text -- rendering re-parses it.
+    Intent(String),
 }
 
 impl NearTransaction {
-    #[must_use]
-    pub fn new(inner: Transaction) -> Self {
-        Self { inner }
-    }
-
-    #[must_use]
-    pub fn inner(&self) -> &Transaction {
-        &self.inner
-    }
-
     /// Decode unsigned first. Only when `developer_config.allow_signed_transactions`
     /// is set does a `SignedTransaction` envelope get accepted, with its signature
     /// discarded to render the inner unsigned transaction -- production callers
@@ -29,36 +28,52 @@ impl NearTransaction {
         s: &str,
         developer_config: Option<&DeveloperConfig>,
     ) -> Result<Self, TransactionParseError> {
-        let bytes = decode_input(s.trim())?;
-        let unsigned_err = match borsh::from_slice::<Transaction>(&bytes) {
-            Ok(unsigned) => return Ok(Self::new(unsigned)),
-            Err(e) => e,
-        };
-        let allow_signed = developer_config
-            .map(|c| c.allow_signed_transactions)
-            .unwrap_or(false);
-        if allow_signed {
-            match borsh::from_slice::<SignedTransaction>(&bytes) {
-                Ok(signed) => {
-                    // Developer-only posture: production callers pass `None`, so
-                    // reaching here in production means a misconfiguration and
-                    // must leave a trail.
-                    tracing::warn!(
-                        "accepted a signed NEAR transaction and discarded its signature; \
-                         allow_signed_transactions is a developer-only setting"
-                    );
-                    return Ok(Self::new(signed.transaction));
+        let trimmed = s.trim();
+        let mut borsh_failure: Option<String> = None;
+        if let Ok(bytes) = decode_input(trimmed) {
+            let unsigned_err = match borsh::from_slice::<Transaction>(&bytes) {
+                Ok(unsigned) => return Ok(Self::OnChain(unsigned)),
+                Err(e) => e,
+            };
+            let allow_signed = developer_config
+                .map(|c| c.allow_signed_transactions)
+                .unwrap_or(false);
+            if allow_signed {
+                match borsh::from_slice::<SignedTransaction>(&bytes) {
+                    Ok(signed) => {
+                        // Developer-only posture: production callers pass `None`, so
+                        // reaching here in production means a misconfiguration and
+                        // must leave a trail.
+                        tracing::warn!(
+                            "accepted a signed NEAR transaction and discarded its signature; \
+                             allow_signed_transactions is a developer-only setting"
+                        );
+                        return Ok(Self::OnChain(signed.transaction));
+                    }
+                    Err(signed_err) => {
+                        borsh_failure =
+                            Some(format!("unsigned={unsigned_err}, signed={signed_err}"));
+                    }
                 }
-                Err(signed_err) => {
-                    return Err(TransactionParseError::DecodeError(format!(
-                        "near borsh decode: unsigned={unsigned_err}, signed={signed_err}"
-                    )));
-                }
+            } else {
+                borsh_failure = Some(unsigned_err.to_string());
             }
         }
-        Err(TransactionParseError::DecodeError(format!(
-            "near borsh decode: {unsigned_err}"
-        )))
+        // Validate eagerly so malformed input is rejected at parse time
+        // rather than at render time.
+        serde_json::from_str::<
+            defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents>,
+        >(trimmed)
+        .map_err(|e| {
+            let borsh_cause = borsh_failure
+                .as_deref()
+                .unwrap_or("input is not hex or base64");
+            TransactionParseError::DecodeError(format!(
+                "input is neither a NEAR borsh transaction (near borsh decode: {borsh_cause}) \
+                 nor a DefusePayload JSON envelope: {e}"
+            ))
+        })?;
+        Ok(Self::Intent(trimmed.to_string()))
     }
 }
 
@@ -68,7 +83,10 @@ impl visualsign::vsptrait::Transaction for NearTransaction {
     }
 
     fn transaction_type(&self) -> String {
-        "NEAR".to_string()
+        match self {
+            Self::OnChain(_) => "NEAR".to_string(),
+            Self::Intent(_) => "NEAR Intent".to_string(),
+        }
     }
 }
 
@@ -95,19 +113,29 @@ mod tests {
     /// Borsh-encoded unsigned NEAR Transfer: alice.near -> bob.near, 1 NEAR.
     const TRANSFER_HEX: &str = "0a000000616c6963652e6e656172000000000000000000000000000000000000000000000000000000000000000000010000000000000008000000626f622e6e65617200000000000000000000000000000000000000000000000000000000000000000100000003000000a1edccce1bc2d3000000000000";
 
+    const SWAP_INTENT: &str = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2100-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+
+    fn onchain(tx: &NearTransaction) -> &Transaction {
+        match tx {
+            NearTransaction::OnChain(inner) => inner,
+            NearTransaction::Intent(_) => panic!("expected OnChain"),
+        }
+    }
+
     #[test]
     fn decode_rejects_garbage() {
-        let result = NearTransaction::from_string("not-hex-not-base64");
+        let result = NearTransaction::from_string("not-hex-not-base64-not-json");
         assert!(result.is_err());
     }
 
     #[test]
     fn decode_hex_transfer() {
         let tx = NearTransaction::from_string(TRANSFER_HEX).expect("decode hex");
-        assert_eq!(tx.inner().signer_id().as_str(), "alice.near");
-        assert_eq!(tx.inner().receiver_id().as_str(), "bob.near");
-        assert_eq!(tx.inner().actions().len(), 1);
-        let near_primitives::action::Action::Transfer(transfer) = &tx.inner().actions()[0] else {
+        let inner = onchain(&tx);
+        assert_eq!(inner.signer_id().as_str(), "alice.near");
+        assert_eq!(inner.receiver_id().as_str(), "bob.near");
+        assert_eq!(inner.actions().len(), 1);
+        let near_primitives::action::Action::Transfer(transfer) = &inner.actions()[0] else {
             panic!("expected Transfer");
         };
         assert_eq!(
@@ -131,7 +159,7 @@ mod tests {
     #[test]
     fn decode_hex_with_0x_prefix() {
         let tx = NearTransaction::from_string(&format!("0x{TRANSFER_HEX}")).expect("decode 0x-hex");
-        assert_eq!(tx.inner().signer_id().as_str(), "alice.near");
+        assert_eq!(onchain(&tx).signer_id().as_str(), "alice.near");
     }
 
     #[test]
@@ -140,8 +168,9 @@ mod tests {
         let bytes = hex::decode(TRANSFER_HEX).expect("hex");
         let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
         let tx = NearTransaction::from_string(&b64).expect("decode base64");
-        assert_eq!(tx.inner().signer_id().as_str(), "alice.near");
-        assert_eq!(tx.inner().receiver_id().as_str(), "bob.near");
+        let inner = onchain(&tx);
+        assert_eq!(inner.signer_id().as_str(), "alice.near");
+        assert_eq!(inner.receiver_id().as_str(), "bob.near");
     }
 
     fn signed_transfer_bytes() -> Vec<u8> {
@@ -169,6 +198,28 @@ mod tests {
         };
         let tx = NearTransaction::from_string_with_options(&hex, Some(&developer_config))
             .expect("decode signed");
-        assert_eq!(tx.inner().signer_id().as_str(), "alice.near");
+        assert_eq!(onchain(&tx).signer_id().as_str(), "alice.near");
+    }
+
+    #[test]
+    fn decode_json_envelope_is_intent() {
+        let tx = NearTransaction::from_string(SWAP_INTENT).expect("decode intent");
+        match tx {
+            NearTransaction::Intent(json) => assert_eq!(json, SWAP_INTENT),
+            NearTransaction::OnChain(_) => panic!("expected Intent"),
+        }
+        assert_eq!(
+            NearTransaction::from_string(SWAP_INTENT)
+                .expect("decode intent")
+                .transaction_type(),
+            "NEAR Intent"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_malformed_json() {
+        // Valid JSON, but not a DefusePayload shape.
+        let result = NearTransaction::from_string(r#"{"foo":"bar"}"#);
+        assert!(result.is_err());
     }
 }

--- a/src/chain_parsers/visualsign-near/src/tx.rs
+++ b/src/chain_parsers/visualsign-near/src/tx.rs
@@ -65,12 +65,15 @@ impl NearTransaction {
             defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents>,
         >(trimmed)
         .map_err(|e| {
+            // Both causes are appended rather than interpolated into the
+            // summary, so the sentence naming the two accepted formats stays
+            // contiguous for callers that match on it.
             let borsh_cause = borsh_failure
                 .as_deref()
                 .unwrap_or("input is not hex or base64");
             TransactionParseError::DecodeError(format!(
-                "input is neither a NEAR borsh transaction (near borsh decode: {borsh_cause}) \
-                 nor a DefusePayload JSON envelope: {e}"
+                "input is neither a NEAR borsh transaction nor a DefusePayload JSON envelope: \
+                 {e}; near borsh decode: {borsh_cause}"
             ))
         })?;
         Ok(Self::Intent(trimmed.to_string()))


### PR DESCRIPTION
Third PR of the NEAR chain-support stack (stacked on #426). Adds the NEAR Intents preset -- decode + render for both the signed-envelope and pre-signature flows -- and merges the crate's two input-format handlers into one.

Stack: A1 (#425) -> A2 (#426) -> **A3 (this)** -> A4 (#429) -> B (identity + wiring) -> C (docs site) -> D (wallet-signed token metadata).

## The preset

`chain_parsers/visualsign-near/src/presets/intents/`:

- `mod.rs` -- entry points (`try_decode_execute_intents` for a signed batch, `try_render_single_intent` for the pre-signature view), `NearIntentsError`, `NearTokenRegistry`/`TokenMeta`. The public surface is `visualsign` types plus primitives; `defuse-*` and `near-sdk` types stay behind this module.
- `args.rs` -- JSON deserialization of `execute_intents` args (`{"signed": [...]}`).
- `tokens.rs` -- seeded NEP-141 metadata and amount formatting.
- `render.rs` -- all 11 intent variants, plus the envelope and signature sections.
- `verify.rs` -- signature verification and payload extraction, reported independently of each other.

## The converter merge

`tx.rs`'s `NearTransaction` is an enum:

```rust
pub enum NearTransaction {
    OnChain(near_primitives::transaction::Transaction),
    Intent(String), // validated DefusePayload JSON, kept as text
}
```

`from_string` tries borsh first (via the existing hex/base64 detection); on failure it validates the input as a `DefusePayload` JSON envelope, and rejects anything that is neither. Borsh bytes are never valid JSON, so the discrimination is unambiguous. One chain identity, format-discriminated, rather than a converter per input format under its own custom chain name.

`convert.rs` dispatches on the variant: `OnChain` renders A2's baseline fields, plus the decoded intents when the action is a `FunctionCall` to `intents.near`/`execute_intents`; `Intent` renders via `try_render_single_intent`, titled "NEAR Intent", with no signature section because nothing is signed at that stage.

## What the signing screen states

- **Verification and extraction are independent.** A bad signature still renders the decoded intents, flagged at the signature line; a body that fails to extract surfaces the reason as a diagnostic rather than silently omitting the envelope.
- **Every field that changes what is authorized renders.** The three withdraws' `storage_deposit` (an unconditional, unrefundable wNEAR debit alongside the withdraw) and `msg` (switches the call into its `_transfer_call` form); `Transfer`'s flattened notification, whose `msg` calls `mt_on_transfer` on the receiver; and the NEP-616 `state_init` on both `Transfer`'s notification and `AuthCall`, which initializes the receiver's contract in the same receipt. `state_init`'s code and data have no cheap field-level render, so it is flagged `(not fully decoded)`, matching `actions.rs`'s handling of NEAR's own `DeterministicStateInit`. `min_gas` is the only field omitted, consistently across the four variants that carry it.
- **`mt_withdraw` rejects a `token_ids`/`amounts` length mismatch** rather than rendering the `zip` overlap and dropping the rest.
- **Signature outcomes are three, not two.** `Valid`, `Invalid`, and `MalformedEncoding` -- a signature that is cryptographically sound but carries Ethereum's `v = recovery_id + 27` against the 0-3 this wire format expects. Reporting that as `Invalid` would render "signature verification failed", which reads as tampering. A separate guard rejects out-of-range recovery ids before `verify()`, because near-crypto's native `ecrecover` panics on them rather than returning `None`, and a signing service must treat malformed input as invalid, never as a crash. The variant list is explicit, so a future secp256k1-backed standard is a build break rather than a latent panic.
- **The account-binding fields claim only what was checked.** When `signer_id` has an implicit-account shape, the recovered key's implied account id is compared against it and the result stated literally. Neither outcome settles authorization: the contract accepts a key that either derives the account id *or* sits in the account's on-chain key set (`Account::has_public_key`, `defuse/v0.4.2`), so a derivation match can still be rejected on-chain and a non-match is expected for any account that added keys via `AddPublicKey`. A named account has nothing to compare against, so no claim is made.
- **Deadline expiry is advisory.** `has_expired()` reads the system clock, which is not necessarily trustworthy inside the enclave; the contract enforces the real deadline.
- **Diagnostics carry in both build shapes.** With the `diagnostics` feature a soft finding is a structured `Diagnostic` field; by default it is the same information as a `Warning`-labelled text field, leaving the production payload shape unchanged.

## Token metadata

`SEEDS` is a compiled-in table of entries verified against the token contract's own `ft_metadata`; anything unverified is omitted and falls back to the raw asset id, since a wrong `decimals` silently misrenders amounts. Request-scoped overrides layer on top via `LayeredRegistry`. `decimals` above 38 does not resolve at all: `format_units` scales by `10^decimals`, which exceeds `u128` past that point, so an out-of-range value would either overflow or -- with overflow checks off -- divide by a wrapped-around scale and misrender the amount being signed.

## Dependencies

`defuse-core`/`defuse-crypto`/`defuse-deadline`, `near-sdk`, `chrono`, `bs58` and `hex` land here, where they are first used. near-sdk 5.27+ (what this workspace resolves) fixes the native-linking gap on the panic path, so `visualsign-near` keeps the workspace's `unsafe_code = "forbid"` with no carve-out and no shim.

## Verification

- `cargo build -p visualsign-near` -- clean.
- `cargo test -p visualsign-near` -- 94/94 pass, under both default and `--features diagnostics`.
- `cargo clippy -p visualsign-near --all-targets -- -D warnings`, `cargo fmt --check` -- clean.
- `cargo clippy -p parser_app --no-default-features --features near` -- clean (narrow-build variant).
- `make -C src lint` -- clean; `make -C src test` -- clean (workspace suite, including the 9 gRPC integration tests).
