### PR TITLE
feat(near): add a parser_cli token-metadata flag for NEAR

### DIFF
--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -128,8 +128,12 @@ cargo run --bin parser_cli -- decode \
   --chain near \
   --output human \
   --near-token-metadata-mappings 'MyToken@mytoken.json@nep141:my-token.near' \
-  -t '{"signer_id":"alice.near", ...}'
+  -t '{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2100-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"my-token.near","receiver_id":"bob.near","amount":"100000000"}]}'
 ```
+
+The envelope withdraws `my-token.near`, the asset the mapping covers, so the
+`Amount` field renders as `1 MYTOKEN` rather than `100000000 (unresolved
+nep141:my-token.near)`.
 
 Two details differ from the Ethereum and Solana mapping flags:
 

--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -117,6 +117,27 @@ The `--network` flag selects the rendered `Network` header — `NEAR_MAINNET` (t
 
 The resolved network also has to agree with the accounts being rendered: an account whose suffix contradicts it (`.testnet` under mainnet, or `.near` under testnet) is refused rather than displayed under a network it does not belong to. This covers the transaction's own accounts and every rendered envelope's `signer_id`/`verifying_contract`. Since the default is mainnet, decoding a `.testnet` envelope needs `--network NEAR_TESTNET` explicitly. Implicit (64-hex) accounts carry no suffix and are not constrained.
 
+### Supplying token metadata locally
+
+Assets the compiled-in seed table doesn't cover render their raw base-unit amount tagged `unresolved <asset id>`. To give the CLI a symbol and decimals for one, pass `--near-token-metadata-mappings`:
+
+```bash
+echo '{"symbol":"MYTOKEN","decimals":8}' > mytoken.json
+
+cargo run --bin parser_cli -- decode \
+  --chain near \
+  --output human \
+  --near-token-metadata-mappings 'MyToken@mytoken.json@nep141:my-token.near' \
+  -t '{"signer_id":"alice.near", ...}'
+```
+
+Two details differ from the Ethereum and Solana mapping flags:
+
+- **`@` separates the fields, not `:`.** NEAR Intents asset ids contain their own colons (`nep141:wrap.near`), so a colon-delimited format would truncate the id at its first embedded colon.
+- **The CLI signs each entry it loads** with its local development key, because it runs the same require-signed posture as the deployed parser — an unsigned entry is dropped rather than trusted. That key is allowlisted only in builds that enable the `dev-signing` feature, which `parser_cli` does and the enclave binary does not.
+
+Repeat the flag for each asset. A mapping that fails to parse or whose file can't be read is reported and skipped; the rest still load.
+
 ### Configuring curator keys
 
 Signer identity is resolved per origin chain from three environment variables, each a comma-separated list of hex public keys:

--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -134,7 +134,7 @@ cargo run --bin parser_cli -- decode \
 Two details differ from the Ethereum and Solana mapping flags:
 
 - **`@` separates the fields, not `:`.** NEAR Intents asset ids contain their own colons (`nep141:wrap.near`), so a colon-delimited format would truncate the id at its first embedded colon.
-- **The CLI signs each entry it loads** with its local development key, because it runs the same require-signed posture as the deployed parser — an unsigned entry is dropped rather than trusted. That key is allowlisted only in builds that enable the `dev-signing` feature, which `parser_cli` does and the enclave binary does not.
+- **The CLI signs each entry it loads** with its local development key, because it runs the require-signed posture — an unsigned entry is dropped rather than trusted. That key is allowlisted only in builds that enable the `dev-signing` feature, which `parser_cli` does and the enclave binary does not. The posture is a per-deployment choice, not a property of the parser: `parser_cli` pins require-signed, while `parser_app` registers the converter with the permissive default.
 
 Repeat the flag for each asset. A mapping that fails to parse or whose file can't be read is reported and skipped; the rest still load.
 

--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -114,6 +114,27 @@ Output:
 
 The `--network` flag selects the rendered `Network` header — `NEAR_MAINNET` (the default) or `NEAR_TESTNET`. An unrecognized value errors before anything renders, rather than silently falling back to mainnet.
 
+### Supplying token metadata locally
+
+Assets the compiled-in seed table doesn't cover render their raw base-unit amount tagged `unresolved <asset id>`. To give the CLI a symbol and decimals for one, pass `--near-token-metadata-mappings`:
+
+```bash
+echo '{"symbol":"MYTOKEN","decimals":8}' > mytoken.json
+
+cargo run --bin parser_cli -- decode \
+  --chain near \
+  --output human \
+  --near-token-metadata-mappings 'MyToken@mytoken.json@nep141:my-token.near' \
+  -t '{"signer_id":"alice.near", ...}'
+```
+
+Two details differ from the Ethereum and Solana mapping flags:
+
+- **`@` separates the fields, not `:`.** NEAR Intents asset ids contain their own colons (`nep141:wrap.near`), so a colon-delimited format would truncate the id at its first embedded colon.
+- **The CLI signs each entry it loads** with its local development key, because it runs the same require-signed posture as the deployed parser — an unsigned entry is dropped rather than trusted. That key is allowlisted only in builds that enable the `dev-signing` feature, which `parser_cli` does and the enclave binary does not.
+
+Repeat the flag for each asset. A mapping that fails to parse or whose file can't be read is reported and skipped; the rest still load.
+
 ## Implementation details
 
 Source code available at:

--- a/docs/parser-cli.mdx
+++ b/docs/parser-cli.mdx
@@ -27,13 +27,14 @@ parser_cli decode --chain <chain> -t <transaction_hex> --output <format>
 
 | Parameter | Description |
 |-----------|-------------|
-| `--chain` | Blockchain type (`ethereum`, `solana`, `sui`, `tron`) |
+| `--chain` | Blockchain type (`ethereum`, `near`, `solana`, `sui`, `tron`) |
 | `-t`, `--transaction` | Raw transaction data (hex encoded) |
 | `--output` | Output format: `text` (default), `json`, or `human` |
 | `--condensed-only` | Show only condensed view (what users see on hardware wallets) |
 | `-n`, `--network` | Network identifier—chain ID (e.g., `1`, `137`) or canonical name (e.g., `ETHEREUM_MAINNET`, `POLYGON_MAINNET`) |
 | `--abi-json-mappings` | Map custom ABI JSON to contract. Format: `Name:/path/to/abi.json:0xAddress`. Can be used multiple times |
 | `--idl-json-mappings` | Map custom IDL JSON to Solana program. Format: `Name:/path/to/idl.json:ProgramId`. Can be used multiple times |
+| `--near-token-metadata-mappings` | Map custom token metadata JSON to a NEAR Intents asset id. Format: `Name@/path/to/token.json@AssetId`. Can be used multiple times |
 
 ## Real-world examples
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,9 +27,11 @@ all: generated
 .PHONY: build
 build:
 	@# Split to avoid Cargo feature unification across the workspace.
-	@# parser_cli enables visualsign-solana/diagnostics and
-	@# visualsign-ethereum/dev-signing; building it together with
-	@# parser_app/grpc-server would unify those features ON for both.
+	@# parser_cli enables visualsign-solana/diagnostics,
+	@# visualsign-ethereum/dev-signing, and visualsign-near/dev-signing;
+	@# building it together with parser_app/grpc-server would unify those
+	@# features ON for both, putting the CLI dev signing keys (and the
+	@# allowlist entries that trust them) into the production binaries.
 	cargo build --workspace --exclude parser_cli
 	cargo build -p parser_cli
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,6 +89,33 @@ narrow-build-check:
 		cargo check -p parser_app --no-default-features --features $$c; \
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
 	done
+	make dev-signing-absent-check
+
+.PHONY: dev-signing-absent-check
+dev-signing-absent-check:
+	@# `dev-signing` carries hardcoded signing-key seeds and allowlists them,
+	@# so it must never resolve in a binary that ships. Only parser_cli
+	@# enables it (`ethereum`/`near` features above pull
+	@# visualsign-{ethereum,near}/dev-signing), and the ONLY thing keeping it
+	@# off parser_app/grpc-server is that `build` compiles parser_cli in a
+	@# separate cargo invocation -- Cargo unifies features across a single
+	@# invocation, so one `cargo build --workspace` covering both would turn
+	@# dev-signing ON for the attested binary.
+	@#
+	@# Asserted against the recipes rather than the resolved feature graph:
+	@# `cargo tree -e features` does not print enabled features that carry no
+	@# dependency edges, and `dev-signing = []` is exactly that, so a graph
+	@# probe silently matches nothing and passes regardless.
+	@set -e; \
+	bad=$$(grep -nE '^[[:space:]]*cargo (build|test|check|clippy).*--workspace' Makefile \
+		| grep -v 'exclude parser_cli' || true); \
+	if [ -n "$$bad" ]; then \
+		echo "ERROR: --workspace recipe without '--exclude parser_cli' would unify"; \
+		echo "       dev-signing onto parser_app/grpc-server:"; \
+		echo "$$bad"; \
+		exit 1; \
+	fi; \
+	echo "==> no --workspace recipe pulls parser_cli into a shared feature resolution"
 
 .PHONY: feature-matrix-check
 feature-matrix-check:

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,6 +103,33 @@ narrow-build-check:
 		cargo check -p parser_app --no-default-features --features $$c; \
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
 	done
+	make dev-signing-absent-check
+
+.PHONY: dev-signing-absent-check
+dev-signing-absent-check:
+	@# `dev-signing` carries hardcoded signing-key seeds and allowlists them,
+	@# so it must never resolve in a binary that ships. Only parser_cli
+	@# enables it (`ethereum`/`near` features above pull
+	@# visualsign-{ethereum,near}/dev-signing), and the ONLY thing keeping it
+	@# off parser_app/grpc-server is that `build` compiles parser_cli in a
+	@# separate cargo invocation -- Cargo unifies features across a single
+	@# invocation, so one `cargo build --workspace` covering both would turn
+	@# dev-signing ON for the attested binary.
+	@#
+	@# Asserted against the recipes rather than the resolved feature graph:
+	@# `cargo tree -e features` does not print enabled features that carry no
+	@# dependency edges, and `dev-signing = []` is exactly that, so a graph
+	@# probe silently matches nothing and passes regardless.
+	@set -e; \
+	bad=$$(grep -nE '^[[:space:]]*cargo (build|test|check|clippy).*--workspace' Makefile \
+		| grep -v 'exclude parser_cli' || true); \
+	if [ -n "$$bad" ]; then \
+		echo "ERROR: --workspace recipe without '--exclude parser_cli' would unify"; \
+		echo "       dev-signing onto parser_app/grpc-server:"; \
+		echo "$$bad"; \
+		exit 1; \
+	fi; \
+	echo "==> no --workspace recipe pulls parser_cli into a shared feature resolution"
 
 .PHONY: feature-matrix-check
 feature-matrix-check:

--- a/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-ethereum/src/cli_plugin.rs
@@ -111,9 +111,13 @@ fn build_abi_mappings_from_files(
 ) -> (BTreeMap<String, Abi>, usize) {
     let (raw, count) = mapping_parser::load_mappings(
         abi_json_mappings,
-        "ABI",
-        "UniswapV2:path/to/uniswap.json:0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-        "ContractAddress",
+        &mapping_parser::MappingFormat {
+            kind: "ABI",
+            example: "UniswapV2:path/to/uniswap.json:0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+            identifier_label: "ContractAddress",
+            format_hint: "Name:/path/to/file.json:ContractAddress",
+        },
+        mapping_parser::parse_mapping,
         validate_eth_address,
         |components, json| {
             // The CLI runs the require-signed posture against its own dev key (see

--- a/src/chain_parsers/visualsign-near/Cargo.toml
+++ b/src/chain_parsers/visualsign-near/Cargo.toml
@@ -31,6 +31,7 @@ defuse-deadline = { workspace = true }
 
 [dev-dependencies]
 near-crypto = "0.35.1"
+parser_cli_core = { path = "../../parser/cli-core", features = ["test-utils"] }
 
 [features]
 default = ["cli-plugin"]

--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -1,19 +1,34 @@
+use std::collections::BTreeMap;
+
 use clap::Args as ClapArgs;
-use generated::parser::{ChainMetadata, NearMetadata, chain_metadata};
+use generated::parser::{ChainMetadata, NearMetadata, TokenMetadataEntry, chain_metadata};
 use visualsign::registry::{Chain, TransactionConverterRegistry};
 
+use parser_cli_core::mapping_parser::load_json_file;
+
 use crate::networks::NearNetwork;
+use crate::presets::intents::sign_token_metadata_for_cli;
 
 /// CLI arguments specific to NEAR.
-///
-/// Currently no NEAR-specific args are needed beyond the global `--network`
-/// flag, which `create_metadata` below turns into `NearMetadata`.
 #[derive(ClapArgs, Debug, Default, Clone)]
-pub struct NearArgs {}
+pub struct NearArgs {
+    /// Map custom token metadata JSON file to a NEAR Intents asset id.
+    ///
+    /// Format: `Name@/path/to/token.json@AssetId`. `@` is the field
+    /// separator here, not `:` (the convention `--abi-json-mappings`/
+    /// `--idl-json-mappings` use), because NEAR Intents asset ids embed
+    /// their own colons (e.g. `nep141:wrap.near`), which would make the
+    /// identifier ambiguous under a colon-delimited format. The file should
+    /// contain `{"symbol":"...","decimals":N}`. Can be used multiple times.
+    #[arg(
+        long = "near-token-metadata-mappings",
+        value_name = "NAME@FILE_PATH@ASSET_ID"
+    )]
+    pub near_token_metadata_mappings: Vec<String>,
+}
 
 /// [`parser_cli_core::ChainPlugin`] implementation for NEAR.
 pub struct NearPlugin {
-    #[allow(dead_code)]
     args: NearArgs,
 }
 
@@ -52,28 +67,171 @@ impl parser_cli_core::ChainPlugin for NearPlugin {
     }
 
     fn create_metadata(&self, network: Option<String>) -> Result<Option<ChainMetadata>, String> {
-        let Some(network) = network else {
-            return Ok(None);
-        };
-        if NearNetwork::from_network_id(&network).is_none() {
-            return Err(format!(
-                "Invalid network '{network}'. Supported: NEAR_MAINNET, NEAR_TESTNET"
-            ));
-        }
-        Ok(Some(ChainMetadata {
-            metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
-                network_id: Some(network.to_uppercase()),
-                token_mappings: Default::default(),
-            })),
-        }))
+        create_chain_metadata(network, &self.args.near_token_metadata_mappings)
     }
 }
 
+/// Parsed components of a `Name@Path@AssetId` mapping string.
+struct NearMappingComponents {
+    name: String,
+    path: String,
+    asset_id: String,
+}
+
+/// Parse the NEAR-specific `Name@Path@AssetId` mapping format.
+///
+/// Splits into exactly 3 parts on `@`; the third part is the asset id
+/// verbatim, including any colons it contains (unlike the shared
+/// `mapping_parser::parse_mapping`, which splits on `:` and would truncate a
+/// NEAR asset id at its first embedded colon).
+fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String> {
+    let mut parts = mapping_str.splitn(3, '@');
+    let (Some(name), Some(path), Some(asset_id)) = (parts.next(), parts.next(), parts.next())
+    else {
+        return Err(format!(
+            "Invalid mapping format (expected Name@FilePath@AssetId): {mapping_str}"
+        ));
+    };
+    if name.is_empty() || path.is_empty() || asset_id.is_empty() {
+        return Err(format!("Mapping components cannot be empty: {mapping_str}"));
+    }
+    Ok(NearMappingComponents {
+        name: name.to_string(),
+        path: path.to_string(),
+        asset_id: asset_id.to_string(),
+    })
+}
+
+/// Load token-metadata JSON files and build mappings for
+/// `NearMetadata.token_mappings`. Each entry is signed with the CLI's local
+/// dev key (NEAR-origin ed25519) so it extracts as verified rather than
+/// dropped by the strict posture [`cli_trust_policy`] installs; if signing is
+/// unavailable (binary built without `dev-signing`), the entry is registered
+/// unsigned instead of dropped here.
+fn build_token_mappings_from_files(
+    mappings: &[String],
+    signing_network: NearNetwork,
+) -> (BTreeMap<String, TokenMetadataEntry>, usize) {
+    let mut map = BTreeMap::new();
+    let mut valid_count = 0;
+
+    for mapping in mappings {
+        let components = match parse_near_mapping(mapping) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error parsing token metadata mapping: {e}");
+                eprintln!("Expected format: Name@/path/to/file.json@AssetId");
+                eprintln!(
+                    "Example: USDC@usdc.json@nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near"
+                );
+                continue;
+            }
+        };
+        let json = match load_json_file(&components.path) {
+            Ok(j) => j,
+            Err(e) => {
+                eprintln!(
+                    "  Warning: Failed to load token metadata '{}' from '{}': {e}",
+                    components.name, components.path
+                );
+                continue;
+            }
+        };
+        let signature = match sign_token_metadata_for_cli(
+            signing_network.network_id(),
+            &components.asset_id,
+            &json,
+        ) {
+            Ok(sig) => Some(sig),
+            Err(e) => {
+                eprintln!(
+                    "  Warning: '{}' could not be signed ({e}); registering unsigned",
+                    components.name
+                );
+                None
+            }
+        };
+        let previous = map.insert(
+            components.asset_id.clone(),
+            TokenMetadataEntry {
+                value: json,
+                signature,
+                origin_chain: None,
+            },
+        );
+        if previous.is_some() {
+            eprintln!(
+                "  Warning: Duplicate asset id '{}' for token metadata '{}'; overwriting previous entry",
+                components.asset_id, components.name
+            );
+        } else {
+            valid_count += 1;
+            eprintln!(
+                "  Loaded token metadata '{}' from {} and mapped to {}",
+                components.name, components.path, components.asset_id
+            );
+        }
+    }
+
+    (map, valid_count)
+}
+
+/// Build NEAR chain metadata from the global `--network` flag and the
+/// NEAR-specific token-metadata mappings.
+///
+/// Returns `None` when neither yields anything: with no network and no loadable
+/// mapping there is nothing for `NearMetadata` to carry.
+fn create_chain_metadata(
+    network: Option<String>,
+    mappings: &[String],
+) -> Result<Option<ChainMetadata>, String> {
+    let network = match network {
+        Some(network) => match NearNetwork::from_network_id(&network) {
+            Some(parsed) => Some(parsed),
+            None => {
+                return Err(format!(
+                    "Invalid network '{network}'. Supported: NEAR_MAINNET, NEAR_TESTNET"
+                ));
+            }
+        },
+        None => None,
+    };
+    let network_id = network.map(|n| n.network_id().to_string());
+    // Token-metadata signatures are scoped to a network, so the CLI must sign
+    // for the one the parser will resolve for this request: the `--network`
+    // flag when given, otherwise the network the converter defaults to.
+    let signing_network = network.unwrap_or_default();
+
+    let token_mappings = if mappings.is_empty() {
+        BTreeMap::new()
+    } else {
+        eprintln!("Loading custom token metadata:");
+        let (token_mappings, valid_count) =
+            build_token_mappings_from_files(mappings, signing_network);
+        eprintln!(
+            "Successfully loaded {}/{} token metadata mappings\n",
+            valid_count,
+            mappings.len()
+        );
+        token_mappings
+    };
+
+    if network_id.is_none() && token_mappings.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(ChainMetadata {
+        metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+            network_id,
+            token_mappings: token_mappings.into_iter().collect(),
+        })),
+    }))
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use generated::parser::TokenMetadataEntry;
     use near_crypto::{KeyType, PublicKey};
     use near_primitives::action::{Action, FunctionCallAction};
     use near_primitives::hash::CryptoHash;
@@ -83,11 +241,29 @@ mod tests {
     use visualsign::vsptrait::VisualSignOptions;
 
     fn plugin() -> NearPlugin {
-        NearPlugin::new(NearArgs {})
+        NearPlugin::new(NearArgs::default())
+    }
+
+    fn plugin_with_mappings(mappings: Vec<String>) -> NearPlugin {
+        NearPlugin::new(NearArgs {
+            near_token_metadata_mappings: mappings,
+        })
+    }
+
+    fn write_temp_json(name: &str, content: &str) -> std::path::PathBuf {
+        parser_cli_core::test_utils::write_temp_json("vsp_near_tests", name, content)
+    }
+
+    /// Unwrap the `Near` variant of the metadata oneof.
+    fn near_metadata(metadata: ChainMetadata) -> NearMetadata {
+        let chain_metadata::Metadata::Near(near) = metadata.metadata.unwrap() else {
+            panic!("expected Near metadata");
+        };
+        near
     }
 
     #[test]
-    fn create_metadata_defaults_to_none_without_a_network_flag() {
+    fn create_metadata_defaults_to_none_without_a_network_flag_or_mappings() {
         assert_eq!(plugin().create_metadata(None).unwrap(), None);
     }
 
@@ -113,6 +289,180 @@ mod tests {
         assert!(plugin().create_metadata(Some("bogus".to_string())).is_err());
     }
 
+    /// An invalid network fails even when a mapping loads fine, so a bad
+    /// `--network` can't be masked by a successful mapping load.
+    #[test]
+    fn create_metadata_rejects_an_invalid_network_even_with_mappings() {
+        let path = write_temp_json("reject.json", r#"{"symbol":"X","decimals":6}"#);
+        let mappings = vec![format!("X@{}@nep141:x.near", path.display())];
+        assert!(
+            plugin_with_mappings(mappings)
+                .create_metadata(Some("bogus".to_string()))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn create_metadata_carries_a_token_mapping() {
+        let path = write_temp_json("usdc.json", r#"{"symbol":"USDC.e","decimals":6}"#);
+        let asset_id = "nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near";
+        let mappings = vec![format!("USDC@{}@{asset_id}", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(Some("NEAR_MAINNET".to_string()))
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.network_id, Some("NEAR_MAINNET".to_string()));
+        assert_eq!(near.token_mappings.len(), 1);
+        let entry = near.token_mappings.get(asset_id).expect("mapping present");
+        assert!(entry.value.contains("USDC.e"));
+        // The CLI signs locally-loaded token metadata so the strict posture it
+        // installs accepts the entry instead of dropping it.
+        assert!(
+            entry.signature.is_some(),
+            "CLI should attach a dev-key signature to locally-loaded token metadata"
+        );
+        assert!(entry.origin_chain.is_none());
+    }
+
+    /// Mappings alone are enough to produce metadata; the network flag is
+    /// independent of them.
+    #[test]
+    fn create_metadata_carries_mappings_without_a_network() {
+        let path = write_temp_json("net_check.json", r#"{"symbol":"X","decimals":6}"#);
+        let mappings = vec![format!("X@{}@nep141:x.near", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert!(near.network_id.is_none());
+        assert_eq!(near.token_mappings.len(), 1);
+    }
+
+    #[test]
+    fn create_metadata_skips_an_unreadable_mapping_file() {
+        let mappings = vec!["Bad@/nonexistent/token.json@nep141:missing.near".to_string()];
+        assert_eq!(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap(),
+            None,
+            "every mapping failing to load leaves nothing to carry"
+        );
+    }
+
+    #[test]
+    fn create_metadata_carries_multiple_mappings() {
+        let path_a = write_temp_json("a.json", r#"{"symbol":"A","decimals":6}"#);
+        let path_b = write_temp_json("b.json", r#"{"symbol":"B","decimals":18}"#);
+        let mappings = vec![
+            format!("A@{}@nep141:a.near", path_a.display()),
+            format!("B@{}@nep141:b.near", path_b.display()),
+        ];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.token_mappings.len(), 2);
+        assert!(near.token_mappings.contains_key("nep141:a.near"));
+        assert!(near.token_mappings.contains_key("nep141:b.near"));
+    }
+
+    /// Regression coverage for the reason `@` is the separator: an asset id
+    /// with an embedded colon must survive intact, not get truncated at the
+    /// first colon the way the shared colon-delimited mapping format would.
+    #[test]
+    fn asset_id_with_embedded_colon_is_preserved() {
+        let path = write_temp_json("colon.json", r#"{"symbol":"X","decimals":6}"#);
+        let asset_id = "nep141:x.factory.bridge.near";
+        let mappings = vec![format!("X@{}@{asset_id}", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert!(
+            near.token_mappings.contains_key(asset_id),
+            "the full asset id (including its colon) must be the map key"
+        );
+    }
+
+    #[test]
+    fn create_metadata_keeps_valid_mappings_alongside_invalid_ones() {
+        let path = write_temp_json("good.json", r#"{"symbol":"GOOD","decimals":6}"#);
+        let mappings = vec![
+            "bad-format-no-at-signs".to_string(),
+            format!("Good@{}@nep141:good.near", path.display()),
+            "Also@/missing/file.json@nep141:bad.near".to_string(),
+        ];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.token_mappings.len(), 1);
+        assert!(near.token_mappings.contains_key("nep141:good.near"));
+    }
+
+    #[test]
+    fn parse_near_mapping_accepts_the_three_field_format() {
+        let result = parse_near_mapping("MyToken@/path/to/file.json@nep141:wrap.near")
+            .expect("valid mapping should parse");
+        assert_eq!(result.name, "MyToken");
+        assert_eq!(result.path, "/path/to/file.json");
+        assert_eq!(result.asset_id, "nep141:wrap.near");
+    }
+
+    #[test]
+    fn parse_near_mapping_rejects_a_malformed_mapping() {
+        assert!(parse_near_mapping("NoAtSigns").is_err());
+        assert!(parse_near_mapping("OnlyOne@AtSign").is_err());
+        assert!(parse_near_mapping("@@EmptyComponents").is_err());
+    }
+
+    /// An `execute_intents` transaction withdrawing the token behind `asset_id`,
+    /// as raw borsh hex.
+    fn intents_tx_hex(asset_id: &str) -> String {
+        let token = asset_id
+            .split_once(':')
+            .map_or(asset_id, |(_, account)| account);
+        let inner = format!(
+            r#"{{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{{"intent":"ft_withdraw","token":"{token}","receiver_id":"bob.near","amount":"1000000"}}]}}"#
+        );
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let tx = Transaction::V0(TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 1,
+            receiver_id: "intents.near".parse().unwrap(),
+            block_hash: CryptoHash::default(),
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_intents".to_string(),
+                args: serde_json::to_vec(&args).unwrap(),
+                gas: Gas::from_gas(30_000_000_000_000),
+                deposit: Balance::from_yoctonear(0),
+            }))],
+        });
+        hex::encode(borsh::to_vec(&tx).unwrap())
+    }
+
     /// The posture must be pinned through `register`, not through the helper that
     /// feeds it.
     ///
@@ -129,30 +479,6 @@ mod tests {
     #[test]
     fn test_register_installs_require_signed_posture() {
         let asset_id = "nep141:test-token.near";
-        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"test-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
-        let args = serde_json::json!({"signed":[{
-            "standard": "raw_ed25519",
-            "payload": inner,
-            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
-            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
-        }]});
-
-        let build_tx_hex = || {
-            let tx = Transaction::V0(TransactionV0 {
-                signer_id: "alice.near".parse().unwrap(),
-                public_key: PublicKey::empty(KeyType::ED25519),
-                nonce: 1,
-                receiver_id: "intents.near".parse().unwrap(),
-                block_hash: CryptoHash::default(),
-                actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                    method_name: "execute_intents".to_string(),
-                    args: serde_json::to_vec(&args).unwrap(),
-                    gas: Gas::from_gas(30_000_000_000_000),
-                    deposit: Balance::from_yoctonear(0),
-                }))],
-            });
-            hex::encode(borsh::to_vec(&tx).unwrap())
-        };
 
         // Deliberately unsigned: this is the entry the CLI's posture must refuse.
         let build_options = || VisualSignOptions {
@@ -181,7 +507,7 @@ mod tests {
             crate::NearVisualSignConverter::new(),
         );
         let permissive = permissive_registry
-            .convert_transaction(&Chain::Near, &build_tx_hex(), build_options())
+            .convert_transaction(&Chain::Near, &intents_tx_hex(asset_id), build_options())
             .unwrap()
             .payload
             .to_json()
@@ -195,7 +521,7 @@ mod tests {
         let mut registry = TransactionConverterRegistry::new();
         plugin().register(&mut registry);
         let rendered = registry
-            .convert_transaction(&Chain::Near, &build_tx_hex(), build_options())
+            .convert_transaction(&Chain::Near, &intents_tx_hex(asset_id), build_options())
             .unwrap()
             .payload
             .to_json()
@@ -207,6 +533,47 @@ mod tests {
         assert!(
             rendered.contains(&format!("unresolved {asset_id}")),
             "dropping the unsigned entry must leave the raw asset id unresolved, got: {rendered}"
+        );
+    }
+
+    /// End-to-end gate on the whole CLI path: the flag builds an entry, the dev
+    /// key signs it, and the strict posture `register` installs accepts it.
+    ///
+    /// Each half alone is insufficient. `create_metadata` asserting
+    /// `signature.is_some()` says nothing about whether that signature verifies,
+    /// and the posture test above only proves an unsigned entry is refused. Drop
+    /// the dev key from `authorized_token_metadata_signers`, or sign under the
+    /// wrong domain tag, and both still pass while the flag resolves nothing.
+    #[test]
+    fn cli_signed_mapping_resolves_through_the_registered_converter() {
+        let asset_id = "nep141:test-token.near";
+        let path = write_temp_json("e2e.json", r#"{"symbol":"CLISIGNED","decimals":6}"#);
+        let mappings = vec![format!("Test@{}@{asset_id}", path.display())];
+        let plugin = plugin_with_mappings(mappings);
+
+        let metadata = plugin
+            .create_metadata(Some("NEAR_MAINNET".to_string()))
+            .unwrap()
+            .expect("Some(ChainMetadata)");
+
+        let mut registry = TransactionConverterRegistry::new();
+        plugin.register(&mut registry);
+        let rendered = registry
+            .convert_transaction(
+                &Chain::Near,
+                &intents_tx_hex(asset_id),
+                VisualSignOptions {
+                    metadata: Some(metadata),
+                    ..VisualSignOptions::default()
+                },
+            )
+            .unwrap()
+            .payload
+            .to_json()
+            .unwrap();
+        assert!(
+            rendered.contains("CLISIGNED"),
+            "a CLI-signed entry must resolve under the posture `register` installs, got: {rendered}"
         );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -1,19 +1,34 @@
+use std::collections::BTreeMap;
+
 use clap::Args as ClapArgs;
-use generated::parser::{ChainMetadata, NearMetadata, chain_metadata};
+use generated::parser::{ChainMetadata, NearMetadata, TokenMetadataEntry, chain_metadata};
 use visualsign::registry::{Chain, TransactionConverterRegistry};
 
+use parser_cli_core::mapping_parser::load_json_file;
+
 use crate::networks::NearNetwork;
+use crate::presets::intents::sign_token_metadata_for_cli;
 
 /// CLI arguments specific to NEAR.
-///
-/// Currently no NEAR-specific args are needed beyond the global `--network`
-/// flag, which `create_metadata` below turns into `NearMetadata`.
 #[derive(ClapArgs, Debug, Default, Clone)]
-pub struct NearArgs {}
+pub struct NearArgs {
+    /// Map custom token metadata JSON file to a NEAR Intents asset id.
+    ///
+    /// Format: `Name@/path/to/token.json@AssetId`. `@` is the field
+    /// separator here, not `:` (the convention `--abi-json-mappings`/
+    /// `--idl-json-mappings` use), because NEAR Intents asset ids embed
+    /// their own colons (e.g. `nep141:wrap.near`), which would make the
+    /// identifier ambiguous under a colon-delimited format. The file should
+    /// contain `{"symbol":"...","decimals":N}`. Can be used multiple times.
+    #[arg(
+        long = "near-token-metadata-mappings",
+        value_name = "NAME@FILE_PATH@ASSET_ID"
+    )]
+    pub near_token_metadata_mappings: Vec<String>,
+}
 
 /// [`parser_cli_core::ChainPlugin`] implementation for NEAR.
 pub struct NearPlugin {
-    #[allow(dead_code)]
     args: NearArgs,
 }
 
@@ -51,28 +66,160 @@ impl parser_cli_core::ChainPlugin for NearPlugin {
     }
 
     fn create_metadata(&self, network: Option<String>) -> Result<Option<ChainMetadata>, String> {
-        let Some(network) = network else {
-            return Ok(None);
-        };
-        if NearNetwork::from_network_id(&network).is_none() {
-            return Err(format!(
-                "Invalid network '{network}'. Supported: NEAR_MAINNET, NEAR_TESTNET"
-            ));
-        }
-        Ok(Some(ChainMetadata {
-            metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
-                network_id: Some(network.to_uppercase()),
-                token_mappings: Default::default(),
-            })),
-        }))
+        create_chain_metadata(network, &self.args.near_token_metadata_mappings)
     }
 }
 
+/// Parsed components of a `Name@Path@AssetId` mapping string.
+struct NearMappingComponents {
+    name: String,
+    path: String,
+    asset_id: String,
+}
+
+/// Parse the NEAR-specific `Name@Path@AssetId` mapping format.
+///
+/// Splits into exactly 3 parts on `@`; the third part is the asset id
+/// verbatim, including any colons it contains (unlike the shared
+/// `mapping_parser::parse_mapping`, which splits on `:` and would truncate a
+/// NEAR asset id at its first embedded colon).
+fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String> {
+    let mut parts = mapping_str.splitn(3, '@');
+    let (Some(name), Some(path), Some(asset_id)) = (parts.next(), parts.next(), parts.next())
+    else {
+        return Err(format!(
+            "Invalid mapping format (expected Name@FilePath@AssetId): {mapping_str}"
+        ));
+    };
+    if name.is_empty() || path.is_empty() || asset_id.is_empty() {
+        return Err(format!("Mapping components cannot be empty: {mapping_str}"));
+    }
+    Ok(NearMappingComponents {
+        name: name.to_string(),
+        path: path.to_string(),
+        asset_id: asset_id.to_string(),
+    })
+}
+
+/// Load token-metadata JSON files and build mappings for
+/// `NearMetadata.token_mappings`. Each entry is signed with the CLI's local
+/// dev key (NEAR-origin ed25519) so it extracts as verified rather than
+/// dropped by the strict posture [`cli_trust_policy`] installs; if signing is
+/// unavailable (binary built without `dev-signing`), the entry is registered
+/// unsigned instead of dropped here.
+fn build_token_mappings_from_files(
+    mappings: &[String],
+) -> (BTreeMap<String, TokenMetadataEntry>, usize) {
+    let mut map = BTreeMap::new();
+    let mut valid_count = 0;
+
+    for mapping in mappings {
+        let components = match parse_near_mapping(mapping) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error parsing token metadata mapping: {e}");
+                eprintln!("Expected format: Name@/path/to/file.json@AssetId");
+                eprintln!(
+                    "Example: USDC@usdc.json@nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near"
+                );
+                continue;
+            }
+        };
+        let json = match load_json_file(&components.path) {
+            Ok(j) => j,
+            Err(e) => {
+                eprintln!(
+                    "  Warning: Failed to load token metadata '{}' from '{}': {e}",
+                    components.name, components.path
+                );
+                continue;
+            }
+        };
+        let signature = match sign_token_metadata_for_cli(&components.asset_id, &json) {
+            Ok(sig) => Some(sig),
+            Err(e) => {
+                eprintln!(
+                    "  Warning: '{}' could not be signed ({e}); registering unsigned",
+                    components.name
+                );
+                None
+            }
+        };
+        let previous = map.insert(
+            components.asset_id.clone(),
+            TokenMetadataEntry {
+                value: json,
+                signature,
+                origin_chain: None,
+            },
+        );
+        if previous.is_some() {
+            eprintln!(
+                "  Warning: Duplicate asset id '{}' for token metadata '{}'; overwriting previous entry",
+                components.asset_id, components.name
+            );
+        } else {
+            valid_count += 1;
+            eprintln!(
+                "  Loaded token metadata '{}' from {} and mapped to {}",
+                components.name, components.path, components.asset_id
+            );
+        }
+    }
+
+    (map, valid_count)
+}
+
+/// Build NEAR chain metadata from the global `--network` flag and the
+/// NEAR-specific token-metadata mappings.
+///
+/// Returns `None` when neither yields anything: with no network and no loadable
+/// mapping there is nothing for `NearMetadata` to carry.
+fn create_chain_metadata(
+    network: Option<String>,
+    mappings: &[String],
+) -> Result<Option<ChainMetadata>, String> {
+    let network_id = match network {
+        Some(network) => {
+            if NearNetwork::from_network_id(&network).is_none() {
+                return Err(format!(
+                    "Invalid network '{network}'. Supported: NEAR_MAINNET, NEAR_TESTNET"
+                ));
+            }
+            Some(network.to_uppercase())
+        }
+        None => None,
+    };
+
+    let token_mappings = if mappings.is_empty() {
+        BTreeMap::new()
+    } else {
+        eprintln!("Loading custom token metadata:");
+        let (token_mappings, valid_count) = build_token_mappings_from_files(mappings);
+        eprintln!(
+            "Successfully loaded {}/{} token metadata mappings\n",
+            valid_count,
+            mappings.len()
+        );
+        token_mappings
+    };
+
+    if network_id.is_none() && token_mappings.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(ChainMetadata {
+        metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+            network_id,
+            token_mappings: token_mappings.into_iter().collect(),
+        })),
+    }))
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
-    use generated::parser::TokenMetadataEntry;
     use near_crypto::{KeyType, PublicKey};
     use near_primitives::action::{Action, FunctionCallAction};
     use near_primitives::hash::CryptoHash;
@@ -82,11 +229,29 @@ mod tests {
     use visualsign::vsptrait::VisualSignOptions;
 
     fn plugin() -> NearPlugin {
-        NearPlugin::new(NearArgs {})
+        NearPlugin::new(NearArgs::default())
+    }
+
+    fn plugin_with_mappings(mappings: Vec<String>) -> NearPlugin {
+        NearPlugin::new(NearArgs {
+            near_token_metadata_mappings: mappings,
+        })
+    }
+
+    fn write_temp_json(name: &str, content: &str) -> std::path::PathBuf {
+        parser_cli_core::test_utils::write_temp_json("vsp_near_tests", name, content)
+    }
+
+    /// Unwrap the `Near` variant of the metadata oneof.
+    fn near_metadata(metadata: ChainMetadata) -> NearMetadata {
+        let chain_metadata::Metadata::Near(near) = metadata.metadata.unwrap() else {
+            panic!("expected Near metadata");
+        };
+        near
     }
 
     #[test]
-    fn create_metadata_defaults_to_none_without_a_network_flag() {
+    fn create_metadata_defaults_to_none_without_a_network_flag_or_mappings() {
         assert_eq!(plugin().create_metadata(None).unwrap(), None);
     }
 
@@ -112,6 +277,180 @@ mod tests {
         assert!(plugin().create_metadata(Some("bogus".to_string())).is_err());
     }
 
+    /// An invalid network fails even when a mapping loads fine, so a bad
+    /// `--network` can't be masked by a successful mapping load.
+    #[test]
+    fn create_metadata_rejects_an_invalid_network_even_with_mappings() {
+        let path = write_temp_json("reject.json", r#"{"symbol":"X","decimals":6}"#);
+        let mappings = vec![format!("X@{}@nep141:x.near", path.display())];
+        assert!(
+            plugin_with_mappings(mappings)
+                .create_metadata(Some("bogus".to_string()))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn create_metadata_carries_a_token_mapping() {
+        let path = write_temp_json("usdc.json", r#"{"symbol":"USDC.e","decimals":6}"#);
+        let asset_id = "nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near";
+        let mappings = vec![format!("USDC@{}@{asset_id}", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(Some("NEAR_MAINNET".to_string()))
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.network_id, Some("NEAR_MAINNET".to_string()));
+        assert_eq!(near.token_mappings.len(), 1);
+        let entry = near.token_mappings.get(asset_id).expect("mapping present");
+        assert!(entry.value.contains("USDC.e"));
+        // The CLI signs locally-loaded token metadata so the strict posture it
+        // installs accepts the entry instead of dropping it.
+        assert!(
+            entry.signature.is_some(),
+            "CLI should attach a dev-key signature to locally-loaded token metadata"
+        );
+        assert!(entry.origin_chain.is_none());
+    }
+
+    /// Mappings alone are enough to produce metadata; the network flag is
+    /// independent of them.
+    #[test]
+    fn create_metadata_carries_mappings_without_a_network() {
+        let path = write_temp_json("net_check.json", r#"{"symbol":"X","decimals":6}"#);
+        let mappings = vec![format!("X@{}@nep141:x.near", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert!(near.network_id.is_none());
+        assert_eq!(near.token_mappings.len(), 1);
+    }
+
+    #[test]
+    fn create_metadata_skips_an_unreadable_mapping_file() {
+        let mappings = vec!["Bad@/nonexistent/token.json@nep141:missing.near".to_string()];
+        assert_eq!(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap(),
+            None,
+            "every mapping failing to load leaves nothing to carry"
+        );
+    }
+
+    #[test]
+    fn create_metadata_carries_multiple_mappings() {
+        let path_a = write_temp_json("a.json", r#"{"symbol":"A","decimals":6}"#);
+        let path_b = write_temp_json("b.json", r#"{"symbol":"B","decimals":18}"#);
+        let mappings = vec![
+            format!("A@{}@nep141:a.near", path_a.display()),
+            format!("B@{}@nep141:b.near", path_b.display()),
+        ];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.token_mappings.len(), 2);
+        assert!(near.token_mappings.contains_key("nep141:a.near"));
+        assert!(near.token_mappings.contains_key("nep141:b.near"));
+    }
+
+    /// Regression coverage for the reason `@` is the separator: an asset id
+    /// with an embedded colon must survive intact, not get truncated at the
+    /// first colon the way the shared colon-delimited mapping format would.
+    #[test]
+    fn asset_id_with_embedded_colon_is_preserved() {
+        let path = write_temp_json("colon.json", r#"{"symbol":"X","decimals":6}"#);
+        let asset_id = "nep141:x.factory.bridge.near";
+        let mappings = vec![format!("X@{}@{asset_id}", path.display())];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert!(
+            near.token_mappings.contains_key(asset_id),
+            "the full asset id (including its colon) must be the map key"
+        );
+    }
+
+    #[test]
+    fn create_metadata_keeps_valid_mappings_alongside_invalid_ones() {
+        let path = write_temp_json("good.json", r#"{"symbol":"GOOD","decimals":6}"#);
+        let mappings = vec![
+            "bad-format-no-at-signs".to_string(),
+            format!("Good@{}@nep141:good.near", path.display()),
+            "Also@/missing/file.json@nep141:bad.near".to_string(),
+        ];
+
+        let near = near_metadata(
+            plugin_with_mappings(mappings)
+                .create_metadata(None)
+                .unwrap()
+                .expect("Some(ChainMetadata)"),
+        );
+        assert_eq!(near.token_mappings.len(), 1);
+        assert!(near.token_mappings.contains_key("nep141:good.near"));
+    }
+
+    #[test]
+    fn parse_near_mapping_accepts_the_three_field_format() {
+        let result = parse_near_mapping("MyToken@/path/to/file.json@nep141:wrap.near")
+            .expect("valid mapping should parse");
+        assert_eq!(result.name, "MyToken");
+        assert_eq!(result.path, "/path/to/file.json");
+        assert_eq!(result.asset_id, "nep141:wrap.near");
+    }
+
+    #[test]
+    fn parse_near_mapping_rejects_a_malformed_mapping() {
+        assert!(parse_near_mapping("NoAtSigns").is_err());
+        assert!(parse_near_mapping("OnlyOne@AtSign").is_err());
+        assert!(parse_near_mapping("@@EmptyComponents").is_err());
+    }
+
+    /// An `execute_intents` transaction withdrawing the token behind `asset_id`,
+    /// as raw borsh hex.
+    fn intents_tx_hex(asset_id: &str) -> String {
+        let token = asset_id
+            .split_once(':')
+            .map_or(asset_id, |(_, account)| account);
+        let inner = format!(
+            r#"{{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{{"intent":"ft_withdraw","token":"{token}","receiver_id":"bob.near","amount":"1000000"}}]}}"#
+        );
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let tx = Transaction::V0(TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 1,
+            receiver_id: "intents.near".parse().unwrap(),
+            block_hash: CryptoHash::default(),
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_intents".to_string(),
+                args: serde_json::to_vec(&args).unwrap(),
+                gas: Gas::from_gas(30_000_000_000_000),
+                deposit: Balance::from_yoctonear(0),
+            }))],
+        });
+        hex::encode(borsh::to_vec(&tx).unwrap())
+    }
+
     /// The posture must be pinned through `register`, not through the helper that
     /// feeds it.
     ///
@@ -128,30 +467,6 @@ mod tests {
     #[test]
     fn test_register_installs_require_signed_posture() {
         let asset_id = "nep141:test-token.near";
-        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"test-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
-        let args = serde_json::json!({"signed":[{
-            "standard": "raw_ed25519",
-            "payload": inner,
-            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
-            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
-        }]});
-
-        let build_tx_hex = || {
-            let tx = Transaction::V0(TransactionV0 {
-                signer_id: "alice.near".parse().unwrap(),
-                public_key: PublicKey::empty(KeyType::ED25519),
-                nonce: 1,
-                receiver_id: "intents.near".parse().unwrap(),
-                block_hash: CryptoHash::default(),
-                actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                    method_name: "execute_intents".to_string(),
-                    args: serde_json::to_vec(&args).unwrap(),
-                    gas: Gas::from_gas(30_000_000_000_000),
-                    deposit: Balance::from_yoctonear(0),
-                }))],
-            });
-            hex::encode(borsh::to_vec(&tx).unwrap())
-        };
 
         // Deliberately unsigned: this is the entry the CLI's posture must refuse.
         let build_options = || VisualSignOptions {
@@ -180,7 +495,7 @@ mod tests {
             crate::NearVisualSignConverter::new(),
         );
         let permissive = permissive_registry
-            .convert_transaction(&Chain::Near, &build_tx_hex(), build_options())
+            .convert_transaction(&Chain::Near, &intents_tx_hex(asset_id), build_options())
             .unwrap()
             .payload
             .to_json()
@@ -194,7 +509,7 @@ mod tests {
         let mut registry = TransactionConverterRegistry::new();
         plugin().register(&mut registry);
         let rendered = registry
-            .convert_transaction(&Chain::Near, &build_tx_hex(), build_options())
+            .convert_transaction(&Chain::Near, &intents_tx_hex(asset_id), build_options())
             .unwrap()
             .payload
             .to_json()
@@ -206,6 +521,47 @@ mod tests {
         assert!(
             rendered.contains(&format!("unresolved {asset_id}")),
             "dropping the unsigned entry must leave the raw asset id unresolved, got: {rendered}"
+        );
+    }
+
+    /// End-to-end gate on the whole CLI path: the flag builds an entry, the dev
+    /// key signs it, and the strict posture `register` installs accepts it.
+    ///
+    /// Each half alone is insufficient. `create_metadata` asserting
+    /// `signature.is_some()` says nothing about whether that signature verifies,
+    /// and the posture test above only proves an unsigned entry is refused. Drop
+    /// the dev key from `authorized_token_metadata_signers`, or sign under the
+    /// wrong domain tag, and both still pass while the flag resolves nothing.
+    #[test]
+    fn cli_signed_mapping_resolves_through_the_registered_converter() {
+        let asset_id = "nep141:test-token.near";
+        let path = write_temp_json("e2e.json", r#"{"symbol":"CLISIGNED","decimals":6}"#);
+        let mappings = vec![format!("Test@{}@{asset_id}", path.display())];
+        let plugin = plugin_with_mappings(mappings);
+
+        let metadata = plugin
+            .create_metadata(Some("NEAR_MAINNET".to_string()))
+            .unwrap()
+            .expect("Some(ChainMetadata)");
+
+        let mut registry = TransactionConverterRegistry::new();
+        plugin.register(&mut registry);
+        let rendered = registry
+            .convert_transaction(
+                &Chain::Near,
+                &intents_tx_hex(asset_id),
+                VisualSignOptions {
+                    metadata: Some(metadata),
+                    ..VisualSignOptions::default()
+                },
+            )
+            .unwrap()
+            .payload
+            .to_json()
+            .unwrap();
+        assert!(
+            rendered.contains("CLISIGNED"),
+            "a CLI-signed entry must resolve under the posture `register` installs, got: {rendered}"
         );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -72,6 +72,7 @@ impl parser_cli_core::ChainPlugin for NearPlugin {
 }
 
 /// Parsed components of a `Name@Path@AssetId` mapping string.
+#[derive(Debug)]
 struct NearMappingComponents {
     name: String,
     path: String,
@@ -85,9 +86,21 @@ struct NearMappingComponents {
 /// `mapping_parser::parse_mapping`, which splits on `:` and would truncate a
 /// NEAR asset id at its first embedded colon).
 fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String> {
-    let mut parts = mapping_str.splitn(3, '@');
-    let (Some(name), Some(path), Some(asset_id)) = (parts.next(), parts.next(), parts.next())
-    else {
+    // Split on every '@' rather than the first two: a path containing '@' is
+    // legal on Linux/macOS, and `splitn(3, '@')` would quietly absorb the
+    // remainder into the asset id, turning "/tmp/a@b/t.json" into path
+    // "/tmp/a" and asset id "b/t.json@nep141:...". An asset id never contains
+    // '@', so a fourth component means the path did.
+    let parts: Vec<&str> = mapping_str.split('@').collect();
+    let [name, path, asset_id] = parts[..] else {
+        if parts.len() > 3 {
+            return Err(format!(
+                "Invalid mapping format: found {} '@'-separated components, expected 3 \
+                 (Name@FilePath@AssetId). A file path containing '@' cannot be used here: \
+                 {mapping_str}",
+                parts.len()
+            ));
+        }
         return Err(format!(
             "Invalid mapping format (expected Name@FilePath@AssetId): {mapping_str}"
         ));
@@ -430,6 +443,33 @@ mod tests {
         assert!(parse_near_mapping("NoAtSigns").is_err());
         assert!(parse_near_mapping("OnlyOne@AtSign").is_err());
         assert!(parse_near_mapping("@@EmptyComponents").is_err());
+    }
+
+    #[test]
+    fn parse_near_mapping_rejects_an_at_sign_in_the_path() {
+        // Previously absorbed into the asset id, yielding path "/tmp/my" and
+        // asset id "dir/token.json@nep141:wrap.near" with no complaint.
+        let err = parse_near_mapping("MyToken@/tmp/my@dir/token.json@nep141:wrap.near")
+            .expect_err("a path containing '@' must be rejected");
+        assert!(err.contains("expected 3"), "{err}");
+        assert!(err.contains("cannot be used here"), "{err}");
+    }
+
+    #[test]
+    fn build_token_mappings_skips_a_file_whose_json_is_invalid() {
+        // Distinct from the file-not-found path: the file opens and reads, and
+        // the failure comes from serde_json rejecting its contents.
+        let dir = std::env::temp_dir().join("vsp_near_cli_plugin_invalid_json");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("broken.json");
+        std::fs::write(&path, "{").expect("write");
+
+        let mapping = format!("Broken@{}@nep141:wrap.near", path.display());
+        let (map, valid) = build_token_mappings_from_files(&[mapping], NearNetwork::default());
+        assert!(map.is_empty(), "an unparseable file must register nothing");
+        assert_eq!(valid, 0);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// An `execute_intents` transaction withdrawing the token behind `asset_id`,

--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -71,6 +71,7 @@ impl parser_cli_core::ChainPlugin for NearPlugin {
 }
 
 /// Parsed components of a `Name@Path@AssetId` mapping string.
+#[derive(Debug)]
 struct NearMappingComponents {
     name: String,
     path: String,
@@ -84,9 +85,21 @@ struct NearMappingComponents {
 /// `mapping_parser::parse_mapping`, which splits on `:` and would truncate a
 /// NEAR asset id at its first embedded colon).
 fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String> {
-    let mut parts = mapping_str.splitn(3, '@');
-    let (Some(name), Some(path), Some(asset_id)) = (parts.next(), parts.next(), parts.next())
-    else {
+    // Split on every '@' rather than the first two: a path containing '@' is
+    // legal on Linux/macOS, and `splitn(3, '@')` would quietly absorb the
+    // remainder into the asset id, turning "/tmp/a@b/t.json" into path
+    // "/tmp/a" and asset id "b/t.json@nep141:...". An asset id never contains
+    // '@', so a fourth component means the path did.
+    let parts: Vec<&str> = mapping_str.split('@').collect();
+    let [name, path, asset_id] = parts[..] else {
+        if parts.len() > 3 {
+            return Err(format!(
+                "Invalid mapping format: found {} '@'-separated components, expected 3 \
+                 (Name@FilePath@AssetId). A file path containing '@' cannot be used here: \
+                 {mapping_str}",
+                parts.len()
+            ));
+        }
         return Err(format!(
             "Invalid mapping format (expected Name@FilePath@AssetId): {mapping_str}"
         ));
@@ -418,6 +431,33 @@ mod tests {
         assert!(parse_near_mapping("NoAtSigns").is_err());
         assert!(parse_near_mapping("OnlyOne@AtSign").is_err());
         assert!(parse_near_mapping("@@EmptyComponents").is_err());
+    }
+
+    #[test]
+    fn parse_near_mapping_rejects_an_at_sign_in_the_path() {
+        // Previously absorbed into the asset id, yielding path "/tmp/my" and
+        // asset id "dir/token.json@nep141:wrap.near" with no complaint.
+        let err = parse_near_mapping("MyToken@/tmp/my@dir/token.json@nep141:wrap.near")
+            .expect_err("a path containing '@' must be rejected");
+        assert!(err.contains("expected 3"), "{err}");
+        assert!(err.contains("cannot be used here"), "{err}");
+    }
+
+    #[test]
+    fn build_token_mappings_skips_a_file_whose_json_is_invalid() {
+        // Distinct from the file-not-found path: the file opens and reads, and
+        // the failure comes from serde_json rejecting its contents.
+        let dir = std::env::temp_dir().join("vsp_near_cli_plugin_invalid_json");
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("broken.json");
+        std::fs::write(&path, "{").expect("write");
+
+        let mapping = format!("Broken@{}@nep141:wrap.near", path.display());
+        let (map, valid) = build_token_mappings_from_files(&[mapping]);
+        assert!(map.is_empty(), "an unparseable file must register nothing");
+        assert_eq!(valid, 0);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// An `execute_intents` transaction withdrawing the token behind `asset_id`,

--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -4,7 +4,7 @@ use clap::Args as ClapArgs;
 use generated::parser::{ChainMetadata, NearMetadata, TokenMetadataEntry, chain_metadata};
 use visualsign::registry::{Chain, TransactionConverterRegistry};
 
-use parser_cli_core::mapping_parser::load_json_file;
+use parser_cli_core::mapping_parser::{MappingComponents, MappingFormat, load_mappings};
 
 use crate::networks::NearNetwork;
 use crate::presets::intents::sign_token_metadata_for_cli;
@@ -71,21 +71,13 @@ impl parser_cli_core::ChainPlugin for NearPlugin {
     }
 }
 
-/// Parsed components of a `Name@Path@AssetId` mapping string.
-#[derive(Debug)]
-struct NearMappingComponents {
-    name: String,
-    path: String,
-    asset_id: String,
-}
-
 /// Parse the NEAR-specific `Name@Path@AssetId` mapping format.
 ///
 /// Splits into exactly 3 parts on `@`; the third part is the asset id
 /// verbatim, including any colons it contains (unlike the shared
 /// `mapping_parser::parse_mapping`, which splits on `:` and would truncate a
 /// NEAR asset id at its first embedded colon).
-fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String> {
+fn parse_near_mapping(mapping_str: &str) -> Result<MappingComponents, String> {
     // Split on every '@' rather than the first two: a path containing '@' is
     // legal on Linux/macOS, and `splitn(3, '@')` would quietly absorb the
     // remainder into the asset id, turning "/tmp/a@b/t.json" into path
@@ -108,10 +100,10 @@ fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String
     if name.is_empty() || path.is_empty() || asset_id.is_empty() {
         return Err(format!("Mapping components cannot be empty: {mapping_str}"));
     }
-    Ok(NearMappingComponents {
+    Ok(MappingComponents {
         name: name.to_string(),
         path: path.to_string(),
-        asset_id: asset_id.to_string(),
+        identifier: asset_id.to_string(),
     })
 }
 
@@ -121,72 +113,53 @@ fn parse_near_mapping(mapping_str: &str) -> Result<NearMappingComponents, String
 /// dropped by the strict posture [`cli_trust_policy`] installs; if signing is
 /// unavailable (binary built without `dev-signing`), the entry is registered
 /// unsigned instead of dropped here.
+///
+/// The load/dedupe/count/report loop is `load_mappings`, shared with the ABI
+/// and IDL flags, so the three chains cannot drift on what a duplicate or an
+/// unreadable file does. Only the parse differs, because a NEAR asset id
+/// carries its own colons.
 fn build_token_mappings_from_files(
     mappings: &[String],
     signing_network: NearNetwork,
 ) -> (BTreeMap<String, TokenMetadataEntry>, usize) {
-    let mut map = BTreeMap::new();
-    let mut valid_count = 0;
-
-    for mapping in mappings {
-        let components = match parse_near_mapping(mapping) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Error parsing token metadata mapping: {e}");
-                eprintln!("Expected format: Name@/path/to/file.json@AssetId");
-                eprintln!(
-                    "Example: USDC@usdc.json@nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near"
-                );
-                continue;
-            }
-        };
-        let json = match load_json_file(&components.path) {
-            Ok(j) => j,
-            Err(e) => {
-                eprintln!(
-                    "  Warning: Failed to load token metadata '{}' from '{}': {e}",
-                    components.name, components.path
-                );
-                continue;
-            }
-        };
-        let signature = match sign_token_metadata_for_cli(
-            signing_network.network_id(),
-            &components.asset_id,
-            &json,
-        ) {
-            Ok(sig) => Some(sig),
-            Err(e) => {
-                eprintln!(
-                    "  Warning: '{}' could not be signed ({e}); registering unsigned",
-                    components.name
-                );
-                None
-            }
-        };
-        let previous = map.insert(
-            components.asset_id.clone(),
-            TokenMetadataEntry {
+    load_mappings(
+        mappings,
+        &MappingFormat {
+            kind: "token metadata",
+            example: "USDC@usdc.json@nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near",
+            identifier_label: "AssetId",
+            format_hint: "Name@/path/to/file.json@AssetId",
+        },
+        parse_near_mapping,
+        // Any non-empty string is a candidate asset id: the id space is the
+        // caller's contract naming, not a fixed encoding this side can check,
+        // and `parse_near_mapping` has already rejected an empty component.
+        |_| Ok(()),
+        |components, json| {
+            // Unlike the ABI and IDL flags, a signing failure is not a
+            // rejection: the entry is still worth rendering as an unsigned
+            // gap-fill, and a build without `dev-signing` cannot sign at all.
+            let signature = match sign_token_metadata_for_cli(
+                signing_network.network_id(),
+                &components.identifier,
+                &json,
+            ) {
+                Ok(sig) => Some(sig),
+                Err(e) => {
+                    eprintln!(
+                        "  Warning: '{}' could not be signed ({e}); registering unsigned",
+                        components.name
+                    );
+                    None
+                }
+            };
+            Ok(TokenMetadataEntry {
                 value: json,
                 signature,
                 origin_chain: None,
-            },
-        );
-        if previous.is_some() {
-            eprintln!(
-                "  Warning: Duplicate asset id '{}' for token metadata '{}'; overwriting previous entry",
-                components.asset_id, components.name
-            );
-        } else {
-            valid_count += 1;
-            eprintln!(
-                "  Loaded token metadata '{}' from {} and mapped to {}",
-                components.name, components.path, components.asset_id
-            );
-        }
-    }
-
-    (map, valid_count)
+            })
+        },
+    )
 }
 
 /// Build NEAR chain metadata from the global `--network` flag and the
@@ -435,7 +408,7 @@ mod tests {
             .expect("valid mapping should parse");
         assert_eq!(result.name, "MyToken");
         assert_eq!(result.path, "/path/to/file.json");
-        assert_eq!(result.asset_id, "nep141:wrap.near");
+        assert_eq!(result.identifier, "nep141:wrap.near");
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -11,7 +11,7 @@ mod tokens;
 mod verify;
 
 pub use token_signature::{
-    TokenMetadataSignerAllowlists, authorized_token_metadata_signers,
+    TokenMetadataSignerAllowlists, authorized_token_metadata_signers, sign_token_metadata_for_cli,
     try_extract_from_chain_metadata as try_extract_token_metadata_from_chain_metadata,
 };
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -12,6 +12,7 @@ mod verify;
 
 pub use token_signature::{
     TokenMetadataDomain, authorized_token_metadata_signers, insert_token_metadata_signer,
+    sign_token_metadata_for_cli,
     try_extract_from_chain_metadata as try_extract_token_metadata_from_chain_metadata,
 };
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -143,16 +143,24 @@ pub struct TokenMetadataSignerAllowlists {
     solana: SignerAllowlist,
 }
 
-/// Build the authorized token-metadata-signer allowlists from env-configured
-/// production lists, cached for the lifetime of the process.
+/// Build the authorized token-metadata-signer allowlists from compile-time +
+/// env-configured production lists, cached for the lifetime of the process.
 ///
 /// - `VISUALSIGN_NEAR_TOKEN_SIGNERS`: comma-separated hex ed25519 public keys.
 /// - `VISUALSIGN_ETH_TOKEN_SIGNERS`: comma-separated hex secp256k1 public keys
 ///   (any SEC1 encoding).
 /// - `VISUALSIGN_SOL_TOKEN_SIGNERS`: comma-separated hex ed25519 public keys.
 ///
-/// An unset (or entirely invalid) env var leaves that chain's allowlist empty,
-/// which rejects every signed entry for that origin chain (fail-closed). These
+/// Under the `dev-signing` feature (and this crate's own tests), the NEAR
+/// dev key derived from [`DEV_NEAR_SIGNING_KEY_SEED`] is also allowlisted,
+/// matching `visualsign-ethereum`'s `authorized_abi_signers()` -- without
+/// this, `sign_token_metadata_for_cli`'s own signature would never verify,
+/// since it always signs with that key and the env var alone is empty in a
+/// local dev run.
+///
+/// An unset (or entirely invalid) env var leaves that chain's allowlist with
+/// only the dev-signing entry above (empty outside `dev-signing`), which
+/// rejects every other signed entry for that origin chain (fail-closed). These
 /// allowlists gate only entries that carry a signature; whether an unsigned
 /// entry is accepted at all is controlled separately by the deployment's
 /// [`MetadataTrustPolicy`] and by the gap-fill-only rule in
@@ -162,10 +170,30 @@ pub struct TokenMetadataSignerAllowlists {
 pub fn authorized_token_metadata_signers() -> &'static TokenMetadataSignerAllowlists {
     static ALLOW: OnceLock<TokenMetadataSignerAllowlists> = OnceLock::new();
     ALLOW.get_or_init(|| TokenMetadataSignerAllowlists {
-        near: build_ed25519_allowlist("VISUALSIGN_NEAR_TOKEN_SIGNERS"),
+        near: with_near_dev_signer(build_ed25519_allowlist("VISUALSIGN_NEAR_TOKEN_SIGNERS")),
         ethereum: build_secp256k1_allowlist("VISUALSIGN_ETH_TOKEN_SIGNERS"),
         solana: build_ed25519_allowlist("VISUALSIGN_SOL_TOKEN_SIGNERS"),
     })
+}
+
+/// Add the NEAR dev key to `allow`, so entries signed by
+/// [`sign_token_metadata_for_cli`] verify in a local dev run.
+#[cfg(any(test, feature = "dev-signing"))]
+fn with_near_dev_signer(mut allow: SignerAllowlist) -> SignerAllowlist {
+    allow.insert(
+        ed25519_dalek::SigningKey::from_bytes(&DEV_NEAR_SIGNING_KEY_SEED)
+            .verifying_key()
+            .to_bytes()
+            .to_vec(),
+    );
+    allow
+}
+
+/// Without `dev-signing` the dev key is not linked, so the allowlist carries
+/// only what the env var configured.
+#[cfg(not(any(test, feature = "dev-signing")))]
+fn with_near_dev_signer(allow: SignerAllowlist) -> SignerAllowlist {
+    allow
 }
 
 fn build_ed25519_allowlist(env_var: &str) -> SignerAllowlist {
@@ -575,6 +603,56 @@ pub fn sign_token_metadata_secp256k1(
             },
         ],
     })
+}
+
+/// CLI entry point for token-metadata signing, decoupled from the
+/// `dev-signing` cargo feature so the `cli_plugin` module compiles regardless
+/// of whether `dev-signing` is enabled.
+///
+/// `cli_plugin` is a default feature of `visualsign-near` (like every other
+/// chain crate's), so it is compiled into every consumer -- including the
+/// production `parser_app`, which enables `cli-plugin` transitively but NOT
+/// `dev-signing`. The underlying [`sign_token_metadata_ed25519`] and
+/// [`DEV_NEAR_SIGNING_KEY_SEED`] are `dev-signing`-gated, so calling them
+/// directly from `cli_plugin` breaks any `cli-plugin`-without-`dev-signing`
+/// build. This wrapper is always present: under `dev-signing` (or tests) it
+/// signs with the dev key; otherwise it returns an error.
+///
+/// Always signs as NEAR-origin (ed25519, the NEAR-only curator dev key): the
+/// CLI has no per-mapping `origin_chain` input yet, so every CLI-supplied
+/// entry defaults to the origin the verifier itself treats as the default
+/// (`Unspecified`/`Near`). Ethereum/Solana-origin CLI signing is not wired up
+/// yet.
+///
+/// # Errors
+/// Returns `Err` if the binary was built without `dev-signing` (in which case
+/// token-metadata signing is unavailable by design).
+#[cfg(any(test, feature = "dev-signing"))]
+pub fn sign_token_metadata_for_cli(
+    asset_id: &str,
+    value: &str,
+) -> Result<generated::parser::SignatureMetadata, String> {
+    Ok(sign_token_metadata_ed25519(
+        asset_id,
+        value,
+        &DEV_NEAR_SIGNING_KEY_SEED,
+        visualsign::signing::near_token_metadata_prehash,
+    ))
+}
+
+/// See the `dev-signing`-enabled variant above. Without `dev-signing` the dev
+/// key is not linked, so token-metadata signing is unavailable and this
+/// returns an error.
+#[cfg(not(any(test, feature = "dev-signing")))]
+pub fn sign_token_metadata_for_cli(
+    _asset_id: &str,
+    _value: &str,
+) -> Result<generated::parser::SignatureMetadata, String> {
+    Err(
+        "token metadata signing is unavailable: this binary was built without the \
+         dev-signing feature"
+            .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -1276,6 +1354,31 @@ mod tests {
                 &accept_unsigned_policy()
             )
             .is_none()
+        );
+    }
+
+    /// A CLI-signed entry must verify under `authorized_token_metadata_signers`
+    /// itself, the allowlist the decode path consults.
+    ///
+    /// The test module's own `near_allowlist()` helper enrolls the dev key
+    /// directly, so asserting against it proves only that the signature is
+    /// well-formed. Without the dev-signing carve-out in the real function, a
+    /// CLI-signed entry signs fine and is then dropped as an untrusted signer
+    /// when the CLI decodes it.
+    #[test]
+    fn authorized_token_metadata_signers_allowlists_the_cli_dev_key() {
+        let sig = sign_token_metadata_for_cli(ASSET_ID, VALUE).expect("cli signing must succeed");
+        let local_sig = convert_proto_signature(&sig);
+        assert!(
+            validate_token_metadata_signature(
+                ASSET_ID,
+                VALUE,
+                TokenOriginChain::Near,
+                &local_sig,
+                authorized_token_metadata_signers()
+            )
+            .is_ok(),
+            "a CLI-signed entry must verify under the allowlist the decode path consults"
         );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -300,6 +300,13 @@ fn scoped_signer_key(domain: TokenMetadataDomain, canonical_pubkey: &[u8]) -> Ve
 /// (or entirely invalid) var leaves that domain unpopulated, and a signature
 /// under it is then never recognized (fail-closed).
 ///
+/// Under the `dev-signing` feature (and this crate's own tests) the NEAR dev key
+/// derived from [`DEV_NEAR_SIGNING_KEY_SEED`] is enrolled for the NEAR domain,
+/// matching `visualsign-ethereum`'s `authorized_abi_signers()`. Without it
+/// [`sign_token_metadata_for_cli`]'s own signatures would never be recognized:
+/// it always signs with that key, and the env var alone is empty in a local dev
+/// run.
+///
 /// This list decides whether a present signature is *recognized*, not whether an
 /// unrecognized entry is *accepted* -- that is the deployment's
 /// [`MetadataTrustPolicy`], together with the gap-fill-only rule in
@@ -312,6 +319,7 @@ pub fn authorized_token_metadata_signers() -> &'static SignerAllowlist {
         for domain in TokenMetadataDomain::ALL {
             insert_env_signers(&mut allow, domain);
         }
+        insert_near_dev_signer(&mut allow);
         allow
     })
 }
@@ -368,6 +376,21 @@ pub fn insert_token_metadata_signer(
         None => false,
     }
 }
+
+/// Enrol the NEAR dev key, so entries signed by
+/// [`sign_token_metadata_for_cli`] are recognized in a local dev run.
+#[cfg(any(test, feature = "dev-signing"))]
+fn insert_near_dev_signer(allow: &mut SignerAllowlist) {
+    let dev_key = ed25519_dalek::SigningKey::from_bytes(&DEV_NEAR_SIGNING_KEY_SEED)
+        .verifying_key()
+        .to_bytes();
+    allow.insert(scoped_signer_key(TokenMetadataDomain::Near, &dev_key));
+}
+
+/// Without `dev-signing` the dev key is not linked, so the allowlist carries
+/// only what the env vars configured.
+#[cfg(not(any(test, feature = "dev-signing")))]
+fn insert_near_dev_signer(_allow: &mut SignerAllowlist) {}
 
 fn canonical_ed25519_pubkey_from_hex(hex_str: &str) -> Option<Vec<u8>> {
     let bytes = decode_hex_fixed::<ED25519_PUBLIC_KEY_LEN>(hex_str, "public key").ok()?;
@@ -834,6 +857,59 @@ pub fn sign_token_metadata_secp256k1(
             },
         ],
     })
+}
+
+/// CLI entry point for token-metadata signing, decoupled from the
+/// `dev-signing` cargo feature so the `cli_plugin` module compiles regardless
+/// of whether `dev-signing` is enabled.
+///
+/// `cli_plugin` is a default feature of `visualsign-near` (like every other
+/// chain crate's), so it is compiled into every consumer -- including the
+/// production `parser_app`, which enables `cli-plugin` transitively but NOT
+/// `dev-signing`. The underlying [`sign_token_metadata_ed25519`] and
+/// [`DEV_NEAR_SIGNING_KEY_SEED`] are `dev-signing`-gated, so calling them
+/// directly from `cli_plugin` breaks any `cli-plugin`-without-`dev-signing`
+/// build. This wrapper is always present: under `dev-signing` (or tests) it
+/// signs with the dev key; otherwise it returns an error.
+///
+/// Always signs as NEAR-origin (ed25519, the NEAR-only curator dev key): the
+/// CLI has no per-mapping `origin_chain` input yet, so every CLI-supplied
+/// entry defaults to the origin the verifier itself treats as the default
+/// (`Unspecified`/`Near`). Ethereum/Solana-origin CLI signing is not wired up
+/// yet.
+///
+/// # Errors
+/// Returns `Err` if the binary was built without `dev-signing` (in which case
+/// token-metadata signing is unavailable by design).
+#[cfg(any(test, feature = "dev-signing"))]
+pub fn sign_token_metadata_for_cli(
+    network_id: &str,
+    asset_id: &str,
+    value: &str,
+) -> Result<generated::parser::SignatureMetadata, String> {
+    Ok(sign_token_metadata_ed25519(
+        network_id,
+        asset_id,
+        value,
+        &DEV_NEAR_SIGNING_KEY_SEED,
+        visualsign::signing::near_token_metadata_prehash,
+    ))
+}
+
+/// See the `dev-signing`-enabled variant above. Without `dev-signing` the dev
+/// key is not linked, so token-metadata signing is unavailable and this
+/// returns an error.
+#[cfg(not(any(test, feature = "dev-signing")))]
+pub fn sign_token_metadata_for_cli(
+    _network_id: &str,
+    _asset_id: &str,
+    _value: &str,
+) -> Result<generated::parser::SignatureMetadata, String> {
+    Err(
+        "token metadata signing is unavailable: this binary was built without the \
+         dev-signing feature"
+            .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -2029,6 +2105,34 @@ mod tests {
                 &accept_unsigned_policy()
             )
             .is_none()
+        );
+    }
+
+    /// A CLI-signed entry must verify under `authorized_token_metadata_signers`
+    /// itself, the allowlist the decode path consults.
+    ///
+    /// The test module's own `near_allowlist()` helper enrolls the dev key
+    /// directly, so asserting against it proves only that the signature is
+    /// well-formed. Without the dev-signing carve-out in the real function, a
+    /// CLI-signed entry signs fine and is then dropped as an untrusted signer
+    /// when the CLI decodes it.
+    #[test]
+    fn authorized_token_metadata_signers_allowlists_the_cli_dev_key() {
+        let sig = sign_token_metadata_for_cli(NETWORK_ID, ASSET_ID, VALUE)
+            .expect("cli signing must succeed");
+        let local_sig = convert_proto_signature(&sig);
+        assert_eq!(
+            validate_token_metadata_signature(
+                NETWORK_ID,
+                ASSET_ID,
+                VALUE,
+                TokenMetadataDomain::Near,
+                &local_sig,
+                authorized_token_metadata_signers()
+            )
+            .expect("a CLI-signed entry must verify"),
+            SignerIdentity::Recognized,
+            "a CLI-signed entry must be recognized under the allowlist the decode path consults"
         );
     }
 }

--- a/src/chain_parsers/visualsign-near/tests/unsigned_without_dev_signing.rs
+++ b/src/chain_parsers/visualsign-near/tests/unsigned_without_dev_signing.rs
@@ -1,0 +1,63 @@
+//! The CLI token-metadata path when the binary carries no signing key.
+//!
+//! Lives in `tests/` rather than the crate's own test module on purpose.
+//! `sign_token_metadata_for_cli` is gated on
+//! `cfg(any(test, feature = "dev-signing"))`, so under unit tests the signing
+//! variant is always linked and its `Err` arm is unreachable. An integration
+//! test compiles the library without `cfg(test)`, so with `dev-signing` off the
+//! error-returning variant is what links -- the configuration a shipped binary
+//! has.
+//!
+//! `make test` already runs this in the right shape: the workspace pass
+//! excludes `parser_cli`, the only crate that enables `dev-signing`, so feature
+//! unification cannot switch it back on here.
+//!
+//! Scope is the half that nothing else covers -- that an entry is registered
+//! *unsigned* rather than dropped when signing is unavailable. What happens to
+//! an unsigned entry afterwards (refused under `RequireAllowlistedSigner`,
+//! accepted only as a gap-fill under `AcceptUnsigned`) is covered by
+//! `token_signature.rs`'s own tests, which don't depend on this feature.
+
+#![cfg(all(feature = "cli-plugin", not(feature = "dev-signing")))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use parser_cli_core::ChainPlugin;
+use visualsign_near::{NearArgs, NearPlugin};
+
+const ASSET_ID: &str = "nep141:not-a-seeded-asset.near";
+const VALUE: &str = r#"{"symbol":"GAP","decimals":6}"#;
+
+#[test]
+fn without_dev_signing_the_cli_registers_the_entry_unsigned() {
+    let dir = std::env::temp_dir().join("vsp_near_no_dev_signing");
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let file = dir.join("token.json");
+    std::fs::write(&file, VALUE).expect("write");
+
+    let plugin = NearPlugin::new(NearArgs {
+        near_token_metadata_mappings: vec![format!("GAP@{}@{ASSET_ID}", file.display())],
+    });
+    let metadata = plugin
+        .create_metadata(Some("NEAR_MAINNET".to_string()))
+        .expect("metadata builds")
+        .expect("a loadable mapping yields metadata");
+
+    let Some(generated::parser::chain_metadata::Metadata::Near(near)) = metadata.metadata.as_ref()
+    else {
+        panic!("expected NEAR chain metadata, got {:?}", metadata.metadata);
+    };
+    let entry = near
+        .token_mappings
+        .get(ASSET_ID)
+        .expect("the mapping registers even though signing was unavailable");
+
+    assert_eq!(entry.value, VALUE, "the file contents are carried verbatim");
+    assert!(
+        entry.signature.is_none(),
+        "a binary built without dev-signing must register the entry unsigned \
+         rather than attaching a signature, got {:?}",
+        entry.signature
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/chain_parsers/visualsign-solana/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-solana/src/cli_plugin.rs
@@ -53,9 +53,13 @@ impl parser_cli_core::ChainPlugin for SolanaPlugin {
 fn build_idl_mappings_from_files(idl_json_mappings: &[String]) -> (BTreeMap<String, Idl>, usize) {
     mapping_parser::load_mappings(
         idl_json_mappings,
-        "IDL",
-        "JupiterSwap:path/to/jupiter.json:JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
-        "ProgramId",
+        &mapping_parser::MappingFormat {
+            kind: "IDL",
+            example: "JupiterSwap:path/to/jupiter.json:JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+            identifier_label: "ProgramId",
+            format_hint: "Name:/path/to/file.json:ProgramId",
+        },
+        mapping_parser::parse_mapping,
         |id| {
             let bytes = bs58::decode(id)
                 .into_vec()

--- a/src/parser/cli-core/src/mapping_parser.rs
+++ b/src/parser/cli-core/src/mapping_parser.rs
@@ -40,13 +40,39 @@ pub fn parse_mapping(mapping_str: &str) -> Result<MappingComponents, String> {
     })
 }
 
+/// How one chain describes its mappings in the lines [`load_mappings`] logs.
+///
+/// Grouped rather than passed as four strings in a row: they are all
+/// human-readable labels of the same mapping format, and positionally they are
+/// interchangeable to the compiler.
+pub struct MappingFormat<'a> {
+    /// What is being loaded, e.g. `"ABI"`, `"IDL"`, `"token metadata"`.
+    pub kind: &'a str,
+    /// A complete, valid mapping string, printed when parsing fails.
+    pub example: &'a str,
+    /// What the trailing component is, e.g. `"ContractAddress"`, `"AssetId"`.
+    pub identifier_label: &'a str,
+    /// The shape a mapping takes, printed when parsing fails. Chain-specific
+    /// because the separator is: NEAR uses `@`, since a NEAR asset id carries
+    /// its own colons.
+    pub format_hint: &'a str,
+}
+
 /// Load JSON files from CLI mapping strings and build a `BTreeMap`.
 ///
-/// Each mapping string is parsed, the JSON file is loaded, and `build_value` converts
-/// the loaded JSON + components into the target value type. `build_value` returns a
-/// `Result` so post-load steps (e.g. signing) can reject the entry without producing a
-/// misleading "loaded" log line or inflating the success count. The identifier from
-/// the mapping becomes the map key.
+/// Each mapping string is parsed by `parse`, the JSON file is loaded, and
+/// `build_value` converts the loaded JSON + components into the target value
+/// type. `build_value` returns a `Result` so post-load steps (e.g. signing) can
+/// reject the entry without producing a misleading "loaded" log line or
+/// inflating the success count. The identifier from the mapping becomes the map
+/// key.
+///
+/// `parse` is supplied by the caller rather than fixed to [`parse_mapping`]:
+/// the separator differs by chain, and so does what a surplus component means.
+/// The colon-separated form splits from the right so a Windows path keeps its
+/// drive letter, while NEAR's `@`-separated form rejects a fourth component
+/// outright, since an asset id never contains `@` and a path that does would
+/// otherwise be silently mis-split.
 ///
 /// Returns the populated map and the count of newly-inserted entries: those
 /// loaded, accepted by `build_value`, and mapped to a fresh identifier. A
@@ -55,17 +81,22 @@ pub fn parse_mapping(mapping_str: &str) -> Result<MappingComponents, String> {
 /// accepted mappings.
 pub fn load_mappings<V>(
     mappings: &[String],
-    kind: &str,
-    example: &str,
-    identifier_label: &str,
+    format: &MappingFormat<'_>,
+    parse: impl Fn(&str) -> Result<MappingComponents, String>,
     validate_identifier: impl Fn(&str) -> Result<(), String>,
     build_value: impl Fn(&MappingComponents, String) -> Result<V, String>,
 ) -> (std::collections::BTreeMap<String, V>, usize) {
+    let MappingFormat {
+        kind,
+        example,
+        identifier_label,
+        format_hint,
+    } = *format;
     let mut map = std::collections::BTreeMap::new();
     let mut valid_count = 0;
 
     for mapping in mappings {
-        match parse_mapping(mapping) {
+        match parse(mapping) {
             Ok(components) => {
                 if let Err(e) = validate_identifier(&components.identifier) {
                     eprintln!(
@@ -108,7 +139,7 @@ pub fn load_mappings<V>(
             }
             Err(e) => {
                 eprintln!("Error parsing {kind} mapping: {e}");
-                eprintln!("Expected format: Name:/path/to/file.json:{identifier_label}");
+                eprintln!("Expected format: {format_hint}");
                 eprintln!("Example: {example}");
             }
         }
@@ -204,6 +235,18 @@ mod tests {
         assert!(parse_mapping("MyToken:/path/to/file.json:").is_err());
     }
 
+    /// The colon-separated format these tests exercise. Only `kind` and
+    /// `identifier_label` reach an assertion; the other two appear in the
+    /// parse-failure lines.
+    fn test_format<'a>(kind: &'a str, identifier_label: &'a str) -> MappingFormat<'a> {
+        MappingFormat {
+            kind,
+            example: "example",
+            identifier_label,
+            format_hint: "Name:/path/to/file.json:Identifier",
+        }
+    }
+
     fn write_temp_json(name: &str, content: &str) -> std::path::PathBuf {
         crate::test_utils::write_temp_json("vsp_tests", name, content)
     }
@@ -243,9 +286,8 @@ mod tests {
 
         let (map, count) = load_mappings(
             &mappings,
-            "ABI",
-            "example",
-            "Address",
+            &test_format("ABI", "Address"),
+            parse_mapping,
             |_| Ok(()),
             |_comp, json| Ok(json.to_uppercase()),
         );
@@ -261,9 +303,8 @@ mod tests {
         let mappings: Vec<String> = vec![];
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "example",
-            "Address",
+            &test_format("ABI", "Address"),
+            parse_mapping,
             |_| Ok(()),
             |_, json| Ok(json),
         );
@@ -276,9 +317,8 @@ mod tests {
         let mappings = vec!["bad-format-no-colons".to_string()];
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "example",
-            "Address",
+            &test_format("ABI", "Address"),
+            parse_mapping,
             |_| Ok(()),
             |_, json| Ok(json),
         );
@@ -291,9 +331,8 @@ mod tests {
         let mappings = vec!["Name:/nonexistent/file.json:0xAddr".to_string()];
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "example",
-            "Address",
+            &test_format("ABI", "Address"),
+            parse_mapping,
             |_| Ok(()),
             |_, json| Ok(json),
         );
@@ -312,9 +351,8 @@ mod tests {
 
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "example",
-            "Address",
+            &test_format("ABI", "Address"),
+            parse_mapping,
             |_| Ok(()),
             |_, json| Ok(json),
         );
@@ -330,9 +368,8 @@ mod tests {
 
         let (map, count) = load_mappings(
             &mappings,
-            "TEST",
-            "ex",
-            "Id",
+            &test_format("TEST", "Id"),
+            parse_mapping,
             |_| Ok(()),
             |components, json| {
                 Ok(format!(
@@ -359,9 +396,8 @@ mod tests {
 
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "ex",
-            "Addr",
+            &test_format("ABI", "Addr"),
+            parse_mapping,
             |_| Ok(()),
             |_, json| Ok(json),
         );
@@ -381,9 +417,8 @@ mod tests {
 
         let (map, count) = load_mappings::<String>(
             &mappings,
-            "ABI",
-            "ex",
-            "Addr",
+            &test_format("ABI", "Addr"),
+            parse_mapping,
             |_| Ok(()),
             |components, json| {
                 if components.identifier == "0xReject" {

--- a/src/parser/cli/Cargo.toml
+++ b/src/parser/cli/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 default = ["solana", "ethereum", "near", "tron", "diagnostics"]
 solana = ["dep:visualsign-solana"]
 ethereum = ["dep:visualsign-ethereum", "visualsign-ethereum/dev-signing"]
-near = ["dep:visualsign-near"]
+near = ["dep:visualsign-near", "visualsign-near/dev-signing"]
 tron = ["dep:visualsign-tron"]
 diagnostics = [
     "visualsign/diagnostics",

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -634,3 +634,80 @@ fn test_cli_solana_idl_invalid_file_still_parses() {
         serde_json::from_str(&output).expect("CLI output should be valid JSON");
     assert_eq!(json["Title"], "Solana Transaction")
 }
+
+/// A NEAR Intents envelope withdrawing an asset no compiled-in seed covers, so
+/// only the mapping can resolve its symbol.
+#[cfg(feature = "near")]
+const NEAR_UNSEEDED_INTENT: &str = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2100-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"cli-test-token.near","receiver_id":"bob.near","amount":"2500000"}]}"#;
+
+/// The whole CLI path for `--near-token-metadata-mappings`, through the real
+/// binary: the flag parses, the file loads, the entry is signed with the dev key,
+/// and the strict require-signed posture the NEAR plugin installs accepts it.
+///
+/// Reaching the built binary is the point. The plugin's own tests construct
+/// `NearArgs` directly, so they pass even if clap never exposes the flag or
+/// `parser_cli` stops enabling `visualsign-near/dev-signing` (which would leave
+/// every entry unsigned and dropped).
+#[test]
+#[cfg(feature = "near")]
+fn test_cli_near_token_metadata_mappings() {
+    let token_path = write_temp_json(
+        "vsp_cli_tests",
+        "near_token.json",
+        r#"{"symbol":"CLITOKEN","decimals":6}"#,
+    );
+    let mapping = format!(
+        "CliToken@{}@nep141:cli-test-token.near",
+        token_path.display()
+    );
+
+    let (stdout, stderr) = run_cli_full(&[
+        "decode",
+        "--chain",
+        "near",
+        "--output",
+        "json",
+        "--near-token-metadata-mappings",
+        &mapping,
+        "-t",
+        NEAR_UNSEEDED_INTENT,
+    ]);
+
+    assert!(
+        stderr.contains("Loaded token metadata 'CliToken'"),
+        "Expected per-mapping load line in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Successfully loaded 1/1 token metadata mappings"),
+        "Expected 1/1 token metadata mappings loaded, got: {stderr}"
+    );
+    assert!(
+        stdout.contains("CLITOKEN"),
+        "Expected the mapped symbol in the rendered amount, got: {stdout}"
+    );
+}
+
+/// An unreadable mapping file is reported and skipped, not fatal.
+#[test]
+#[cfg(feature = "near")]
+fn test_cli_near_token_metadata_invalid_file_still_parses() {
+    let (stdout, stderr) = run_cli_full(&[
+        "decode",
+        "--chain",
+        "near",
+        "--output",
+        "json",
+        "--near-token-metadata-mappings",
+        "Bad@/nonexistent/token.json@nep141:cli-test-token.near",
+        "-t",
+        NEAR_UNSEEDED_INTENT,
+    ]);
+
+    assert!(
+        stderr.contains("Successfully loaded 0/1 token metadata mappings"),
+        "Expected 0/1 token metadata mappings loaded, got: {stderr}"
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("CLI output should be valid JSON");
+    assert_eq!(json["Title"], "NEAR Intent");
+}


### PR DESCRIPTION
Adds the NEAR token-metadata flag `parser_cli` was missing, closing the CLI
parity gap with Ethereum (`--abi-json-mappings`) and Solana
(`--idl-json-mappings`).

Depends on #432 (`near-d-token-metadata`), which adds the
`ChainMetadata.near` token-metadata plumbing this flag feeds.

Based on #463 rather than #432 directly. That is merge sequencing, not a
dependency: #463 only adds seed entries and touches no file this PR does, and it
sits lower because it is ready to merge while this one is still in review.

## The gap

`NearPlugin::create_metadata` accepts only `--network`. An asset outside the
compiled-in seed table renders its raw base-unit amount tagged
`unresolved <asset id>`, with no way to supply a symbol and decimals locally:

```
└─ Amount: 250000000 (unresolved nep141:my-token.near)
```

## The flag

```bash
echo '{"symbol":"MYTOKEN","decimals":8}' > mytoken.json

