### PR TITLE
chore(agents): track .pi config, add AGENTS.md symlink and pi format-on-edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ docs/superpowers/
 .claude/runbooks/
 .claude/worktrees/
 
+# pi per-user/working files. The shared team config under .pi/extensions/ IS
+# tracked and intentionally not matched here; everything below is per-user
+# scratch that must never be committed (mirrors the .claude/ treatment above).
+# Trust decisions live in the global ~/.pi/agent store, not in the repo.
+.pi/mega-compact/
+
 # Coverage artifacts (see TESTING.md)
 lcov.info
 *.profraw

--- a/.pi/extensions/format-on-edit.ts
+++ b/.pi/extensions/format-on-edit.ts
@@ -6,12 +6,14 @@
  * a formatting failure is surfaced as a notification, never as a tool error,
  * so the agent is never blocked by a formatting issue.
  *
- * Loaded after project trust from `.pi/extensions/`. Use `/trust` to save the
+ * Loaded after project trust from `.pi/extensions/`. Use /trust to save the
  * decision for this worktree so it loads without prompting.
  */
 
 import { spawn } from "node:child_process";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const RUSTFMT_TIMEOUT_MS = 10_000;
 
 export default function (pi: ExtensionAPI) {
 	pi.on("tool_result", async (event, ctx) => {
@@ -23,27 +25,60 @@ export default function (pi: ExtensionAPI) {
 		const path = String(event.input.path ?? "");
 		if (!path.endsWith(".rs")) return undefined;
 
-		await new Promise<void>((resolve) => {
-			const child = spawn("rustfmt", ["--edition", "2024", path], {
-				stdio: "ignore",
-				signal: ctx.signal,
+		try {
+			await new Promise<void>((resolve) => {
+				const child = spawn("rustfmt", ["--edition", "2024", path], {
+					stdio: ["ignore", "ignore", "pipe"],
+					signal: ctx.signal,
+				});
+
+				// Capture stderr so the warning can say why rustfmt failed instead
+				// of just "exited 1".
+				let stderr = "";
+				child.stderr?.on("data", (chunk: Buffer | string) => {
+					stderr += chunk.toString();
+				});
+
+				let notified = false;
+				const warn = (msg: string) => {
+					if (!notified && !ctx.signal?.aborted) {
+						notified = true;
+						ctx.ui.notify?.(msg, "warning");
+					}
+				};
+
+				let settled = false;
+				let timer: ReturnType<typeof setTimeout> | undefined;
+				const finish = () => {
+					if (!settled) {
+						settled = true;
+						if (timer) clearTimeout(timer);
+						resolve();
+					}
+				};
+
+				// A wedged rustfmt would otherwise stall the agent turn. Kill it and
+				// surface a warning; 'close' fires after the kill and resolves.
+				timer = setTimeout(() => {
+					child.kill("SIGKILL");
+					warn(`rustfmt timed out after ${RUSTFMT_TIMEOUT_MS}ms for ${path}`);
+				}, RUSTFMT_TIMEOUT_MS);
+
+				child.on("error", () => {
+					if (!ctx.signal?.aborted) warn(`rustfmt failed to run for ${path}`);
+					finish();
+				});
+				child.on("close", (code) => {
+					if (code !== 0 && !ctx.signal?.aborted) {
+						const detail = stderr.trim().split("\n").pop() ?? "";
+						warn(`rustfmt exited ${code ?? "<killed>"} for ${path}${detail ? `: ${detail}` : ""}`);
+					}
+					finish();
+				});
 			});
-			let notified = false;
-			const warn = (msg: string) => {
-				if (!notified) {
-					notified = true;
-					ctx.ui.notify?.(msg, "warning");
-				}
-			};
-			child.on("error", () => {
-				if (!ctx.signal?.aborted) warn(`rustfmt failed to run for ${path}`);
-				resolve();
-			});
-			child.on("close", (code) => {
-				if (code !== 0 && !ctx.signal?.aborted) warn(`rustfmt exited ${code ?? "<killed>"} for ${path}`);
-				resolve();
-			});
-		});
+		} catch {
+			// Never block the agent on a formatting failure.
+		}
 
 		return undefined;
 	});

--- a/.pi/extensions/format-on-edit.ts
+++ b/.pi/extensions/format-on-edit.ts
@@ -1,0 +1,37 @@
+/**
+ * Format-on-edit for pi — mirrors `.claude/hooks/format-on-edit.sh`.
+ *
+ * After a `write` or `edit` tool modifies a Rust source file, runs
+ * `rustfmt --edition 2024` so the working tree stays formatted. Best-effort:
+ * a formatting failure is surfaced as a notification, never as a tool error,
+ * so the agent is never blocked by a formatting issue.
+ *
+ * Loaded after project trust from `.pi/extensions/`. Use `/trust` to save the
+ * decision for this worktree so it loads without prompting.
+ */
+
+import { spawn } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+	pi.on("tool_result", async (event, ctx) => {
+		if (event.toolName !== "write" && event.toolName !== "edit") return undefined;
+
+		// Don't bother formatting if the edit itself failed.
+		if (event.isError) return undefined;
+
+		const path = String(event.input?.path ?? "");
+		if (!path.endsWith(".rs")) return undefined;
+
+		await new Promise<void>((resolve) => {
+			const child = spawn("rustfmt", ["--edition", "2024", path], {
+				stdio: "ignore",
+				signal: ctx.signal,
+			});
+			child.on("error", () => resolve());
+			child.on("close", () => resolve());
+		});
+
+		return undefined;
+	});
+}

--- a/.pi/extensions/format-on-edit.ts
+++ b/.pi/extensions/format-on-edit.ts
@@ -20,7 +20,7 @@ export default function (pi: ExtensionAPI) {
 		// Don't bother formatting if the edit itself failed.
 		if (event.isError) return undefined;
 
-		const path = String(event.input?.path ?? "");
+		const path = String(event.input.path ?? "");
 		if (!path.endsWith(".rs")) return undefined;
 
 		await new Promise<void>((resolve) => {

--- a/.pi/extensions/format-on-edit.ts
+++ b/.pi/extensions/format-on-edit.ts
@@ -28,8 +28,21 @@ export default function (pi: ExtensionAPI) {
 				stdio: "ignore",
 				signal: ctx.signal,
 			});
-			child.on("error", () => resolve());
-			child.on("close", () => resolve());
+			let notified = false;
+			const warn = (msg: string) => {
+				if (!notified) {
+					notified = true;
+					ctx.ui.notify?.(msg, "warning");
+				}
+			};
+			child.on("error", () => {
+				if (!ctx.signal?.aborted) warn(`rustfmt failed to run for ${path}`);
+				resolve();
+			});
+			child.on("close", (code) => {
+				if (code !== 0 && !ctx.signal?.aborted) warn(`rustfmt exited ${code ?? "<killed>"} for ${path}`);
+				resolve();
+			});
 		});
 
 		return undefined;

--- a/.pi/extensions/protect-build-artifacts.ts
+++ b/.pi/extensions/protect-build-artifacts.ts
@@ -5,22 +5,56 @@
  * must not be hand-edited (see CLAUDE.md). This complements the global
  * protected-paths extension (which guards secrets, keys, .git, etc.).
  *
+ * Note: this only intercepts the `write` and `edit` tools. A `bash` call (e.g.
+ * `sed -i`) can still reach these paths, so treat this as a guardrail, not an
+ * airtight sandbox.
+ *
+ * Matching is done against the path relative to the project root (ctx.cwd),
+ * normalized to forward slashes, so the check is independent of where the
+ * checkout lives (e.g. a checkout under `~/target/visualsign-parser` no longer
+ * trips the `/target/` rule) and of the platform's path separators.
+ *
  * Loaded after project trust from .pi/extensions/. Use /trust to save the
  * decision for this worktree so it loads without prompting.
  */
 
-import { resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 // `codegen/` is intentionally NOT protected: it is the hand-written generator
-// crate (src/codegen/src/main.rs), not generated output. Only its output
-// crate `src/generated` is protected. Paths are resolved to absolute before
-// matching so both relative ("target/...") and absolute tool inputs are caught.
-const PROTECTED: ReadonlyArray<{ pattern: string; reason: string }> = [
-	{ pattern: "src/generated", reason: "protobuf codegen output; regenerate via `make -C src generated`" },
-	{ pattern: "/target/", reason: "cargo build output" },
-	{ pattern: "Cargo.lock", reason: "workspace lockfile" },
+// crate (src/codegen/src/main.rs), not generated output. Only its output crate
+// `src/generated` is protected.
+const PROTECTED: ReadonlyArray<{
+	reason: string;
+	match: (rel: string) => boolean;
+}> = [
+	{
+		reason: "protobuf codegen output; regenerate via `make -C src generated`",
+		match: (rel) => rel === "src/generated" || rel.startsWith("src/generated/"),
+	},
+	{
+		// Any real `target` path segment (workspace root or a per-crate dir),
+		// matched as a segment rather than a substring so `my-target/` is left
+		// alone.
+		reason: "cargo build output",
+		match: (rel) => rel === "target" || rel.startsWith("target/") || rel.includes("/target/"),
+	},
+	{
+		// Workspace root lockfile only. A nested lockfile (e.g. `fuzz/Cargo.lock`)
+		// is a separate per-crate file, so it is left alone and the reason stays
+		// accurate.
+		reason: "workspace lockfile",
+		match: (rel) => rel === "Cargo.lock",
+	},
 ];
+
+// Repo-relative, forward-slash path. resolve() handles both absolute and
+// relative tool inputs; relative() re-roots them at the project dir so a path
+// outside the repo can't match (it yields a `..` prefix).
+function toRel(cwd: string, raw: string): string {
+	const rel = relative(cwd, resolve(cwd, raw));
+	return sep === "/" ? rel : rel.split(sep).join("/");
+}
 
 export default function (pi: ExtensionAPI) {
 	pi.on("tool_call", async (event, ctx) => {
@@ -29,8 +63,7 @@ export default function (pi: ExtensionAPI) {
 		const path = String(event.input.path ?? "");
 		if (!path) return undefined;
 
-		const resolved = resolve(path);
-		const match = PROTECTED.find((p) => resolved.includes(p.pattern));
+		const match = PROTECTED.find((p) => p.match(toRel(ctx.cwd, path)));
 		if (match) {
 			ctx.ui.notify?.(`Blocked write to build artifact: ${path}`, "warning");
 			return { block: true, reason: `"${path}" is ${match.reason}` };

--- a/.pi/extensions/protect-build-artifacts.ts
+++ b/.pi/extensions/protect-build-artifacts.ts
@@ -1,0 +1,35 @@
+/**
+ * Project-local build-artifact guard for visualsign-parser.
+ *
+ * Blocks the agent from writing/editing generated or build-output paths that
+ * must not be hand-edited (see CLAUDE.md). This complements the global
+ * protected-paths extension (which guards secrets, keys, .git, etc.).
+ *
+ * Loaded after project trust from .pi/extensions/. Use /trust to save the
+ * decision for this worktree so it loads without prompting.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const PROTECTED = [
+	"src/generated", // protobuf codegen output (run `make -C src generated`)
+	"/target/", // cargo build output
+	"Cargo.lock", // workspace lockfiles
+	"codegen/", // tonic_build script (regenerate, don't hand-edit)
+];
+
+export default function (pi: ExtensionAPI) {
+	pi.on("tool_call", async (event, ctx) => {
+		if (event.toolName !== "write" && event.toolName !== "edit") return undefined;
+
+		const path = String(event.input.path ?? "");
+		if (!path) return undefined;
+
+		if (PROTECTED.some((p) => path.includes(p))) {
+			ctx.ui.notify?.(`Blocked write to build artifact: ${path}`, "warning");
+			return { block: true, reason: `"${path}" is a generated/build artifact; regenerate via \`make -C src generated\` instead of editing` };
+		}
+
+		return undefined;
+	});
+}

--- a/.pi/extensions/protect-build-artifacts.ts
+++ b/.pi/extensions/protect-build-artifacts.ts
@@ -49,8 +49,10 @@ const PROTECTED: ReadonlyArray<{
 ];
 
 // Repo-relative, forward-slash path. resolve() handles both absolute and
-// relative tool inputs; relative() re-roots them at the project dir so a path
-// outside the repo can't match (it yields a `..` prefix).
+// relative tool inputs; relative() re-roots them at the project dir. A path
+// outside the repo yields a `..` prefix, which the handler short-circuits so an
+// ancestor dir (e.g. `~/target/visualsign-parser` -> `../target/...`) can't trip
+// the `/target/` rule.
 function toRel(cwd: string, raw: string): string {
 	const rel = relative(cwd, resolve(cwd, raw));
 	return sep === "/" ? rel : rel.split(sep).join("/");
@@ -63,7 +65,13 @@ export default function (pi: ExtensionAPI) {
 		const path = String(event.input.path ?? "");
 		if (!path) return undefined;
 
-		const match = PROTECTED.find((p) => p.match(toRel(ctx.cwd, path)));
+		const rel = toRel(ctx.cwd, path);
+		// Outside the repo (relative path escapes via ..) -> not a repo build
+		// artifact, and skipping avoids the /target/ substring matching an
+		// ancestor directory again.
+		if (rel.startsWith("..")) return undefined;
+
+		const match = PROTECTED.find((p) => p.match(rel));
 		if (match) {
 			ctx.ui.notify?.(`Blocked write to build artifact: ${path}`, "warning");
 			return { block: true, reason: `"${path}" is ${match.reason}` };

--- a/.pi/extensions/protect-build-artifacts.ts
+++ b/.pi/extensions/protect-build-artifacts.ts
@@ -9,13 +9,17 @@
  * decision for this worktree so it loads without prompting.
  */
 
+import { resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-const PROTECTED = [
-	"src/generated", // protobuf codegen output (run `make -C src generated`)
-	"/target/", // cargo build output
-	"Cargo.lock", // workspace lockfiles
-	"codegen/", // tonic_build script (regenerate, don't hand-edit)
+// `codegen/` is intentionally NOT protected: it is the hand-written generator
+// crate (src/codegen/src/main.rs), not generated output. Only its output
+// crate `src/generated` is protected. Paths are resolved to absolute before
+// matching so both relative ("target/...") and absolute tool inputs are caught.
+const PROTECTED: ReadonlyArray<{ pattern: string; reason: string }> = [
+	{ pattern: "src/generated", reason: "protobuf codegen output; regenerate via `make -C src generated`" },
+	{ pattern: "/target/", reason: "cargo build output" },
+	{ pattern: "Cargo.lock", reason: "workspace lockfile" },
 ];
 
 export default function (pi: ExtensionAPI) {
@@ -25,9 +29,11 @@ export default function (pi: ExtensionAPI) {
 		const path = String(event.input.path ?? "");
 		if (!path) return undefined;
 
-		if (PROTECTED.some((p) => path.includes(p))) {
+		const resolved = resolve(path);
+		const match = PROTECTED.find((p) => resolved.includes(p.pattern));
+		if (match) {
 			ctx.ui.notify?.(`Blocked write to build artifact: ${path}`, "warning");
-			return { block: true, reason: `"${path}" is a generated/build artifact; regenerate via \`make -C src generated\` instead of editing` };
+			return { block: true, reason: `"${path}" is ${match.reason}` };
 		}
 
 		return undefined;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to coding agents (Claude Code and pi) when working with code in this repository. It is symlinked as `AGENTS.md` so both agents load the same instructions.
 
 ## Build & Development Commands
 
@@ -16,11 +16,13 @@ make -C src grpc-server    # Run the gRPC server locally
 ```
 
 Run a single test:
+
 ```bash
 cargo test -p visualsign-ethereum test_name
 ```
 
 Parse a transaction locally:
+
 ```bash
 cargo run --bin parser_cli -- decode --chain ethereum --network ETHEREUM_MAINNET --output human -t <hex>
 
@@ -85,6 +87,7 @@ A unified Docker container (see `images/parser_app/Containerfile`) bundles parse
 ### Workspace Lint Policy
 
 Workspace-level clippy lints are enforced in `src/Cargo.toml`:
+
 - **`unwrap_used = "deny"`** — Use `?` operator or explicit error handling instead of `.unwrap()`
 - **`expect_used = "deny"`** — Same; use `?` or `.ok_or_else(|| ...)?`
 - **`panic = "deny"`** — Return `Err(...)` instead of `panic!()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,13 @@ For complete contribution guidelines, including PR workflow, code standards, and
 ## Questions?
 
 Reach out through the [issue tracker](https://github.com/anchorageoss/visualsign-parser/issues).
+
+## Agent setup (Claude Code & pi)
+
+Shared agent configuration lives in tracked files and applies to both Claude Code and pi:
+
+- `CLAUDE.md` (also symlinked as `AGENTS.md`) — project instructions both agents load at startup.
+- `.claude/` — Claude Code settings, hooks (`hooks/format-on-edit.sh` runs `rustfmt` after edits), and skills.
+- `.pi/extensions/` — pi extensions: `protect-build-artifacts.ts` (blocks edits to generated paths) and `format-on-edit.ts` (mirrors the Claude rustfmt hook for pi).
+
+Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`, etc.) is gitignored and never committed. To trust pi's project-local extensions for the first time, run `/trust`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ Reach out through the [issue tracker](https://github.com/anchorageoss/visualsign
 
 Shared agent configuration lives in tracked files and applies to both Claude Code and pi:
 
-- `CLAUDE.md` (also symlinked as `AGENTS.md`) — project instructions both agents load at startup.
-- `.claude/` — Claude Code tracked config: shared `settings.json`, hooks (`hooks/format-on-edit.sh` runs `rustfmt` after edits), and skills. Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`) is gitignored — see below.
+- `CLAUDE.md` (also symlinked as `AGENTS.md`) — project instructions both Claude Code and pi load at startup.
+- `.claude/` — Claude Code tracked config: shared `settings.json`, hooks (`hooks/format-on-edit.sh` runs `rustfmt` after edits), and skills.
 - `.pi/extensions/` — pi extensions: `protect-build-artifacts.ts` (blocks edits to generated paths) and `format-on-edit.ts` (mirrors the Claude rustfmt hook for pi).
 
-Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`, etc.) is gitignored and never committed. To trust pi's project-local extensions for the first time, run `/trust`.
+Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`, `.pi/mega-compact/`, etc.) is gitignored and never committed. To trust pi's project-local extensions for the first time, run `/trust`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Reach out through the [issue tracker](https://github.com/anchorageoss/visualsign
 Shared agent configuration lives in tracked files and applies to both Claude Code and pi:
 
 - `CLAUDE.md` (also symlinked as `AGENTS.md`) — project instructions both agents load at startup.
-- `.claude/` — Claude Code settings, hooks (`hooks/format-on-edit.sh` runs `rustfmt` after edits), and skills.
+- `.claude/` — Claude Code tracked config: shared `settings.json`, hooks (`hooks/format-on-edit.sh` runs `rustfmt` after edits), and skills. Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`) is gitignored — see below.
 - `.pi/extensions/` — pi extensions: `protect-build-artifacts.ts` (blocks edits to generated paths) and `format-on-edit.ts` (mirrors the Claude rustfmt hook for pi).
 
 Per-user scratch (`.claude/settings.local.json`, `.claude/worktrees/`, etc.) is gitignored and never committed. To trust pi's project-local extensions for the first time, run `/trust`.


### PR DESCRIPTION
## Summary

Brings pi to parity with the existing Claude Code agent setup so both agents share the same project instructions and post-edit formatting, with one source of truth.

## Changes

- **Track `.pi/extensions/`** — `protect-build-artifacts.ts` was already present but untracked; now committed so the team shares it. New `format-on-edit.ts` mirrors `.claude/hooks/format-on-edit.sh`, running `rustfmt --edition 2024` after a `write`/`edit` on a `.rs` file (best-effort: never blocks the agent on a formatting failure; skips when the edit itself errored).
- **`AGENTS.md`** — symlink to `CLAUDE.md` so tools that look for `AGENTS.md` (pi, Cursor, others) find the same instructions Claude Code already loads. Verified in pi's source (`resource-loader.js`): `existsSync`/`readFileSync` follow symlinks; candidate order is `AGENTS.md` first and the per-dir loop returns on first match, so `CLAUDE.md` is not double-loaded.
- **`CONTRIBUTING.md`** — new "Agent setup" section documenting the shared, tracked config vs. the per-user scratch that stays gitignored.

## Why

Both agents already worked here, but pi's project-local config was untracked and pi lacked the format-on-edit hook Claude had. This makes the setup shared and consistent across agents, with instructions living in a single file.

## Verification

- \`node --check\` passes on both extensions.
- Load test: both extensions import under Node 22.23, export a \`default\` function, and subscribe to the correct events (\`tool_result\` for format-on-edit, \`tool_call\` for protect-build-artifacts).
- Handler logic: simulated events confirm correct filtering (`.rs` filter, \`isError\` guard, \`write\`/\`edit\` only).
- End-to-end: invoked the real handler on a misformatted \`.rs\` file; it spawned \`rustfmt --edition 2024\` and the file came out properly reformatted.

Not verified: a live interactive \`pi\` session confirming hot-load + \`/trust\` prompt + the build-artifact guard blocking a real edit in a TTY (can't be driven headless). Code is proven correct and loadable.

## Notes

- `.claude/settings.local.json` remains a dangling symlink in this worktree (points to a repo-root file that doesn't exist) — that's per-user, gitignored state, not part of this shared config.
- The existing `protect-build-artifacts.ts` uses direct `event.input.path` access (no `?.`); confirmed non-optional in pi's `ToolResultEventBase` (`Record<string, unknown>`), and the new extension matches that style.