parser_cli decode --chain near --output human \
  --near-token-metadata-mappings 'MyToken@mytoken.json@nep141:my-token.near' \
  -t '{"signer_id":"alice.near", ...}'
```

```
└─ Amount: 2.5 MYTOKEN
```

Two things differ from the sibling flags:

**`@` separates the fields, not `:`.** NEAR Intents asset ids embed their own
colons (`nep141:wrap.near`), so the shared colon-delimited
`mapping_parser::parse_mapping` would truncate the id at its first embedded
colon. `parse_near_mapping` splits on `@` into exactly three parts and takes
the asset id verbatim. A regression test pins this.

**Each entry is signed with the CLI dev key.** The NEAR plugin installs the
strict `MetadataTrustPolicy::RequireAllowlistedSigner` posture, carrying the
env-configured curator allowlist the decode path checks against, so an entry
the parser cannot attribute to a curator is dropped —
signing is what makes the flag do anything at all. This follows Ethereum's
fuller template (mappings + signing) rather than Solana's unsigned-only one.
Three pieces make that work:

- `sign_token_metadata_for_cli` is decoupled from the `dev-signing` cargo
  feature the same way `sign_abi_for_cli` is, so `cli_plugin` still compiles
  in a `cli-plugin`-without-`dev-signing` build (verified explicitly).
- `authorized_token_metadata_signers` enrolls that dev key under
  `dev-signing`/`cfg(test)`, matching `visualsign-ethereum`'s
  `authorized_abi_signers`. Without it the CLI would sign entries its own
  decode path then rejects as an untrusted signer.
- `parser_cli`'s `near` feature enables `visualsign-near/dev-signing`, as its
  `ethereum` feature already does for `visualsign-ethereum`.

`parser_app` enables neither `dev-signing` nor `diagnostics`, so the enclave
binary carries no key material and no allowlist entry trusting the dev key.
`make build` splits `parser_cli` out of the workspace build to keep Cargo
feature unification from crossing that line, and the release image builds from
`parser/app` alone; this PR extends the Makefile comment enumerating those
features, which no longer listed all of them.

CLI-signed entries are always NEAR-origin (`origin_chain` unset).
Ethereum/Solana-origin CLI signing is not wired up.

## Composition with `--network`

The flag composes with `--network` rather than replacing it. An invalid
network still errors before any mapping file is read, so a bad `--network`
can't be masked by a successful mapping load, and metadata is emitted when
either input yields something. `None` is returned only when neither does.

`--network` also decides what the signatures are valid for. A token-metadata
signature is scoped to one NEAR network, so entries are signed for the network
the parser will resolve for the same request: the flag's value when given,
otherwise the network the converter defaults to. `--network NEAR_TESTNET`
therefore produces testnet-scoped entries, and the same mappings signed for one
network do not verify against the other.

## Coverage

- 11 plugin-level cases: composition with `--network` in both directions, the
  colon-in-asset-id regression, duplicate asset ids, and partial failure
  (a malformed mapping and a missing file alongside a good one).
- One end-to-end case proving a CLI-signed entry resolves through the posture
  `register` installs. This is the gate that fails if the dev key leaves the
  allowlist or the signing domain tag drifts — assertions on
  `signature.is_some()` and on unsigned-entry refusal both pass in that case.
- Two `parser_cli` tests drive the real binary, so clap exposure and the
  `dev-signing` feature wiring are covered, not just direct `NearArgs`
  construction.
- Docs: the new flag in `docs/parser-cli.mdx` (whose `--chain` row also did
  not list `near`) and a worked example in `docs/chains/near.mdx`, both run
  against the built binary before being written down.

Known follow-up, raised in review and not addressed here:
`build_token_mappings_from_files` reimplements the load/parse/sign/dedupe/count/
log loop that `parser_cli_core::mapping_parser::load_mappings` provides for
Ethereum, rather than generalizing that helper to take a pluggable delimiter. A
fix to `load_mappings`'s dedup or logging will not reach this copy.

`make lint` and `make test` are green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


