### PR TITLE
feat(near): report refused token metadata as a diagnostic

### DIFF
--- a/docs/contributor-guides/lint-diagnostics.mdx
+++ b/docs/contributor-guides/lint-diagnostics.mdx
@@ -28,14 +28,24 @@ Three categories of issues:
 
 ## The `diagnostics` Cargo feature
 
-Diagnostic emission is gated behind a `diagnostics` Cargo feature on `visualsign`, `visualsign-solana`, and `parser_cli`. The default builds:
+Diagnostic emission is gated behind a `diagnostics` Cargo feature on `visualsign`, `visualsign-near`, `visualsign-solana`, and `parser_cli`. The default builds:
 
 - `parser_cli` enables `diagnostics` (default-on); CLI users see the full diagnostic detail.
 - `parser_app` and `parser_grpc_server` do **not** enable it. Their `SignablePayload` shape is stable for HSMs and wallets that derive a metadata digest from it.
 
 When the feature is off, `decode_instructions` returns `Result<Vec<AnnotatedPayloadField>, VisualSignError>` instead of a struct with separate diagnostic and error vectors. Empty `account_keys` and per-instruction visualizer errors abort the decode with `Err`; out-of-bounds indices flow through to the catch-all `unknown_program` visualizer with no diagnostic emission.
 
-Paired `*.diagnostics.expected` fixtures only matter when the feature is on. The CI Makefile splits invocations to defeat Cargo feature unification: `cargo {build,test,clippy} --workspace --exclude parser_cli` covers the OFF path; `-p parser_cli` and `-p visualsign-solana --features diagnostics --lib` cover the ON path.
+Paired `*.diagnostics.expected` fixtures only matter when the feature is on. The CI Makefile splits invocations to defeat Cargo feature unification: `cargo {build,test,clippy} --workspace --exclude parser_cli` covers the OFF path; `-p parser_cli`, `-p visualsign-near --features diagnostics --lib`, and `-p visualsign-solana --features diagnostics --lib` cover the ON path.
+
+## What each chain reports
+
+| Chain | Rules | Shape when the feature is off |
+|-------|-------|-------------------------------|
+| Solana | `transaction::*`, `decode::visualizer_error` — see the rule list below | The decode returns `Err` or drops the diagnostic; see the feature section above |
+| NEAR | `signature`, `account-binding`, `deadline`, `extraction`, `unverified-token-metadata`, `rejected-token-metadata` | A `Warning`-labelled text field carrying `rule: message` |
+| Ethereum | None yet | — |
+
+NEAR's rules are bare names rather than `domain::rule_name`, and every one of them is a *soft finding*: the intents still render, with the problem reported alongside the content it qualifies. Rather than dropping a diagnostic when the feature is off, the NEAR renderer falls back to a `Warning` text field with the same information, so a wallet on a production (diagnostics-off) build still sees the finding — it just isn't machine-readable. `rejected-token-metadata` is the reason caller-supplied token metadata the parser refused is visible to the signer at all; the refusal is otherwise only in an operator log.
 
 ## Adding a diagnostic to a chain parser
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,6 +46,8 @@ test: build
 	@# diagnostics ON: parser_cli + lib tests gated behind the feature.
 	cargo test -p parser_cli --all-targets
 	cargo test -p visualsign --features diagnostics --lib
+	cargo test -p parser_cli_core --features diagnostics --lib
+	cargo test -p visualsign-near --features diagnostics --lib
 	cargo test -p visualsign-solana --features diagnostics --lib
 
 # Solana preset sources, which `cargo fmt` cannot reach. `presets/mod.rs`
@@ -72,6 +74,8 @@ lint:
 	cargo clippy --workspace --exclude parser_cli --all-targets -- -D warnings
 	cargo clippy -p parser_cli --all-targets -- -D warnings
 	cargo clippy -p visualsign --features diagnostics --lib -- -D warnings
+	cargo clippy -p parser_cli_core --features diagnostics --lib -- -D warnings
+	cargo clippy -p visualsign-near --features diagnostics --lib -- -D warnings
 	cargo clippy -p visualsign-solana --features diagnostics --lib -- -D warnings
 
 .PHONY: narrow-build-check
@@ -140,9 +144,9 @@ feature-matrix-check:
 	@# $(PARSER_APP_CHAINS) above.
 	@#
 	@# Note: `diagnostics` propagates to the always-on `visualsign` core
-	@# crate, and weakly to `visualsign-solana` via the `?` syntax. The
-	@# non-solana + diagnostics combos still exercise the weak-dep path
-	@# (resolving to a no-op for visualsign-solana).
+	@# crate, and weakly to `visualsign-near`/`visualsign-solana` via the
+	@# `?` syntax. Combos without those chains still exercise the weak-dep
+	@# path (resolving to a no-op for the absent crate).
 	@#
 	@# Uses `cargo check` for the same reason as narrow-build-check
 	@# above -- the goal is compile-level regression detection, not

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,6 +46,8 @@ test: build
 	@# diagnostics ON: parser_cli + lib tests gated behind the feature.
 	cargo test -p parser_cli --all-targets
 	cargo test -p visualsign --features diagnostics --lib
+	cargo test -p parser_cli_core --features diagnostics --lib
+	cargo test -p visualsign-near --features diagnostics --lib
 	cargo test -p visualsign-solana --features diagnostics --lib
 
 .PHONY: fmt
@@ -58,6 +60,8 @@ lint:
 	cargo clippy --workspace --exclude parser_cli --all-targets -- -D warnings
 	cargo clippy -p parser_cli --all-targets -- -D warnings
 	cargo clippy -p visualsign --features diagnostics --lib -- -D warnings
+	cargo clippy -p parser_cli_core --features diagnostics --lib -- -D warnings
+	cargo clippy -p visualsign-near --features diagnostics --lib -- -D warnings
 	cargo clippy -p visualsign-solana --features diagnostics --lib -- -D warnings
 
 .PHONY: narrow-build-check
@@ -126,9 +130,9 @@ feature-matrix-check:
 	@# $(PARSER_APP_CHAINS) above.
 	@#
 	@# Note: `diagnostics` propagates to the always-on `visualsign` core
-	@# crate, and weakly to `visualsign-solana` via the `?` syntax. The
-	@# non-solana + diagnostics combos still exercise the weak-dep path
-	@# (resolving to a no-op for visualsign-solana).
+	@# crate, and weakly to `visualsign-near`/`visualsign-solana` via the
+	@# `?` syntax. Combos without those chains still exercise the weak-dep
+	@# path (resolving to a no-op for the absent crate).
 	@#
 	@# Uses `cargo check` for the same reason as narrow-build-check
 	@# above -- the goal is compile-level regression detection, not

--- a/src/chain_parsers/visualsign-near/src/actions.rs
+++ b/src/chain_parsers/visualsign-near/src/actions.rs
@@ -323,12 +323,13 @@ fn push_amount_and_notes(
     Ok(())
 }
 
-/// Strips everything except printable ASCII and spaces, so a transaction's
-/// JSON args (`memo`, `msg`, `method_name`) cannot smuggle a newline into a
-/// text field's fallback text. The core crate's charset validator permits
-/// `\n` as the wallet's documented multi-line separator, so an unfiltered
-/// attacker-controlled string can render as extra apparent confirmed fields
-/// on the signing screen.
+/// Strips everything except printable ASCII and spaces. Every untrusted string
+/// that becomes field text passes through here first -- a transaction's JSON
+/// args (`memo`, `msg`, `method_name`), and the caller-supplied asset ids a
+/// token-metadata refusal quotes back. The core crate's charset validator
+/// permits `\n` as the wallet's documented multi-line separator, so an
+/// unfiltered attacker-controlled string can render as extra apparent confirmed
+/// fields on the signing screen.
 ///
 /// A literal backslash is stripped too, on availability grounds rather than
 /// spoofing: it serializes as `\\`, so a backslash before `u`/`t`/`r`/`b`/`f`

--- a/src/chain_parsers/visualsign-near/src/actions.rs
+++ b/src/chain_parsers/visualsign-near/src/actions.rs
@@ -339,7 +339,7 @@ fn push_amount_and_notes(
 /// deliberately permits so field text can carry real embedded JSON -- and
 /// `ft_transfer_call`'s `msg` is exactly such a field, so deleting its quotes
 /// would strip structure a signer needs to read literally.
-fn charset_safe(text: &str) -> String {
+pub(crate) fn charset_safe(text: &str) -> String {
     text.chars()
         .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
         .collect()

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -36,11 +36,20 @@ use crate::tx::NearTransaction;
 /// present signature is checked against -- its own under the strict posture,
 /// the deployment's `authorized_token_metadata_signers` under the permissive
 /// one. A present signature is checked against that list under either.
+///
+/// Returns the registry plus a diagnostic field for every entry the extraction
+/// refused. Callers render those once per payload, not once per action.
 fn token_registry_for(
     options: &VisualSignOptions,
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
-) -> LayeredRegistry<NearTokenRegistry> {
+) -> Result<
+    (
+        LayeredRegistry<NearTokenRegistry>,
+        Vec<SignablePayloadField>,
+    ),
+    VisualSignError,
+> {
     // Identity decides whether an entry renders as verified and whether it may
     // override a curated seed, neither of which the posture itself answers, so a
     // list is needed under both postures. The strict posture carries its own;
@@ -59,18 +68,22 @@ fn token_registry_for(
         MetadataTrustPolicy::AcceptUnsigned => authorized_token_metadata_signers(),
         _ => &no_signers,
     };
-    let request = try_extract_token_metadata_from_chain_metadata(
+    let extraction = try_extract_token_metadata_from_chain_metadata(
         options.metadata.as_ref(),
         network,
         allowlist,
         trust_policy,
     );
-    match request {
+    let registry = match extraction.registry {
         Some(request) => {
             LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request)
         }
         None => LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
-    }
+    };
+    Ok((
+        registry,
+        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected)?,
+    ))
 }
 
 /// Resolve the network for one request: the `network_id` the request supplied,
@@ -215,6 +228,14 @@ impl NearVisualSignConverter {
             create_address_field("To", tx.receiver_id().as_str(), None, None, None, None)?
                 .signable_payload_field,
         );
+        // Built once for the whole transaction: the metadata is request-scoped,
+        // so a rejection is a property of the request, not of each action that
+        // consults the registry. Building it per action would repeat every
+        // rejection diagnostic for a multi-action transaction.
+        let (registry, rejection_diagnostics) =
+            token_registry_for(options, network, &self.trust_policy)?;
+        fields.extend(rejection_diagnostics);
+
         let total_actions = tx.actions().len();
         for action in tx.actions() {
             fields.extend(render_action(action, total_actions)?);
@@ -222,8 +243,8 @@ impl NearVisualSignConverter {
                 tx.receiver_id().as_str(),
                 action,
                 options,
+                &registry,
                 network,
-                &self.trust_policy,
             )?);
         }
 
@@ -260,8 +281,8 @@ fn decode_intents(
     receiver_id: &str,
     action: &Action,
     options: &VisualSignOptions,
+    registry: &LayeredRegistry<NearTokenRegistry>,
     network: NearNetwork,
-    trust_policy: &MetadataTrustPolicy,
 ) -> Result<Vec<SignablePayloadField>, VisualSignError> {
     if receiver_id != "intents.near" {
         return Ok(vec![]);
@@ -272,8 +293,7 @@ fn decode_intents(
     if fc.method_name != "execute_intents" {
         return Ok(vec![]);
     }
-    let registry = token_registry_for(options, network, trust_policy);
-    crate::presets::intents::try_decode_execute_intents(&fc.args, &registry, options, network)
+    crate::presets::intents::try_decode_execute_intents(&fc.args, registry, options, network)
         .map_err(intents_error)
 }
 
@@ -297,12 +317,13 @@ fn render_intent_envelope(
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    let registry = token_registry_for(options, network, trust_policy);
+    let (registry, rejection_diagnostics) = token_registry_for(options, network, trust_policy)?;
     // The resolved network is part of every token-metadata signed scope, so the
     // payload has to show which network that scope was checked against -- the
     // same field, for the same reason, as the on-chain path renders.
     let mut fields =
         vec![create_text_field("Network", network.display_name())?.signable_payload_field];
+    fields.extend(rejection_diagnostics);
     fields.extend(
         crate::presets::intents::try_render_single_intent(
             json.as_bytes(),
@@ -829,5 +850,172 @@ mod tests {
             assert!(json.contains(expected), "missing {expected}: {json}");
         }
         assert!(!json.contains("Standard"), "unexpected signature section");
+    }
+
+    /// Metadata the parser refuses must be visible in the payload, not just in
+    /// an operator log.
+    ///
+    /// The refusal here is the `require-signed` posture dropping an unsigned
+    /// entry. Without the diagnostic, the signer sees an amount in raw base
+    /// units against an `unresolved` asset id and has no way to tell that
+    /// metadata was supplied at all.
+    #[test]
+    fn rejected_metadata_surfaces_a_diagnostic_end_to_end() {
+        let asset_id = "nep141:rejected-token.near";
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        asset_id.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: r#"{"symbol":"DROPPED","decimals":6}"#.to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#.to_string();
+        let payload = NearVisualSignConverter::with_trust_policy(
+            MetadataTrustPolicy::RequireAllowlistedSigner(SignerAllowlist::new()),
+        )
+        .to_visual_sign_payload(NearTransaction::Intent(envelope), options)
+        .expect("convert");
+        let fields = &payload.payload.fields;
+
+        assert!(
+            fields.iter().any(
+                |f| crate::presets::intents::test_support::is_warning_diagnostic(
+                    f,
+                    "rejected-token-metadata"
+                )
+            ),
+            "a refused entry must report itself in the payload: {fields:?}"
+        );
+        let json = payload.payload.to_json().expect("json");
+        assert!(
+            !json.contains("DROPPED"),
+            "the refused entry must not resolve the symbol: {json}"
+        );
+        assert!(
+            json.contains(asset_id),
+            "the diagnostic must name the asset id it refused: {json}"
+        );
+    }
+
+    /// The rejection is a property of the request's metadata, so it reports
+    /// once even when several actions consult the registry.
+    #[test]
+    fn rejected_metadata_reports_once_for_a_multi_action_transaction() {
+        let asset_id = "nep141:rejected-token.near";
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let call = || {
+            Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_intents".to_string(),
+                args: serde_json::to_vec(&args).unwrap(),
+                gas: Gas::from_gas(30_000_000_000_000),
+                deposit: Balance::from_yoctonear(0),
+            }))
+        };
+        let txv0 = TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 1,
+            receiver_id: "intents.near".parse().unwrap(),
+            block_hash: CryptoHash::default(),
+            actions: vec![call(), call()],
+        };
+
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        asset_id.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: "not valid json".to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(NearTransaction::OnChain(Transaction::V0(txv0)), options)
+            .expect("convert");
+        let count = payload
+            .payload
+            .fields
+            .iter()
+            .filter(|f| {
+                crate::presets::intents::test_support::is_warning_diagnostic(
+                    f,
+                    "rejected-token-metadata",
+                )
+            })
+            .count();
+        assert_eq!(
+            count, 1,
+            "two actions must not each repeat the request's one rejection"
+        );
+    }
+
+    /// A caller-controlled asset id cannot smuggle a newline into the rejection
+    /// diagnostic, which would render as extra apparent fields on the signing
+    /// screen. Same class as the `memo`/`msg`/`method_name` filtering in
+    /// `actions.rs`, reached through a different field.
+    #[test]
+    fn rejected_metadata_diagnostic_strips_newlines_from_the_asset_id() {
+        let hostile = "nep141:x.near\nAmount: 1000000 NEAR";
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        hostile.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: "not valid json".to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(NearTransaction::Intent(envelope.to_string()), options)
+            .expect("convert");
+        let json = payload.payload.to_json().expect("json");
+
+        assert!(
+            json.contains("rejected-token-metadata"),
+            "the refusal must still be reported: {json}"
+        );
+        assert!(
+            !json.contains("x.near\\nAmount"),
+            "the newline must be filtered out of the rendered text: {json}"
+        );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use near_primitives::action::Action;
+use near_primitives::action::{Action, FunctionCallAction};
 use near_primitives::transaction::Transaction;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_address_field, create_text_field};
@@ -43,10 +43,7 @@ fn token_registry_for(
     options: &VisualSignOptions,
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
-) -> (
-    LayeredRegistry<NearTokenRegistry>,
-    Vec<SignablePayloadField>,
-) {
+) -> RequestTokenRegistry {
     // Identity decides whether an entry renders as verified and whether it may
     // override a curated seed, neither of which the posture itself answers, so a
     // list is needed under both postures. The strict posture carries its own;
@@ -61,14 +58,18 @@ fn token_registry_for(
     // Unreachable today -- `MetadataTrustPolicy` is `#[non_exhaustive]`, so a
     // third variant cannot be constructed from this crate, which is also why
     // this arm carries no test.
+    // NEAR compiles in no global token table -- `tokens::SEEDS` is consulted
+    // separately, after a registry miss -- so the global layer is empty
+    // whichever way this resolves.
+    let global = Arc::new(NearTokenRegistry::default());
     let allowlist = match trust_policy {
         MetadataTrustPolicy::RequireAllowlistedSigner(allow) => allow,
         MetadataTrustPolicy::AcceptUnsigned => authorized_token_metadata_signers(),
         unknown => {
-            return (
-                LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
-                unknown_posture_diagnostics(unknown),
-            );
+            return RequestTokenRegistry {
+                registry: LayeredRegistry::new(global),
+                diagnostics: unknown_posture_diagnostics(unknown),
+            };
         }
     };
     let extraction = try_extract_token_metadata_from_chain_metadata(
@@ -77,16 +78,39 @@ fn token_registry_for(
         allowlist,
         trust_policy,
     );
-    let registry = match extraction.registry {
-        Some(request) => {
-            LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request)
+    RequestTokenRegistry {
+        registry: match extraction.registry {
+            Some(request) => LayeredRegistry::with_request(global, request),
+            None => LayeredRegistry::new(global),
+        },
+        diagnostics: crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected),
+    }
+}
+
+/// The token registry one request resolves amounts against, and what building
+/// it refused.
+///
+/// Named rather than a bare pair: the two halves are used at different points
+/// -- the diagnostics go into the payload once, up front, while the registry is
+/// threaded through every action -- and a `(registry, fields)` tuple leaves
+/// nothing at the call site saying which is which.
+struct RequestTokenRegistry {
+    /// Seed lookups only: `tokens::SEEDS` still resolves what this misses.
+    registry: LayeredRegistry<NearTokenRegistry>,
+    /// One field per refused entry, rendered once per payload rather than once
+    /// per action that consults the registry.
+    diagnostics: Vec<SignablePayloadField>,
+}
+
+impl RequestTokenRegistry {
+    /// No caller-supplied metadata is in play: an empty request layer, and no
+    /// refusal to report because nothing was examined.
+    fn empty() -> Self {
+        Self {
+            registry: LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
+            diagnostics: vec![],
         }
-        None => LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
-    };
-    (
-        registry,
-        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected),
-    )
+    }
 }
 
 /// Refuse the whole request-scoped metadata blob under a trust posture this
@@ -248,13 +272,23 @@ impl NearVisualSignConverter {
             create_address_field("To", tx.receiver_id().as_str(), None, None, None, None)?
                 .signable_payload_field,
         );
-        // Built once for the whole transaction: the metadata is request-scoped,
-        // so a rejection is a property of the request, not of each action that
-        // consults the registry. Building it per action would repeat every
-        // rejection diagnostic for a multi-action transaction.
-        let (registry, rejection_diagnostics) =
-            token_registry_for(options, network, &self.trust_policy);
-        fields.extend(rejection_diagnostics);
+        // Built once for the whole transaction, and only when an action will
+        // consult it. Once, because the metadata is request-scoped: a rejection
+        // is a property of the request, not of each action, and building per
+        // action would repeat every diagnostic for a multi-action transaction.
+        // Only when applicable, because metadata nothing reads cannot mislead
+        // the signer -- a rejection diagnostic on a plain transfer would report
+        // a refusal that changed nothing about what is rendered.
+        let tokens = if tx
+            .actions()
+            .iter()
+            .any(|action| token_metadata_consumer(tx.receiver_id().as_str(), action).is_some())
+        {
+            token_registry_for(options, network, &self.trust_policy)
+        } else {
+            RequestTokenRegistry::empty()
+        };
+        fields.extend(tokens.diagnostics);
 
         let total_actions = tx.actions().len();
         for action in tx.actions() {
@@ -263,7 +297,7 @@ impl NearVisualSignConverter {
                 tx.receiver_id().as_str(),
                 action,
                 options,
-                &registry,
+                &tokens.registry,
                 network,
             )?);
         }
@@ -293,6 +327,32 @@ impl VisualSignConverterFromString<NearTransaction> for NearVisualSignConverter 
     }
 }
 
+/// The intents verifier contract, and the method on it that carries a signed
+/// intent batch.
+const INTENTS_RECEIVER: &str = "intents.near";
+const EXECUTE_INTENTS_METHOD: &str = "execute_intents";
+
+/// The call on this action that a decoder resolving token amounts will handle,
+/// or `None` when nothing in the action loop consults the request-scoped token
+/// registry.
+///
+/// This is the one place that answers "is caller-supplied token metadata
+/// applicable here?". [`NearVisualSignConverter::render_on_chain`] gates
+/// building the registry on it and [`decode_intents`] dispatches on it, so the
+/// gate can never skip a call the decoder would have resolved amounts for --
+/// which would leave the signer raw base units and no diagnostic explaining
+/// why. A preset that resolves amounts from the registry belongs here.
+fn token_metadata_consumer<'a>(
+    receiver_id: &str,
+    action: &'a Action,
+) -> Option<&'a FunctionCallAction> {
+    let Action::FunctionCall(fc) = action else {
+        return None;
+    };
+    (receiver_id == INTENTS_RECEIVER && fc.method_name == EXECUTE_INTENTS_METHOD)
+        .then(|| fc.as_ref())
+}
+
 /// Decode an `execute_intents` call to `intents.near` and render the signed
 /// intent batch. Any other action or receiver yields no extra fields. A
 /// decode failure surfaces as a conversion error rather than silently
@@ -304,15 +364,9 @@ fn decode_intents(
     registry: &LayeredRegistry<NearTokenRegistry>,
     network: NearNetwork,
 ) -> Result<Vec<SignablePayloadField>, VisualSignError> {
-    if receiver_id != "intents.near" {
-        return Ok(vec![]);
-    }
-    let Action::FunctionCall(fc) = action else {
+    let Some(fc) = token_metadata_consumer(receiver_id, action) else {
         return Ok(vec![]);
     };
-    if fc.method_name != "execute_intents" {
-        return Ok(vec![]);
-    }
     crate::presets::intents::try_decode_execute_intents(&fc.args, registry, options, network)
         .map_err(intents_error)
 }
@@ -337,17 +391,20 @@ fn render_intent_envelope(
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    let (registry, rejection_diagnostics) = token_registry_for(options, network, trust_policy);
+    // Always built on this path: the payload is an intents envelope, so
+    // caller-supplied token metadata is applicable by construction -- the
+    // on-chain path's applicability gate has nothing to decide here.
+    let tokens = token_registry_for(options, network, trust_policy);
     // The resolved network is part of every token-metadata signed scope, so the
     // payload has to show which network that scope was checked against -- the
     // same field, for the same reason, as the on-chain path renders.
     let mut fields =
         vec![create_text_field("Network", network.display_name())?.signable_payload_field];
-    fields.extend(rejection_diagnostics);
+    fields.extend(tokens.diagnostics);
     fields.extend(
         crate::presets::intents::try_render_single_intent(
             json.as_bytes(),
-            &registry,
+            &tokens.registry,
             options,
             network,
         )
@@ -407,6 +464,60 @@ mod tests {
             block_hash: CryptoHash::default(),
             actions,
         }))
+    }
+
+    /// A signed single-intent `execute_intents` call: the action shape the
+    /// token registry exists for.
+    fn execute_intents_action() -> Action {
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: EXECUTE_INTENTS_METHOD.to_string(),
+            args: serde_json::to_vec(&args).unwrap(),
+            gas: Gas::from_gas(30_000_000_000_000),
+            deposit: Balance::from_yoctonear(0),
+        }))
+    }
+
+    /// One caller-supplied token mapping, keyed under `asset_id`, carrying
+    /// `value` as its metadata JSON.
+    fn options_with_token_mapping(asset_id: &str, value: &str) -> VisualSignOptions {
+        VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        asset_id.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: value.to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn rejection_diagnostic_count(payload: &SignablePayload) -> usize {
+        payload
+            .fields
+            .iter()
+            .filter(|f| {
+                crate::presets::intents::test_support::is_warning_diagnostic(
+                    f,
+                    "rejected-token-metadata",
+                )
+            })
+            .count()
     }
 
     #[test]
@@ -882,24 +993,7 @@ mod tests {
     #[test]
     fn rejected_metadata_surfaces_a_diagnostic_end_to_end() {
         let asset_id = "nep141:rejected-token.near";
-        let options = VisualSignOptions {
-            metadata: Some(ChainMetadata {
-                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
-                    network_id: Some("NEAR_MAINNET".to_string()),
-                    token_mappings: [(
-                        asset_id.to_string(),
-                        generated::parser::TokenMetadataEntry {
-                            value: r#"{"symbol":"DROPPED","decimals":6}"#.to_string(),
-                            signature: None,
-                            origin_chain: None,
-                        },
-                    )]
-                    .into_iter()
-                    .collect(),
-                })),
-            }),
-            ..Default::default()
-        };
+        let options = options_with_token_mapping(asset_id, r#"{"symbol":"DROPPED","decimals":6}"#);
 
         let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#.to_string();
         let payload = NearVisualSignConverter::with_trust_policy(
@@ -935,66 +1029,23 @@ mod tests {
     /// once even when several actions consult the registry.
     #[test]
     fn rejected_metadata_reports_once_for_a_multi_action_transaction() {
-        let asset_id = "nep141:rejected-token.near";
-        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
-        let args = serde_json::json!({"signed":[{
-            "standard": "raw_ed25519",
-            "payload": inner,
-            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
-            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
-        }]});
-        let call = || {
-            Action::FunctionCall(Box::new(FunctionCallAction {
-                method_name: "execute_intents".to_string(),
-                args: serde_json::to_vec(&args).unwrap(),
-                gas: Gas::from_gas(30_000_000_000_000),
-                deposit: Balance::from_yoctonear(0),
-            }))
-        };
         let txv0 = TransactionV0 {
             signer_id: "alice.near".parse().unwrap(),
             public_key: PublicKey::empty(KeyType::ED25519),
             nonce: 1,
-            receiver_id: "intents.near".parse().unwrap(),
+            receiver_id: INTENTS_RECEIVER.parse().unwrap(),
             block_hash: CryptoHash::default(),
-            actions: vec![call(), call()],
+            actions: vec![execute_intents_action(), execute_intents_action()],
         };
 
-        let options = VisualSignOptions {
-            metadata: Some(ChainMetadata {
-                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
-                    network_id: Some("NEAR_MAINNET".to_string()),
-                    token_mappings: [(
-                        asset_id.to_string(),
-                        generated::parser::TokenMetadataEntry {
-                            value: "not valid json".to_string(),
-                            signature: None,
-                            origin_chain: None,
-                        },
-                    )]
-                    .into_iter()
-                    .collect(),
-                })),
-            }),
-            ..Default::default()
-        };
+        let options = options_with_token_mapping("nep141:rejected-token.near", "not valid json");
 
         let payload = NearVisualSignConverter::new()
             .to_visual_sign_payload(NearTransaction::OnChain(Transaction::V0(txv0)), options)
             .expect("convert");
-        let count = payload
-            .payload
-            .fields
-            .iter()
-            .filter(|f| {
-                crate::presets::intents::test_support::is_warning_diagnostic(
-                    f,
-                    "rejected-token-metadata",
-                )
-            })
-            .count();
         assert_eq!(
-            count, 1,
+            rejection_diagnostic_count(&payload.payload),
+            1,
             "two actions must not each repeat the request's one rejection"
         );
     }
@@ -1006,24 +1057,7 @@ mod tests {
     #[test]
     fn rejected_metadata_diagnostic_strips_newlines_from_the_asset_id() {
         let hostile = "nep141:x.near\nAmount: 1000000 NEAR";
-        let options = VisualSignOptions {
-            metadata: Some(ChainMetadata {
-                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
-                    network_id: Some("NEAR_MAINNET".to_string()),
-                    token_mappings: [(
-                        hostile.to_string(),
-                        generated::parser::TokenMetadataEntry {
-                            value: "not valid json".to_string(),
-                            signature: None,
-                            origin_chain: None,
-                        },
-                    )]
-                    .into_iter()
-                    .collect(),
-                })),
-            }),
-            ..Default::default()
-        };
+        let options = options_with_token_mapping(hostile, "not valid json");
 
         let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
         let payload = NearVisualSignConverter::new()
@@ -1038,6 +1072,68 @@ mod tests {
         assert!(
             !json.contains("x.near\\nAmount"),
             "the newline must be filtered out of the rendered text: {json}"
+        );
+    }
+
+    /// A transaction no decoder resolves token amounts for must not carry a
+    /// refusal diagnostic: the metadata was never consulted, so nothing about
+    /// what the signer sees changed, and a caveat about an invisible refusal is
+    /// noise on every plain transfer a wallet happens to attach mappings to.
+    #[test]
+    fn a_transfer_reports_no_refusal_for_metadata_no_action_consults() {
+        let options = options_with_token_mapping("nep141:rejected-token.near", "not valid json");
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(near_tx(vec![transfer()]), options)
+            .expect("convert");
+        assert_eq!(
+            rejection_diagnostic_count(&payload.payload),
+            0,
+            "a plain transfer consults no token metadata, so it has no refusal to report: {:?}",
+            payload.payload.fields
+        );
+    }
+
+    /// The gate that decides whether to build the token registry and the
+    /// dispatch that consumes it must agree. If an action can render intent
+    /// fields while the gate reads it as inapplicable, the decoder resolves
+    /// amounts against an empty registry and the signer gets raw base units
+    /// with no diagnostic saying why. Asserted over every combination rather
+    /// than by inspection, so a preset wired into `decode_intents` alone fails
+    /// here.
+    #[test]
+    fn every_action_that_renders_intents_is_one_the_gate_recognizes() {
+        let other_method = Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: "ft_transfer".to_string(),
+            args: b"{}".to_vec(),
+            gas: Gas::from_gas(30_000_000_000_000),
+            deposit: Balance::from_yoctonear(0),
+        }));
+        let registry = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
+        for receiver in [INTENTS_RECEIVER, "bob.near"] {
+            for action in [execute_intents_action(), other_method.clone(), transfer()] {
+                let rendered = decode_intents(
+                    receiver,
+                    &action,
+                    &VisualSignOptions::default(),
+                    &registry,
+                    NearNetwork::Mainnet,
+                )
+                .expect("decode");
+                if !rendered.is_empty() {
+                    assert!(
+                        token_metadata_consumer(receiver, &action).is_some(),
+                        "{receiver} renders {} intent fields the gate does not recognize, so the \
+                         registry would be skipped: {action:?}",
+                        rendered.len()
+                    );
+                }
+            }
+        }
+        // The invariant holds vacuously if nothing renders, so pin the one
+        // combination that must.
+        assert!(
+            token_metadata_consumer(INTENTS_RECEIVER, &execute_intents_action()).is_some(),
+            "an execute_intents call to the verifier is the gate's whole purpose"
         );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -7,7 +7,7 @@ use near_primitives::transaction::Transaction;
 use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_address_field, create_text_field};
 use visualsign::registry::LayeredRegistry;
-use visualsign::signing::{MetadataTrustPolicy, SignerAllowlist};
+use visualsign::signing::MetadataTrustPolicy;
 use visualsign::vsptrait::{
     ConversionResult, VisualSignConverter, VisualSignConverterFromString, VisualSignOptions,
 };
@@ -16,7 +16,7 @@ use visualsign::{SignablePayload, SignablePayloadField};
 use crate::actions::render_action;
 use crate::networks::{NearNetwork, extract_network_from_metadata, network_mismatch};
 use crate::presets::intents::{
-    NearIntentsError, NearTokenRegistry, authorized_token_metadata_signers,
+    NearIntentsError, NearTokenRegistry, RejectedTokenMetadata, authorized_token_metadata_signers,
     try_extract_token_metadata_from_chain_metadata,
 };
 use crate::tx::NearTransaction;
@@ -53,17 +53,23 @@ fn token_registry_for(
     // the permissive one has no payload to carry, so the deployment's
     // env-configured curators stand in.
     //
-    // A posture added upstream after this build recognizes nobody rather than
-    // guessing which of the two it resembles: an empty allowlist leaves every
-    // signature unrecognized, so entries fall back to gap-fill-only terms.
+    // A posture added upstream after this build refuses the request-scoped
+    // metadata outright rather than guessing which of the two it resembles, and
+    // says so: the same fail-closed outcome an empty allowlist would reach, but
+    // stated rather than emergent, so the signer is not left with a silently
+    // thinner payload. Amounts then resolve from `tokens::SEEDS` alone.
     // Unreachable today -- `MetadataTrustPolicy` is `#[non_exhaustive]`, so a
     // third variant cannot be constructed from this crate, which is also why
     // this arm carries no test.
-    let no_signers = SignerAllowlist::new();
     let allowlist = match trust_policy {
         MetadataTrustPolicy::RequireAllowlistedSigner(allow) => allow,
         MetadataTrustPolicy::AcceptUnsigned => authorized_token_metadata_signers(),
-        _ => &no_signers,
+        unknown => {
+            return (
+                LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
+                unknown_posture_diagnostics(unknown),
+            );
+        }
     };
     let extraction = try_extract_token_metadata_from_chain_metadata(
         options.metadata.as_ref(),
@@ -81,6 +87,23 @@ fn token_registry_for(
         registry,
         crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected),
     )
+}
+
+/// Refuse the whole request-scoped metadata blob under a trust posture this
+/// build does not recognize, reported as one refusal naming the posture.
+///
+/// One diagnostic rather than one per entry: the posture is a property of the
+/// deployment, not of any entry, and the reason is identical for every one. The
+/// posture's `Display` is what an operator sees in the startup log, so quoting
+/// it here lets the two be matched up.
+fn unknown_posture_diagnostics(policy: &MetadataTrustPolicy) -> Vec<SignablePayloadField> {
+    crate::presets::intents::rejected_metadata_diagnostics(&[RejectedTokenMetadata {
+        asset_id: "all assets".to_string(),
+        reason: format!(
+            "this build does not recognize the deployment's trust posture ({policy}), so no \
+             caller-supplied token metadata was used"
+        ),
+    }])
 }
 
 /// Resolve the network for one request: the `network_id` the request supplied,

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -43,13 +43,10 @@ fn token_registry_for(
     options: &VisualSignOptions,
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
-) -> Result<
-    (
-        LayeredRegistry<NearTokenRegistry>,
-        Vec<SignablePayloadField>,
-    ),
-    VisualSignError,
-> {
+) -> (
+    LayeredRegistry<NearTokenRegistry>,
+    Vec<SignablePayloadField>,
+) {
     // Identity decides whether an entry renders as verified and whether it may
     // override a curated seed, neither of which the posture itself answers, so a
     // list is needed under both postures. The strict posture carries its own;
@@ -80,10 +77,10 @@ fn token_registry_for(
         }
         None => LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
     };
-    Ok((
+    (
         registry,
-        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected)?,
-    ))
+        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected),
+    )
 }
 
 /// Resolve the network for one request: the `network_id` the request supplied,
@@ -233,7 +230,7 @@ impl NearVisualSignConverter {
         // consults the registry. Building it per action would repeat every
         // rejection diagnostic for a multi-action transaction.
         let (registry, rejection_diagnostics) =
-            token_registry_for(options, network, &self.trust_policy)?;
+            token_registry_for(options, network, &self.trust_policy);
         fields.extend(rejection_diagnostics);
 
         let total_actions = tx.actions().len();
@@ -317,7 +314,7 @@ fn render_intent_envelope(
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    let (registry, rejection_diagnostics) = token_registry_for(options, network, trust_policy)?;
+    let (registry, rejection_diagnostics) = token_registry_for(options, network, trust_policy);
     // The resolved network is part of every token-metadata signed scope, so the
     // payload has to show which network that scope was checked against -- the
     // same field, for the same reason, as the on-chain path renders.
@@ -883,7 +880,9 @@ mod tests {
 
         let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#.to_string();
         let payload = NearVisualSignConverter::with_trust_policy(
-            MetadataTrustPolicy::RequireAllowlistedSigner(SignerAllowlist::new()),
+            MetadataTrustPolicy::RequireAllowlistedSigner(
+                visualsign::signing::SignerAllowlist::new(),
+            ),
         )
         .to_visual_sign_payload(NearTransaction::Intent(envelope), options)
         .expect("convert");

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -391,10 +391,19 @@ fn render_intent_envelope(
     network: NearNetwork,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    // Always built on this path: the payload is an intents envelope, so
-    // caller-supplied token metadata is applicable by construction -- the
-    // on-chain path's applicability gate has nothing to decide here.
-    let tokens = token_registry_for(options, network, trust_policy);
+    // Built only when the envelope's decoded intents include a kind that
+    // reads it -- the same reasoning as render_on_chain's gate via
+    // token_metadata_consumer, applied here to the intent kinds inside the
+    // envelope rather than to the wrapping action. A plain native_withdraw
+    // (or add_public_key, storage_deposit, ...) carrying unrelated or
+    // malformed caller-supplied token metadata must not get a rejection
+    // diagnostic for metadata nothing here reads.
+    let tokens = if crate::presets::intents::single_intent_consumes_token_registry(json.as_bytes())
+    {
+        token_registry_for(options, network, trust_policy)
+    } else {
+        RequestTokenRegistry::empty()
+    };
     // The resolved network is part of every token-metadata signed scope, so the
     // payload has to show which network that scope was checked against -- the
     // same field, for the same reason, as the on-chain path renders.
@@ -1023,6 +1032,78 @@ mod tests {
             json.contains(asset_id),
             "the diagnostic must name the asset id it refused: {json}"
         );
+    }
+
+    /// A standalone intent envelope whose only intent never reads the token
+    /// registry (`native_withdraw` moves NEAR itself, not a NEP-141) must not
+    /// get a rejection diagnostic for unrelated or malformed caller-supplied
+    /// token metadata: nothing here consults it, so a refusal would describe a
+    /// problem the rendered payload never had.
+    #[test]
+    fn native_withdraw_envelope_reports_no_refusal_for_metadata_it_never_reads() {
+        let options = options_with_token_mapping("nep141:rejected-token.near", "not valid json");
+        let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"native_withdraw","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
+
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(NearTransaction::Intent(envelope.to_string()), options)
+            .expect("convert");
+        assert_eq!(
+            rejection_diagnostic_count(&payload.payload),
+            0,
+            "native_withdraw consults no token metadata, so it has no refusal to report: {:?}",
+            payload.payload.fields
+        );
+    }
+
+    /// The gate that decides whether to build the token registry for a
+    /// standalone envelope and the per-intent dispatch that consumes it must
+    /// agree, the same invariant `every_action_that_renders_intents_is_one_the_gate_recognizes`
+    /// checks for the on-chain path. Asserted over every `Intent` kind
+    /// `render_intent` handles, so a kind wired to read the registry there
+    /// without being added to the gate fails here.
+    #[test]
+    fn every_intent_kind_the_registry_gate_recognizes_matches_render_intent() {
+        use crate::presets::intents::single_intent_consumes_token_registry;
+
+        let envelope_with = |intent_json: &str| -> String {
+            format!(
+                r#"{{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{intent_json}]}}"#
+            )
+        };
+        let cases: &[(&str, bool)] = &[
+            (
+                r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1"}"#,
+                true,
+            ),
+            (
+                r#"{"intent":"token_diff","diff":{"nep141:wrap.near":"-1","nep141:usdc.near":"1"}}"#,
+                true,
+            ),
+            (
+                r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep141:wrap.near":"1"}}"#,
+                true,
+            ),
+            (
+                r#"{"intent":"native_withdraw","receiver_id":"bob.near","amount":"1"}"#,
+                false,
+            ),
+            (
+                r#"{"intent":"add_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#,
+                false,
+            ),
+            (
+                r#"{"intent":"storage_deposit","contract_id":"wrap.near","deposit_for_account_id":"bob.near","amount":"1"}"#,
+                false,
+            ),
+        ];
+        for (intent_json, expected) in cases {
+            let json = envelope_with(intent_json);
+            assert_eq!(
+                single_intent_consumes_token_registry(json.as_bytes()),
+                *expected,
+                "gate disagrees with render_intent for {intent_json}"
+            );
+        }
     }
 
     /// The rejection is a property of the request's metadata, so it reports

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -41,13 +41,10 @@ use crate::tx::NearTransaction;
 fn token_registry_for(
     options: &VisualSignOptions,
     trust_policy: &MetadataTrustPolicy,
-) -> Result<
-    (
-        LayeredRegistry<NearTokenRegistry>,
-        Vec<SignablePayloadField>,
-    ),
-    VisualSignError,
-> {
+) -> (
+    LayeredRegistry<NearTokenRegistry>,
+    Vec<SignablePayloadField>,
+) {
     let extraction = try_extract_token_metadata_from_chain_metadata(
         options.metadata.as_ref(),
         authorized_token_metadata_signers(),
@@ -59,10 +56,10 @@ fn token_registry_for(
         }
         None => LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
     };
-    Ok((
+    (
         registry,
-        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected)?,
-    ))
+        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected),
+    )
 }
 
 /// Payload version emitted for NEAR payloads.
@@ -175,7 +172,7 @@ impl NearVisualSignConverter {
         // so a rejection is a property of the request, not of each action that
         // consults the registry. Building it per action would repeat every
         // rejection diagnostic for a multi-action transaction.
-        let (registry, rejection_diagnostics) = token_registry_for(options, &self.trust_policy)?;
+        let (registry, rejection_diagnostics) = token_registry_for(options, &self.trust_policy);
         fields.extend(rejection_diagnostics);
 
         let total_actions = tx.actions().len();
@@ -244,7 +241,7 @@ fn render_intent_envelope(
     options: &VisualSignOptions,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    let (registry, rejection_diagnostics) = token_registry_for(options, trust_policy)?;
+    let (registry, rejection_diagnostics) = token_registry_for(options, trust_policy);
     let mut fields = rejection_diagnostics;
     fields.extend(
         crate::presets::intents::try_render_single_intent(json.as_bytes(), &registry, options)

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -35,21 +35,34 @@ use crate::tx::NearTransaction;
 /// path, already dispatches identity checks per origin chain, so the
 /// allowlist `MetadataTrustPolicy::RequireAllowlistedSigner` carries is not
 /// itself consulted here.
+///
+/// Returns the registry plus a diagnostic field for every entry the extraction
+/// refused. Callers render those once per payload, not once per action.
 fn token_registry_for(
     options: &VisualSignOptions,
     trust_policy: &MetadataTrustPolicy,
-) -> LayeredRegistry<NearTokenRegistry> {
-    let request = try_extract_token_metadata_from_chain_metadata(
+) -> Result<
+    (
+        LayeredRegistry<NearTokenRegistry>,
+        Vec<SignablePayloadField>,
+    ),
+    VisualSignError,
+> {
+    let extraction = try_extract_token_metadata_from_chain_metadata(
         options.metadata.as_ref(),
         authorized_token_metadata_signers(),
         trust_policy,
     );
-    match request {
+    let registry = match extraction.registry {
         Some(request) => {
             LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request)
         }
         None => LayeredRegistry::new(Arc::new(NearTokenRegistry::default())),
-    }
+    };
+    Ok((
+        registry,
+        crate::presets::intents::rejected_metadata_diagnostics(&extraction.rejected)?,
+    ))
 }
 
 /// Payload version emitted for NEAR payloads.
@@ -158,6 +171,13 @@ impl NearVisualSignConverter {
             create_address_field("To", tx.receiver_id().as_str(), None, None, None, None)?
                 .signable_payload_field,
         );
+        // Built once for the whole transaction: the metadata is request-scoped,
+        // so a rejection is a property of the request, not of each action that
+        // consults the registry. Building it per action would repeat every
+        // rejection diagnostic for a multi-action transaction.
+        let (registry, rejection_diagnostics) = token_registry_for(options, &self.trust_policy)?;
+        fields.extend(rejection_diagnostics);
+
         let total_actions = tx.actions().len();
         for action in tx.actions() {
             fields.extend(render_action(action, total_actions)?);
@@ -165,7 +185,7 @@ impl NearVisualSignConverter {
                 tx.receiver_id().as_str(),
                 action,
                 options,
-                &self.trust_policy,
+                &registry,
             )?);
         }
 
@@ -202,7 +222,7 @@ fn decode_intents(
     receiver_id: &str,
     action: &Action,
     options: &VisualSignOptions,
-    trust_policy: &MetadataTrustPolicy,
+    registry: &LayeredRegistry<NearTokenRegistry>,
 ) -> Result<Vec<SignablePayloadField>, VisualSignError> {
     if receiver_id != "intents.near" {
         return Ok(vec![]);
@@ -213,8 +233,7 @@ fn decode_intents(
     if fc.method_name != "execute_intents" {
         return Ok(vec![]);
     }
-    let registry = token_registry_for(options, trust_policy);
-    crate::presets::intents::try_decode_execute_intents(&fc.args, &registry, options)
+    crate::presets::intents::try_decode_execute_intents(&fc.args, registry, options)
         .map_err(|e| VisualSignError::ConversionError(e.to_string()))
 }
 
@@ -225,10 +244,12 @@ fn render_intent_envelope(
     options: &VisualSignOptions,
     trust_policy: &MetadataTrustPolicy,
 ) -> Result<ConversionResult, VisualSignError> {
-    let registry = token_registry_for(options, trust_policy);
-    let fields =
+    let (registry, rejection_diagnostics) = token_registry_for(options, trust_policy)?;
+    let mut fields = rejection_diagnostics;
+    fields.extend(
         crate::presets::intents::try_render_single_intent(json.as_bytes(), &registry, options)
-            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?;
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
+    );
     Ok(ConversionResult::new(SignablePayload::new(
         PAYLOAD_VERSION,
         "NEAR Intent".to_string(),
@@ -557,6 +578,175 @@ mod tests {
         assert!(
             json.contains("unverified-token-metadata"),
             "unsigned gap-fill entry must carry its provenance into the render: {json}"
+        );
+    }
+
+    /// Metadata the parser refuses must be visible in the payload, not just in
+    /// an operator log.
+    ///
+    /// The refusal here is the `require-signed` posture dropping an unsigned
+    /// entry. Without the diagnostic, the signer sees an amount in raw base
+    /// units against an `unresolved` asset id and has no way to tell that
+    /// metadata was supplied at all.
+    #[test]
+    fn rejected_metadata_surfaces_a_diagnostic_end_to_end() {
+        let asset_id = "nep141:rejected-token.near";
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        asset_id.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: r#"{"symbol":"DROPPED","decimals":6}"#.to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#.to_string();
+        let payload = NearVisualSignConverter::with_trust_policy(
+            MetadataTrustPolicy::RequireAllowlistedSigner(
+                visualsign::signing::SignerAllowlist::new(),
+            ),
+        )
+        .to_visual_sign_payload(NearTransaction::Intent(envelope), options)
+        .expect("convert");
+        let fields = &payload.payload.fields;
+
+        assert!(
+            fields.iter().any(
+                |f| crate::presets::intents::test_support::is_warning_diagnostic(
+                    f,
+                    "rejected-token-metadata"
+                )
+            ),
+            "a refused entry must report itself in the payload: {fields:?}"
+        );
+        let json = payload.payload.to_json().expect("json");
+        assert!(
+            !json.contains("DROPPED"),
+            "the refused entry must not resolve the symbol: {json}"
+        );
+        assert!(
+            json.contains(asset_id),
+            "the diagnostic must name the asset id it refused: {json}"
+        );
+    }
+
+    /// The rejection is a property of the request's metadata, so it reports
+    /// once even when several actions consult the registry.
+    #[test]
+    fn rejected_metadata_reports_once_for_a_multi_action_transaction() {
+        let asset_id = "nep141:rejected-token.near";
+        let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"rejected-token.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
+        let args = serde_json::json!({"signed":[{
+            "standard": "raw_ed25519",
+            "payload": inner,
+            "public_key": "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN",
+            "signature": "ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"
+        }]});
+        let call = || {
+            Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_intents".to_string(),
+                args: serde_json::to_vec(&args).unwrap(),
+                gas: Gas::from_gas(30_000_000_000_000),
+                deposit: Balance::from_yoctonear(0),
+            }))
+        };
+        let txv0 = TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            nonce: 1,
+            receiver_id: "intents.near".parse().unwrap(),
+            block_hash: CryptoHash::default(),
+            actions: vec![call(), call()],
+        };
+
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        asset_id.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: "not valid json".to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(NearTransaction::OnChain(Transaction::V0(txv0)), options)
+            .expect("convert");
+        let count = payload
+            .payload
+            .fields
+            .iter()
+            .filter(|f| {
+                crate::presets::intents::test_support::is_warning_diagnostic(
+                    f,
+                    "rejected-token-metadata",
+                )
+            })
+            .count();
+        assert_eq!(
+            count, 1,
+            "two actions must not each repeat the request's one rejection"
+        );
+    }
+
+    /// A caller-controlled asset id cannot smuggle a newline into the rejection
+    /// diagnostic, which would render as extra apparent fields on the signing
+    /// screen. Same class as the `memo`/`msg`/`method_name` filtering in
+    /// `actions.rs`, reached through a different field.
+    #[test]
+    fn rejected_metadata_diagnostic_strips_newlines_from_the_asset_id() {
+        let hostile = "nep141:x.near\nAmount: 1000000 NEAR";
+        let options = VisualSignOptions {
+            metadata: Some(ChainMetadata {
+                metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                    network_id: Some("NEAR_MAINNET".to_string()),
+                    token_mappings: [(
+                        hostile.to_string(),
+                        generated::parser::TokenMetadataEntry {
+                            value: "not valid json".to_string(),
+                            signature: None,
+                            origin_chain: None,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                })),
+            }),
+            ..Default::default()
+        };
+
+        let envelope = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000"}]}"#;
+        let payload = NearVisualSignConverter::new()
+            .to_visual_sign_payload(NearTransaction::Intent(envelope.to_string()), options)
+            .expect("convert");
+        let json = payload.payload.to_json().expect("json");
+
+        assert!(
+            json.contains("rejected-token-metadata"),
+            "the refusal must still be reported: {json}"
+        );
+        assert!(
+            !json.contains("x.near\\nAmount"),
+            "the newline must be filtered out of the rendered text: {json}"
         );
     }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -11,10 +11,13 @@ mod tokens;
 mod verify;
 
 pub use token_signature::{
-    TokenMetadataDomain, authorized_token_metadata_signers, insert_token_metadata_signer,
+    RejectedTokenMetadata, TokenMetadataDomain, TokenMetadataExtraction,
+    authorized_token_metadata_signers, insert_token_metadata_signer,
     sign_token_metadata_for_cli,
     try_extract_from_chain_metadata as try_extract_token_metadata_from_chain_metadata,
 };
+
+pub(crate) use render::rejected_metadata_diagnostics;
 
 /// Dev/CLI signing helpers for constructing signed `TokenMetadataEntry` proto
 /// values (e.g. for local test fixtures). Gated the same way as the

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -160,6 +160,29 @@ pub fn try_decode_execute_intents(
     Ok(fields)
 }
 
+/// Whether the pre-signature single-intent envelope's decoded intents include
+/// a kind that consults the token registry. The equivalent, for this path, of
+/// the on-chain converter's action-level gate: the envelope can name any of
+/// eleven intent kinds and only three read the registry, so a caller must
+/// check this before building one -- otherwise an envelope that never
+/// consults token metadata (e.g. a plain `native_withdraw`) gets a rejection
+/// diagnostic for metadata nothing here reads.
+///
+/// Malformed JSON reads as inapplicable rather than as an error here: the
+/// subsequent [`try_render_single_intent`] call decodes the same bytes and
+/// reports the parse failure properly.
+pub fn single_intent_consumes_token_registry(payload_json: &[u8]) -> bool {
+    serde_json::from_slice::<
+        defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents>,
+    >(payload_json)
+    .is_ok_and(|payload| {
+        payload
+            .intents
+            .iter()
+            .any(render::intent_consumes_token_registry)
+    })
+}
+
 /// Render the single intent a user is about to sign, from the JSON of its
 /// `DefusePayload` message (the inner message that gets signed, independent of
 /// which signature standard later wraps it).

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -12,8 +12,7 @@ mod verify;
 
 pub use token_signature::{
     RejectedTokenMetadata, TokenMetadataDomain, TokenMetadataExtraction,
-    authorized_token_metadata_signers, insert_token_metadata_signer,
-    sign_token_metadata_for_cli,
+    authorized_token_metadata_signers, insert_token_metadata_signer, sign_token_metadata_for_cli,
     try_extract_from_chain_metadata as try_extract_token_metadata_from_chain_metadata,
 };
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -11,9 +11,12 @@ mod tokens;
 mod verify;
 
 pub use token_signature::{
-    TokenMetadataSignerAllowlists, authorized_token_metadata_signers, sign_token_metadata_for_cli,
+    RejectedTokenMetadata, TokenMetadataExtraction, TokenMetadataSignerAllowlists,
+    authorized_token_metadata_signers, sign_token_metadata_for_cli,
     try_extract_from_chain_metadata as try_extract_token_metadata_from_chain_metadata,
 };
+
+pub(crate) use render::rejected_metadata_diagnostics;
 
 /// Dev/CLI signing helpers for constructing signed `TokenMetadataEntry` proto
 /// values (e.g. for local test fixtures). Gated the same way as the

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -58,17 +58,28 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// apparent fields on the signing screen.
 pub(crate) fn rejected_metadata_diagnostics(
     rejected: &[super::token_signature::RejectedTokenMetadata],
-) -> Result<Fields, VisualSignError> {
+) -> Fields {
+    // Infallible by construction: reporting a refusal must never be able to
+    // withhold the transaction. A field that fails to build (an empty message
+    // after charset filtering, say) is logged and dropped, leaving the signer
+    // a payload minus one caveat rather than no payload at all.
     rejected
         .iter()
-        .map(|r| {
-            diagnostic(
-                "rejected-token-metadata",
-                &crate::actions::charset_safe(&format!(
-                    "token metadata supplied for {} was rejected and not used: {}",
-                    r.asset_id, r.reason
-                )),
-            )
+        .filter_map(|r| {
+            let message = crate::actions::charset_safe(&format!(
+                "token metadata supplied for {} was rejected and not used: {}",
+                r.asset_id, r.reason
+            ));
+            match diagnostic("rejected-token-metadata", &message) {
+                Ok(field) => Some(field),
+                Err(e) => {
+                    tracing::warn!(
+                        "could not render the rejection diagnostic for '{}': {e}",
+                        r.asset_id
+                    );
+                    None
+                }
+            }
         })
         .collect()
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -44,6 +44,35 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
     Ok(create_text_field("Warning", &format!("{rule}: {message}"))?.signable_payload_field)
 }
 
+/// Report each caller-supplied token-metadata entry the parser refused.
+///
+/// Without this the signer sees only the consequence -- an amount rendered in
+/// raw base units against an `unresolved` asset id, or resolved from a seed
+/// instead of the supplied override -- with no indication that metadata was
+/// supplied and thrown away. A rejection is a soft finding: the intents still
+/// render, since the refusal protects them rather than invalidating them.
+///
+/// Both halves of the message are charset-filtered. `asset_id` is a
+/// caller-controlled map key and `reason` can quote it back (a JSON parse
+/// error, a length), so an embedded newline would otherwise render as extra
+/// apparent fields on the signing screen.
+pub(crate) fn rejected_metadata_diagnostics(
+    rejected: &[super::token_signature::RejectedTokenMetadata],
+) -> Result<Fields, VisualSignError> {
+    rejected
+        .iter()
+        .map(|r| {
+            diagnostic(
+                "rejected-token-metadata",
+                &crate::actions::charset_safe(&format!(
+                    "token metadata supplied for {} was rejected and not used: {}",
+                    r.asset_id, r.reason
+                )),
+            )
+        })
+        .collect()
+}
+
 /// Render one token amount, resolving symbol/decimals when the asset is known;
 /// otherwise show the raw base-unit amount tagged with the unresolved asset id.
 /// Metadata resolved from an unattributed request entry (a gap-fill for an asset

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -214,6 +214,24 @@ pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, V
     }
 }
 
+/// Whether [`render_intent`] passes this intent's kind through to a token
+/// registry lookup. Matched exhaustively against the same arms so a kind that
+/// starts (or stops) reading `registry` there forces this to be revisited
+/// rather than silently drifting out of step.
+pub(crate) fn intent_consumes_token_registry(intent: &Intent) -> bool {
+    match intent {
+        Intent::TokenDiff(_) | Intent::Transfer(_) | Intent::FtWithdraw(_) => true,
+        Intent::NftWithdraw(_)
+        | Intent::MtWithdraw(_)
+        | Intent::NativeWithdraw(_)
+        | Intent::AddPublicKey(_)
+        | Intent::RemovePublicKey(_)
+        | Intent::SetAuthByPredecessorId(_)
+        | Intent::StorageDeposit(_)
+        | Intent::AuthCall(_) => false,
+    }
+}
+
 /// Flags an attached NEP-616 `state_init`: a global-contract id plus initial
 /// state, which initializes the callee's contract in the same receipt. The
 /// code/data have no cheap field-level render, so surface that the attachment

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -56,17 +56,28 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// apparent fields on the signing screen.
 pub(crate) fn rejected_metadata_diagnostics(
     rejected: &[super::token_signature::RejectedTokenMetadata],
-) -> Result<Fields, VisualSignError> {
+) -> Fields {
+    // Infallible by construction: reporting a refusal must never be able to
+    // withhold the transaction. A field that fails to build (an empty message
+    // after charset filtering, say) is logged and dropped, leaving the signer
+    // a payload minus one caveat rather than no payload at all.
     rejected
         .iter()
-        .map(|r| {
-            diagnostic(
-                "rejected-token-metadata",
-                &crate::actions::charset_safe(&format!(
-                    "token metadata supplied for {} was rejected and not used: {}",
-                    r.asset_id, r.reason
-                )),
-            )
+        .filter_map(|r| {
+            let message = crate::actions::charset_safe(&format!(
+                "token metadata supplied for {} was rejected and not used: {}",
+                r.asset_id, r.reason
+            ));
+            match diagnostic("rejected-token-metadata", &message) {
+                Ok(field) => Some(field),
+                Err(e) => {
+                    tracing::warn!(
+                        "could not render the rejection diagnostic for '{}': {e}",
+                        r.asset_id
+                    );
+                    None
+                }
+            }
         })
         .collect()
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -42,6 +42,35 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
     Ok(create_text_field("Warning", &format!("{rule}: {message}"))?.signable_payload_field)
 }
 
+/// Report each caller-supplied token-metadata entry the parser refused.
+///
+/// Without this the signer sees only the consequence -- an amount rendered in
+/// raw base units against an `unresolved` asset id, or resolved from a seed
+/// instead of the supplied override -- with no indication that metadata was
+/// supplied and thrown away. A rejection is a soft finding: the intents still
+/// render, since the refusal protects them rather than invalidating them.
+///
+/// Both halves of the message are charset-filtered. `asset_id` is a
+/// caller-controlled map key and `reason` can quote it back (a JSON parse
+/// error, a length), so an embedded newline would otherwise render as extra
+/// apparent fields on the signing screen.
+pub(crate) fn rejected_metadata_diagnostics(
+    rejected: &[super::token_signature::RejectedTokenMetadata],
+) -> Result<Fields, VisualSignError> {
+    rejected
+        .iter()
+        .map(|r| {
+            diagnostic(
+                "rejected-token-metadata",
+                &crate::actions::charset_safe(&format!(
+                    "token metadata supplied for {} was rejected and not used: {}",
+                    r.asset_id, r.reason
+                )),
+            )
+        })
+        .collect()
+}
+
 /// Render one token amount, resolving symbol/decimals when the asset is known;
 /// otherwise show the raw base-unit amount tagged with the unresolved asset id.
 /// Metadata resolved from an unsigned request entry (a gap-fill for an asset

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -523,14 +523,40 @@ fn validate_secp256k1(
     ))
 }
 
+/// A caller-supplied token-metadata entry that was refused, and why.
+///
+/// Carried out of extraction so the renderer can surface it to the signer
+/// instead of leaving it in an operator log the wallet never sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedTokenMetadata {
+    /// The asset id the refused entry was keyed under.
+    pub asset_id: String,
+    /// Why it was refused, in the same words as the operator log.
+    pub reason: String,
+}
+
+/// Outcome of extracting caller-supplied token metadata: the entries that
+/// survived validation, plus the ones that did not.
+#[derive(Debug, Default)]
+pub struct TokenMetadataExtraction {
+    /// Accepted entries, or `None` when nothing survived (or none was
+    /// supplied) -- shaped so callers can plug it straight into a
+    /// [`visualsign::registry::LayeredRegistry`] request layer.
+    pub registry: Option<NearTokenRegistry>,
+    /// Refused entries, in asset-id order.
+    pub rejected: Vec<RejectedTokenMetadata>,
+}
+
 /// Extract and validate token-metadata entries from `ChainMetadata`, if
 /// present.
 ///
-/// Navigates `ChainMetadata -> Near -> token_mappings`. Returns `None` if the
-/// metadata contains no NEAR token mappings (or no metadata at all), matching
-/// the Ethereum ABI / Solana IDL extraction functions' convention so callers
-/// can plug the result straight into a
-/// [`visualsign::registry::LayeredRegistry`] request layer.
+/// Navigates `ChainMetadata -> Near -> token_mappings`. `registry` is `None`
+/// if the metadata contains no NEAR token mappings (or no metadata at all),
+/// matching the Ethereum ABI / Solana IDL extraction functions' convention.
+///
+/// Every refused entry is also returned in `rejected`: a caller that supplies
+/// metadata the parser then throws away needs to learn that from the payload,
+/// not only from an operator log it has no access to.
 ///
 /// `network` is the NEAR network this request resolved to, taken as a parameter
 /// rather than re-derived from `chain_metadata`: the caller already resolves it
@@ -551,47 +577,82 @@ pub fn try_extract_from_chain_metadata(
     network: NearNetwork,
     allowlist: &SignerAllowlist,
     trust_policy: &MetadataTrustPolicy,
-) -> Option<NearTokenRegistry> {
-    let chain_metadata = chain_metadata?;
-    let chain_metadata::Metadata::Near(near) = chain_metadata.metadata.as_ref()? else {
-        return None;
+) -> TokenMetadataExtraction {
+    let mut rejected: Vec<RejectedTokenMetadata> = Vec::new();
+    let nothing = |rejected: Vec<RejectedTokenMetadata>| TokenMetadataExtraction {
+        registry: None,
+        rejected,
+    };
+
+    let Some(chain_metadata) = chain_metadata else {
+        return nothing(rejected);
+    };
+    let Some(chain_metadata::Metadata::Near(near)) = chain_metadata.metadata.as_ref() else {
+        return nothing(rejected);
     };
     if near.token_mappings.is_empty() {
-        return None;
+        return nothing(rejected);
     }
     // The canonical id, not whatever spelling the request used, so a signature
     // does not depend on the casing a caller happened to send.
     let network_id = network.network_id();
 
     if near.token_mappings.len() > MAX_TOKEN_METADATA_ENTRIES {
-        tracing::warn!(
-            "Ignoring all NEAR token metadata: {} entries exceeds the limit of \
-             {MAX_TOKEN_METADATA_ENTRIES}",
+        let reason = format!(
+            "{} entries exceeds the limit of {MAX_TOKEN_METADATA_ENTRIES}",
             near.token_mappings.len()
         );
-        return None;
+        tracing::warn!("Ignoring all NEAR token metadata: {reason}");
+        // Reported as one refusal covering the whole map rather than one per
+        // entry: the map is refused as a unit, and 256+ identical diagnostics
+        // would bury the reason rather than surface it.
+        rejected.push(RejectedTokenMetadata {
+            asset_id: "all assets".to_string(),
+            reason,
+        });
+        return nothing(rejected);
     }
 
     let mut registry = NearTokenRegistry::default();
     let mut unverified_count: usize = 0;
     for (asset_id, entry) in &near.token_mappings {
-        // First, and quoting only the length: every other refusal echoes the
-        // asset id, so an oversized key is refused before it can be copied into
-        // a message.
+        // Bind each refusal to its `continue` so a new rejection path can't be
+        // added without also reporting it.
+        macro_rules! reject {
+            ($($reason:tt)+) => {{
+                let reason = format!($($reason)+);
+                tracing::warn!("Skipping token metadata for '{asset_id}': {reason}");
+                rejected.push(RejectedTokenMetadata {
+                    asset_id: asset_id.clone(),
+                    reason,
+                });
+                continue;
+            }};
+        }
+
+        // First, and deliberately not through `reject!`: that macro clones the
+        // asset id into the rejection, which is exactly the copy this bound
+        // exists to prevent. The refusal quotes the length and stands in a fixed
+        // label for the key, so an oversized id is still reported without being
+        // echoed.
         if asset_id.len() > MAX_ASSET_ID_BYTES {
-            tracing::warn!(
-                "Skipping token metadata for an oversized asset id: {} bytes > {MAX_ASSET_ID_BYTES}",
+            let reason = format!(
+                "asset id exceeds size limit ({} bytes > {MAX_ASSET_ID_BYTES})",
                 asset_id.len()
             );
+            tracing::warn!("Skipping token metadata for an oversized asset id: {reason}");
+            rejected.push(RejectedTokenMetadata {
+                asset_id: "oversized asset id".to_string(),
+                reason,
+            });
             continue;
         }
 
         if entry.value.len() > MAX_TOKEN_METADATA_VALUE_BYTES {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': exceeds size limit ({} bytes > {MAX_TOKEN_METADATA_VALUE_BYTES})",
+            reject!(
+                "exceeds size limit ({} bytes > {MAX_TOKEN_METADATA_VALUE_BYTES})",
                 entry.value.len()
             );
-            continue;
         }
 
         // Only an omitted field and an explicit Unspecified default to NEAR's
@@ -602,12 +663,7 @@ pub fn try_extract_from_chain_metadata(
         let origin_chain = match entry.origin_chain {
             Some(v) => match TokenOriginChain::try_from(v) {
                 Ok(chain) => chain,
-                Err(_) => {
-                    tracing::warn!(
-                        "Skipping token metadata for '{asset_id}': unrecognized origin_chain {v}"
-                    );
-                    continue;
-                }
+                Err(_) => reject!("unrecognized origin_chain {v}"),
             },
             None => {
                 if entry.signature.is_some() {
@@ -631,10 +687,7 @@ pub fn try_extract_from_chain_metadata(
         // request: under RequireAllowlistedSigner a missing signature is always
         // a rejection, regardless of the asset id.
         if is_unsigned && !trust_policy.accepts_unsigned() {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': this deployment requires signed entries"
-            );
-            continue;
+            reject!("this deployment requires signed entries");
         }
 
         // Unattributable metadata may fill a gap for an asset the compiled-in
@@ -646,32 +699,18 @@ pub fn try_extract_from_chain_metadata(
         // all; one whose signature proves to be from a key this deployment does
         // not recognize is caught after verification, below.
         if is_unsigned && tokens::is_seeded(asset_id) {
-            tracing::warn!(
-                "Skipping unsigned token metadata for '{asset_id}': would override a curated seed"
-            );
-            continue;
+            reject!("unsigned entry would override a curated seed");
         }
 
         let parsed: TokenMetadataValue = match serde_json::from_str(&entry.value) {
             Ok(v) => v,
-            Err(e) => {
-                tracing::warn!("Skipping token metadata for '{asset_id}': invalid value JSON: {e}");
-                continue;
-            }
+            Err(e) => reject!("invalid value JSON: {e}"),
         };
         if parsed.decimals > MAX_TOKEN_DECIMALS {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': decimals {} out of range",
-                parsed.decimals
-            );
-            continue;
+            reject!("decimals {} out of range", parsed.decimals);
         }
         if parsed.symbol.is_empty() || parsed.symbol.len() > MAX_TOKEN_SYMBOL_LEN {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': symbol length {} out of range",
-                parsed.symbol.len()
-            );
-            continue;
+            reject!("symbol length {} out of range", parsed.symbol.len());
         }
         // The symbol is embedded verbatim in an amount's abbreviation and
         // fallback text, so its character content decides what a signer reads.
@@ -723,18 +762,11 @@ pub fn try_extract_from_chain_metadata(
                     &signature,
                     allowlist,
                 ) {
-                    Err(e) => {
-                        tracing::warn!("Skipping token metadata for '{asset_id}': {e}");
-                        continue;
-                    }
+                    Err(e) => reject!("{e}"),
                     Ok(SignerIdentity::Recognized) => TokenProvenance::RecognizedSigner,
                     Ok(SignerIdentity::Unrecognized) => {
                         if !trust_policy.accepts_unsigned() {
-                            tracing::warn!(
-                                "Skipping token metadata for '{asset_id}': signer is not an \
-                                 authorized curator for this origin chain"
-                            );
-                            continue;
+                            reject!("signer is not an authorized curator for this origin chain");
                         }
                         tracing::warn!(
                             "Token metadata for '{asset_id}': signed by a key this deployment \
@@ -777,9 +809,12 @@ pub fn try_extract_from_chain_metadata(
         );
     }
     if registry.by_asset_id.is_empty() {
-        return None;
+        return nothing(rejected);
     }
-    Some(registry)
+    TokenMetadataExtraction {
+        registry: Some(registry),
+        rejected,
+    }
 }
 
 /// Deterministic 32-byte seeds used to sign token metadata in local dev
@@ -936,6 +971,18 @@ mod tests {
         assert_eq!(NETWORK.network_id(), NETWORK_ID);
     }
 
+    /// The accepted-entry half of extraction, for cases that assert on what
+    /// survived validation. Cases that assert on refusals call
+    /// [`try_extract_from_chain_metadata`] directly and read `rejected`.
+    fn extract_registry(
+        chain_metadata: Option<&ChainMetadata>,
+        network: NearNetwork,
+        allowlist: &SignerAllowlist,
+        trust_policy: &MetadataTrustPolicy,
+    ) -> Option<NearTokenRegistry> {
+        try_extract_from_chain_metadata(chain_metadata, network, allowlist, trust_policy).registry
+    }
+
     fn accept_unsigned_policy() -> MetadataTrustPolicy {
         MetadataTrustPolicy::AcceptUnsigned
     }
@@ -1007,6 +1054,7 @@ mod tests {
             &allowlist,
             &require_signed_policy_with(allowlist.clone()),
         )
+        .registry
         .expect("an entry signed by the enrolled key must register");
         assert_eq!(
             registry
@@ -1261,7 +1309,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &empty_allowlists(),
@@ -1304,7 +1352,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &empty_allowlists(),
@@ -1340,7 +1388,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &empty_allowlists(),
@@ -1422,16 +1470,20 @@ mod tests {
             .collect()
     }
 
+    /// `ChainMetadata` carrying exactly the given entries.
+    fn chain_metadata_with(entries: Vec<(&str, TokenMetadataEntry)>) -> ChainMetadata {
+        ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                network_id: Some("NEAR_MAINNET".to_string()),
+                token_mappings: make_mappings(entries),
+            })),
+        }
+    }
+
     #[test]
     fn extract_no_metadata_is_none() {
         assert!(
-            try_extract_from_chain_metadata(
-                None,
-                NETWORK,
-                &near_allowlist(),
-                &accept_unsigned_policy()
-            )
-            .is_none()
+            extract_registry(None, NETWORK, &near_allowlist(), &accept_unsigned_policy()).is_none()
         );
     }
 
@@ -1446,7 +1498,7 @@ mod tests {
             )),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1474,7 +1526,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &near_allowlist(),
@@ -1515,7 +1567,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1545,7 +1597,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1584,7 +1636,7 @@ mod tests {
 
         // The control: checked against the network it was signed for, it
         // registers verified.
-        let mainnet = try_extract_from_chain_metadata(
+        let mainnet = extract_registry(
             Some(&metadata),
             NearNetwork::Mainnet,
             &near_allowlist(),
@@ -1601,7 +1653,7 @@ mod tests {
             "signed entry registers as verified on its own network"
         );
 
-        let testnet = try_extract_from_chain_metadata(
+        let testnet = extract_registry(
             Some(&metadata),
             NearNetwork::Testnet,
             &near_allowlist(),
@@ -1640,7 +1692,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NearNetwork::Testnet,
             &near_allowlist(),
@@ -1683,7 +1735,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &near_allowlist(),
@@ -1718,7 +1770,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1752,7 +1804,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1783,7 +1835,7 @@ mod tests {
                 token_mappings: entries.into_iter().collect(),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &near_allowlist(),
@@ -1819,7 +1871,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &near_allowlist(),
@@ -1853,7 +1905,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             NETWORK,
             &near_allowlist(),
@@ -1889,7 +1941,7 @@ mod tests {
         };
         // No allowlist authorizes the dev seed used above.
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &empty_allowlists(),
@@ -1915,7 +1967,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -1955,7 +2007,7 @@ mod tests {
                 })),
             };
             assert!(
-                try_extract_from_chain_metadata(
+                extract_registry(
                     Some(&metadata),
                     NETWORK,
                     &near_allowlist(),
@@ -1983,7 +2035,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -2013,7 +2065,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -2039,7 +2091,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -2068,7 +2120,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -2098,7 +2150,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 NETWORK,
                 &near_allowlist(),
@@ -2106,6 +2158,213 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    /// Every refusal path reports itself in `rejected`, keyed by asset id.
+    ///
+    /// A refused entry that reported nothing would leave the signer looking at
+    /// an amount rendered without the metadata they supplied, with the reason
+    /// only in an operator log.
+    #[test]
+    fn every_refusal_path_reports_the_rejected_entry() {
+        let signed_by_dev_key = |asset_id: &str, value: &str| {
+            Some(sign_token_metadata_ed25519(
+                NETWORK_ID,
+                asset_id,
+                value,
+                &DEV_NEAR_SIGNING_KEY_SEED,
+                visualsign::signing::near_token_metadata_prehash,
+            ))
+        };
+
+        // (case, asset id, entry, policy, expected reason fragment)
+        let cases: Vec<(&str, &str, TokenMetadataEntry, MetadataTrustPolicy, &str)> = vec![
+            (
+                "oversized value",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: format!(
+                        r#"{{"symbol":"X","decimals":6,"pad":"{}"}}"#,
+                        "p".repeat(1100)
+                    ),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "exceeds size limit",
+            ),
+            (
+                "unsigned under require-signed",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                require_signed_policy(),
+                "requires signed entries",
+            ),
+            (
+                "unsigned override of a curated seed",
+                ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "would override a curated seed",
+            ),
+            (
+                // Only a refusal under the strict posture. The permissive one
+                // accepts an unrecognized signer as unverified, on the same
+                // terms as an unsigned entry -- covered by
+                // `extract_accepts_an_unrecognized_signer_as_unverified`.
+                "signature from an unrecognized signer, strict posture",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: signed_by_dev_key(UNSEEDED_ASSET_ID, VALUE),
+                    origin_chain: None,
+                },
+                require_signed_policy_with(SignerAllowlist::new()),
+                "signer is not an authorized curator",
+            ),
+            (
+                "value that isn't the expected JSON",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: "not json at all".to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "invalid value JSON",
+            ),
+            (
+                "decimals past the formatting bound",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"X","decimals":39}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "decimals 39 out of range",
+            ),
+            (
+                "unrecognized origin_chain",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: None,
+                    origin_chain: Some(9999),
+                },
+                accept_unsigned_policy(),
+                "unrecognized origin_chain 9999",
+            ),
+            (
+                "empty symbol",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"","decimals":6}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "symbol length 0 out of range",
+            ),
+        ];
+
+        for (case, asset_id, entry, policy, expected_reason) in cases {
+            // An allowlist with no entries at all, so the "unlisted signer"
+            // case is refused on identity rather than on a bad signature.
+            let allowlists = SignerAllowlist::new();
+            let metadata = chain_metadata_with(vec![(asset_id, entry)]);
+            let extraction =
+                try_extract_from_chain_metadata(Some(&metadata), NETWORK, &allowlists, &policy);
+
+            assert!(
+                extraction.registry.is_none(),
+                "{case}: entry must be refused, not registered"
+            );
+            assert_eq!(
+                extraction.rejected.len(),
+                1,
+                "{case}: expected exactly one reported rejection, got {:?}",
+                extraction.rejected
+            );
+            assert_eq!(
+                extraction.rejected[0].asset_id, asset_id,
+                "{case}: rejection must name the asset id it was keyed under"
+            );
+            assert!(
+                extraction.rejected[0].reason.contains(expected_reason),
+                "{case}: reason should mention '{expected_reason}', got '{}'",
+                extraction.rejected[0].reason
+            );
+        }
+    }
+
+    /// An accepted entry reports no rejection, so the diagnostic can't fire on
+    /// the happy path.
+    #[test]
+    fn an_accepted_entry_reports_no_rejection() {
+        let metadata = chain_metadata_with(vec![(
+            UNSEEDED_ASSET_ID,
+            TokenMetadataEntry {
+                value: VALUE.to_string(),
+                signature: None,
+                origin_chain: None,
+            },
+        )]);
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            NETWORK,
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+        assert!(extraction.registry.is_some(), "entry should be accepted");
+        assert!(
+            extraction.rejected.is_empty(),
+            "an accepted entry must report no rejection, got {:?}",
+            extraction.rejected
+        );
+    }
+
+    /// One refused entry doesn't take the surviving ones down with it.
+    #[test]
+    fn a_refused_entry_does_not_discard_the_entries_beside_it() {
+        let good = "nep141:good-unlisted-token.near";
+        let metadata = chain_metadata_with(vec![
+            (
+                good,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"GOOD","decimals":6}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+            ),
+            (
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: "not json".to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+            ),
+        ]);
+
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            NETWORK,
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+        let registry = extraction.registry.expect("the good entry should survive");
+        assert!(registry.by_asset_id.contains_key(good));
+        assert_eq!(extraction.rejected.len(), 1);
+        assert_eq!(extraction.rejected[0].asset_id, UNSEEDED_ASSET_ID);
     }
 
     /// A CLI-signed entry must verify under `authorized_token_metadata_signers`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -690,18 +690,6 @@ pub fn try_extract_from_chain_metadata(
             reject!("this deployment requires signed entries");
         }
 
-        // Unattributable metadata may fill a gap for an asset the compiled-in
-        // table doesn't cover, but must never override an already-curated one:
-        // tokens::resolve checks this registry before SEEDS unconditionally, so
-        // allowing it would let an unauthenticated caller shadow verified data
-        // -- turning, e.g., 1 wNEAR into 1000000 wNEAR by claiming the wrong
-        // decimals. Checked cheaply here for an entry carrying no signature at
-        // all; one whose signature proves to be from a key this deployment does
-        // not recognize is caught after verification, below.
-        if is_unsigned && tokens::is_seeded(asset_id) {
-            reject!("unsigned entry would override a curated seed");
-        }
-
         let parsed: TokenMetadataValue = match serde_json::from_str(&entry.value) {
             Ok(v) => v,
             Err(e) => reject!("invalid value JSON: {e}"),
@@ -727,11 +715,7 @@ pub fn try_extract_from_chain_metadata(
             .chars()
             .all(|c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
         {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': symbol contains characters outside \
-                 printable ASCII"
-            );
-            continue;
+            reject!("symbol contains characters outside printable ASCII");
         }
 
         // A present signature must verify: one that does not match its own
@@ -778,15 +762,28 @@ pub fn try_extract_from_chain_metadata(
             }
         };
 
-        // The gap-fill rule again, now that identity is settled: a signature
-        // from an unrecognized key must not buy an override the same caller
-        // could not have had by omitting it.
-        if !provenance.verified() && tokens::is_seeded(asset_id) {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': {} would override a curated seed",
-                provenance.override_subject()
-            );
-            continue;
+        // Unattributed metadata may fill a gap for an asset the compiled-in table
+        // doesn't cover, but must never override an already-curated one:
+        // `tokens::resolve` checks this registry before SEEDS unconditionally, so
+        // allowing it would let an unauthenticated caller shadow verified data --
+        // turning, e.g., 1 wNEAR into 1000000 wNEAR by claiming the wrong
+        // decimals. A signature from an unrecognized key must not buy the
+        // override either, since the same caller could have had it by omitting
+        // the signature.
+        //
+        // One check for both cases, placed after the parse so the refusal can
+        // name the values that differ: a bogus `decimals` is the whole attack,
+        // and the signer is owed what was attempted. The parse it waits on is of
+        // an already size-capped string, and no signature verification happens
+        // for the unsigned case, so nothing expensive moves ahead of it.
+        if !provenance.verified() {
+            if let Some(curated) = tokens::seeded_decimals(asset_id) {
+                reject!(
+                    "{} would override a curated seed (proposed decimals {}, curated {curated})",
+                    provenance.override_subject(),
+                    parsed.decimals
+                );
+            }
         }
 
         registry.by_asset_id.insert(
@@ -2167,6 +2164,10 @@ mod tests {
     /// only in an operator log.
     #[test]
     fn every_refusal_path_reports_the_rejected_entry() {
+        // Same seeded asset as `VALUE`, differing only in `decimals`, so the
+        // refusal has two distinguishable numbers to name.
+        const SEED_OVERRIDE_VALUE: &str = r#"{"symbol":"USDC.e","decimals":18}"#;
+
         let signed_by_dev_key = |asset_id: &str, value: &str| {
             Some(sign_token_metadata_ed25519(
                 NETWORK_ID,
@@ -2273,6 +2274,36 @@ mod tests {
                 },
                 accept_unsigned_policy(),
                 "symbol length 0 out of range",
+            ),
+            (
+                // The permissive posture accepts an unrecognized signer, but not
+                // as a licence to override a curated seed: the same terms an
+                // unsigned entry gets, since signing with a key nobody enrolled
+                // buys nothing over omitting the signature. The reason quotes
+                // both decimals because a bogus `decimals` is the whole attack.
+                "unrecognized signer overriding a curated seed",
+                ASSET_ID,
+                TokenMetadataEntry {
+                    value: SEED_OVERRIDE_VALUE.to_string(),
+                    signature: signed_by_dev_key(ASSET_ID, SEED_OVERRIDE_VALUE),
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "unrecognized signer would override a curated seed (proposed decimals 18, \
+                 curated 6)",
+            ),
+            (
+                // U+202E RIGHT-TO-LEFT OVERRIDE would reorder the asset name
+                // where the symbol renders.
+                "symbol outside printable ASCII",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: format!("{{\"symbol\":\"BTC{}\",\"decimals\":8}}", '\u{202E}'),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "symbol contains characters outside printable ASCII",
             ),
         ];
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -95,6 +95,12 @@ const MAX_TOKEN_METADATA_ENTRIES: usize = 256;
 /// account id (`nep141:a0b8...factory.bridge.near`), well inside this.
 const MAX_ASSET_ID_BYTES: usize = 128;
 
+/// How much of an oversized asset id the refusal names it by, counted in
+/// characters so a multi-byte boundary cannot be split. Long enough to
+/// distinguish one mapping from another, short enough that the copy stays
+/// bounded whatever the key's length.
+const ASSET_ID_PREVIEW_CHARS: usize = 32;
+
 /// Maximum accepted `decimals` value. `tokens::format_units` computes
 /// `10u128.pow(u32::from(decimals))`, which overflows above 38 -- a remote
 /// panic (debug) or a silently wrapped, wrong-looking amount (release, where
@@ -529,7 +535,11 @@ fn validate_secp256k1(
 /// instead of leaving it in an operator log the wallet never sees.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RejectedTokenMetadata {
-    /// The asset id the refused entry was keyed under.
+    /// The asset id the refused entry was keyed under, or -- when the key
+    /// itself broke [`MAX_ASSET_ID_BYTES`] -- its first
+    /// [`ASSET_ID_PREVIEW_CHARS`] characters followed by `...`, so refusing an
+    /// oversized key does not copy it whole. A refusal covering the entire map
+    /// rather than one entry is keyed `all assets`.
     pub asset_id: String,
     /// Why it was refused, in the same words as the operator log.
     pub reason: String,
@@ -631,18 +641,21 @@ pub fn try_extract_from_chain_metadata(
         }
 
         // First, and deliberately not through `reject!`: that macro clones the
-        // asset id into the rejection, which is exactly the copy this bound
-        // exists to prevent. The refusal quotes the length and stands in a fixed
-        // label for the key, so an oversized id is still reported without being
-        // echoed.
+        // whole asset id into the rejection, which is the copy this bound exists
+        // to prevent. A fixed-width prefix names the entry the signer's wallet
+        // supplied -- enough to identify which mapping was dropped -- without
+        // reintroducing an unbounded copy, and the reason carries the length.
+        // `rejected_metadata_diagnostics` charset-filters both halves, so the
+        // prefix cannot smuggle control characters onto the signing screen.
         if asset_id.len() > MAX_ASSET_ID_BYTES {
+            let preview: String = asset_id.chars().take(ASSET_ID_PREVIEW_CHARS).collect();
             let reason = format!(
                 "asset id exceeds size limit ({} bytes > {MAX_ASSET_ID_BYTES})",
                 asset_id.len()
             );
-            tracing::warn!("Skipping token metadata for an oversized asset id: {reason}");
+            tracing::warn!("Skipping token metadata for '{preview}...': {reason}");
             rejected.push(RejectedTokenMetadata {
-                asset_id: "oversized asset id".to_string(),
+                asset_id: format!("{preview}..."),
                 reason,
             });
             continue;
@@ -2335,6 +2348,88 @@ mod tests {
                 extraction.rejected[0].reason
             );
         }
+    }
+
+    /// An oversized asset id is refused like any other entry, but named by a
+    /// bounded prefix rather than copied whole: the signer still learns which
+    /// mapping was dropped, and the payload never carries the unbounded key
+    /// that `MAX_ASSET_ID_BYTES` exists to keep out of it.
+    #[test]
+    fn an_oversized_asset_id_is_reported_by_a_bounded_prefix() {
+        let oversized = format!("nep141:{}.near", "x".repeat(MAX_ASSET_ID_BYTES));
+        let metadata = chain_metadata_with(vec![(
+            oversized.as_str(),
+            TokenMetadataEntry {
+                value: VALUE.to_string(),
+                signature: None,
+                origin_chain: None,
+            },
+        )]);
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            NETWORK,
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+
+        assert!(extraction.registry.is_none(), "the entry must be refused");
+        assert_eq!(
+            extraction.rejected.len(),
+            1,
+            "expected exactly one reported rejection, got {:?}",
+            extraction.rejected
+        );
+        let rejection = &extraction.rejected[0];
+        let expected: String = oversized.chars().take(ASSET_ID_PREVIEW_CHARS).collect();
+        assert_eq!(
+            rejection.asset_id,
+            format!("{expected}..."),
+            "the refusal must name the entry by its leading characters"
+        );
+        assert!(
+            !rejection.asset_id.contains(&oversized),
+            "the whole key must not reach the payload: {}",
+            rejection.asset_id
+        );
+        assert!(
+            rejection.reason.contains("exceeds size limit")
+                && rejection.reason.contains(&oversized.len().to_string()),
+            "the refusal must quote the length that broke the bound: {}",
+            rejection.reason
+        );
+    }
+
+    /// The prefix is taken in characters, so a multi-byte key cannot be split
+    /// mid-character -- byte slicing here would panic on the whole request.
+    #[test]
+    fn an_oversized_multibyte_asset_id_is_previewed_on_a_character_boundary() {
+        let oversized = "é".repeat(MAX_ASSET_ID_BYTES);
+        let metadata = chain_metadata_with(vec![(
+            oversized.as_str(),
+            TokenMetadataEntry {
+                value: VALUE.to_string(),
+                signature: None,
+                origin_chain: None,
+            },
+        )]);
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            NETWORK,
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+
+        assert_eq!(
+            extraction.rejected.len(),
+            1,
+            "expected exactly one reported rejection, got {:?}",
+            extraction.rejected
+        );
+        assert_eq!(
+            extraction.rejected[0].asset_id,
+            format!("{}...", "é".repeat(ASSET_ID_PREVIEW_CHARS)),
+            "the preview must end on a character boundary"
+        );
     }
 
     /// An accepted entry reports no rejection, so the diagnostic can't fire on

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -1129,7 +1129,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1163,12 +1163,9 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
-            Some(&metadata),
-            &near_allowlist(),
-            &require_signed_policy(),
-        )
-        .expect("an unrecognized origin_chain falls back to the NEAR curve");
+        let registry =
+            extract_registry(Some(&metadata), &near_allowlist(), &require_signed_policy())
+                .expect("an unrecognized origin_chain falls back to the NEAR curve");
         assert_eq!(
             registry.by_asset_id.get(ASSET_ID).expect("present").symbol,
             "USDC.e"

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -356,14 +356,40 @@ fn validate_secp256k1(
     Ok(())
 }
 
+/// A caller-supplied token-metadata entry that was refused, and why.
+///
+/// Carried out of extraction so the renderer can surface it to the signer
+/// instead of leaving it in an operator log the wallet never sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedTokenMetadata {
+    /// The asset id the refused entry was keyed under.
+    pub asset_id: String,
+    /// Why it was refused, in the same words as the operator log.
+    pub reason: String,
+}
+
+/// Outcome of extracting caller-supplied token metadata: the entries that
+/// survived validation, plus the ones that did not.
+#[derive(Debug, Default)]
+pub struct TokenMetadataExtraction {
+    /// Accepted entries, or `None` when nothing survived (or none was
+    /// supplied) -- shaped so callers can plug it straight into a
+    /// [`visualsign::registry::LayeredRegistry`] request layer.
+    pub registry: Option<NearTokenRegistry>,
+    /// Refused entries, in asset-id order.
+    pub rejected: Vec<RejectedTokenMetadata>,
+}
+
 /// Extract and validate token-metadata entries from `ChainMetadata`, if
 /// present.
 ///
-/// Navigates `ChainMetadata -> Near -> token_mappings`. Returns `None` if the
-/// metadata contains no NEAR token mappings (or no metadata at all), matching
-/// the Ethereum ABI / Solana IDL extraction functions' convention so callers
-/// can plug the result straight into a
-/// [`visualsign::registry::LayeredRegistry`] request layer.
+/// Navigates `ChainMetadata -> Near -> token_mappings`. `registry` is `None`
+/// if the metadata contains no NEAR token mappings (or no metadata at all),
+/// matching the Ethereum ABI / Solana IDL extraction functions' convention.
+///
+/// Every refused entry is also returned in `rejected`: a caller that supplies
+/// metadata the parser then throws away needs to learn that from the payload,
+/// not only from an operator log it has no access to.
 ///
 /// `trust_policy` gates only whether an entry with no signature at all is
 /// accepted ([`MetadataTrustPolicy::accepts_unsigned`]); a present signature
@@ -377,24 +403,45 @@ pub fn try_extract_from_chain_metadata(
     chain_metadata: Option<&ChainMetadata>,
     allowlists: &TokenMetadataSignerAllowlists,
     trust_policy: &MetadataTrustPolicy,
-) -> Option<NearTokenRegistry> {
-    let chain_metadata = chain_metadata?;
-    let chain_metadata::Metadata::Near(near) = chain_metadata.metadata.as_ref()? else {
-        return None;
+) -> TokenMetadataExtraction {
+    let mut rejected: Vec<RejectedTokenMetadata> = Vec::new();
+    let nothing = |rejected: Vec<RejectedTokenMetadata>| TokenMetadataExtraction {
+        registry: None,
+        rejected,
+    };
+
+    let Some(chain_metadata) = chain_metadata else {
+        return nothing(rejected);
+    };
+    let Some(chain_metadata::Metadata::Near(near)) = chain_metadata.metadata.as_ref() else {
+        return nothing(rejected);
     };
     if near.token_mappings.is_empty() {
-        return None;
+        return nothing(rejected);
     }
 
     let mut registry = NearTokenRegistry::default();
     let mut unsigned_count: usize = 0;
     for (asset_id, entry) in &near.token_mappings {
+        // Bind each refusal to its `continue` so a new rejection path can't be
+        // added without also reporting it.
+        macro_rules! reject {
+            ($($reason:tt)+) => {{
+                let reason = format!($($reason)+);
+                tracing::warn!("Skipping token metadata for '{asset_id}': {reason}");
+                rejected.push(RejectedTokenMetadata {
+                    asset_id: asset_id.clone(),
+                    reason,
+                });
+                continue;
+            }};
+        }
+
         if entry.value.len() > MAX_TOKEN_METADATA_VALUE_BYTES {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': exceeds size limit ({} bytes > {MAX_TOKEN_METADATA_VALUE_BYTES})",
+            reject!(
+                "exceeds size limit ({} bytes > {MAX_TOKEN_METADATA_VALUE_BYTES})",
                 entry.value.len()
             );
-            continue;
         }
 
         // An unrecognized discriminant and an omitted field both land on
@@ -434,10 +481,7 @@ pub fn try_extract_from_chain_metadata(
         // RequireAllowlistedSigner, a missing signature is always a
         // rejection, regardless of the asset id.
         if is_unsigned && !trust_policy.accepts_unsigned() {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': this deployment requires signed entries"
-            );
-            continue;
+            reject!("this deployment requires signed entries");
         }
 
         // An unsigned entry may fill a gap for an asset the compiled-in table
@@ -449,10 +493,7 @@ pub fn try_extract_from_chain_metadata(
         // from an allowlisted signer is still a trusted correction and may
         // override normally.
         if is_unsigned && tokens::is_seeded(asset_id) {
-            tracing::warn!(
-                "Skipping unsigned token metadata for '{asset_id}': would override a curated seed"
-            );
-            continue;
+            reject!("unsigned entry would override a curated seed");
         }
 
         if let Some(proto_sig) = entry.signature.as_ref() {
@@ -464,31 +505,19 @@ pub fn try_extract_from_chain_metadata(
                 &signature,
                 allowlists,
             ) {
-                tracing::warn!("Skipping token metadata for '{asset_id}': {e}");
-                continue;
+                reject!("{e}");
             }
         }
 
         let parsed: TokenMetadataValue = match serde_json::from_str(&entry.value) {
             Ok(v) => v,
-            Err(e) => {
-                tracing::warn!("Skipping token metadata for '{asset_id}': invalid value JSON: {e}");
-                continue;
-            }
+            Err(e) => reject!("invalid value JSON: {e}"),
         };
         if parsed.decimals > MAX_TOKEN_DECIMALS {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': decimals {} out of range",
-                parsed.decimals
-            );
-            continue;
+            reject!("decimals {} out of range", parsed.decimals);
         }
         if parsed.symbol.is_empty() || parsed.symbol.len() > MAX_TOKEN_SYMBOL_LEN {
-            tracing::warn!(
-                "Skipping token metadata for '{asset_id}': symbol length {} out of range",
-                parsed.symbol.len()
-            );
-            continue;
+            reject!("symbol length {} out of range", parsed.symbol.len());
         }
         // The symbol is embedded verbatim in an amount's abbreviation and
         // fallback text, so its character content decides what a signer reads.
@@ -529,9 +558,12 @@ pub fn try_extract_from_chain_metadata(
         );
     }
     if registry.by_asset_id.is_empty() {
-        return None;
+        return nothing(rejected);
     }
-    Some(registry)
+    TokenMetadataExtraction {
+        registry: Some(registry),
+        rejected,
+    }
 }
 
 /// Deterministic 32-byte seeds used to sign token metadata in local dev
@@ -668,6 +700,17 @@ mod tests {
     /// of `ASSET_ID` so the gap-fill-only guard doesn't intercept first and
     /// mask what they're actually testing.
     const UNSEEDED_ASSET_ID: &str = "nep141:new-unlisted-token.near";
+
+    /// The accepted-entry half of extraction, for cases that assert on what
+    /// survived validation. Cases that assert on refusals call
+    /// [`try_extract_from_chain_metadata`] directly and read `rejected`.
+    fn extract_registry(
+        chain_metadata: Option<&ChainMetadata>,
+        allowlists: &TokenMetadataSignerAllowlists,
+        trust_policy: &MetadataTrustPolicy,
+    ) -> Option<NearTokenRegistry> {
+        try_extract_from_chain_metadata(chain_metadata, allowlists, trust_policy).registry
+    }
 
     fn accept_unsigned_policy() -> MetadataTrustPolicy {
         MetadataTrustPolicy::AcceptUnsigned
@@ -905,12 +948,19 @@ mod tests {
             .collect()
     }
 
+    /// `ChainMetadata` carrying exactly the given entries.
+    fn chain_metadata_with(entries: Vec<(&str, TokenMetadataEntry)>) -> ChainMetadata {
+        ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                network_id: Some("NEAR_MAINNET".to_string()),
+                token_mappings: make_mappings(entries),
+            })),
+        }
+    }
+
     #[test]
     fn extract_no_metadata_is_none() {
-        assert!(
-            try_extract_from_chain_metadata(None, &near_allowlist(), &accept_unsigned_policy())
-                .is_none()
-        );
+        assert!(extract_registry(None, &near_allowlist(), &accept_unsigned_policy()).is_none());
     }
 
     #[test]
@@ -924,7 +974,7 @@ mod tests {
             )),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -951,7 +1001,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             &near_allowlist(),
             &accept_unsigned_policy(),
@@ -990,7 +1040,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1019,12 +1069,8 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
-                Some(&metadata),
-                &near_allowlist(),
-                &require_signed_policy()
-            )
-            .is_none()
+            extract_registry(Some(&metadata), &near_allowlist(), &require_signed_policy())
+                .is_none()
         );
     }
 
@@ -1053,12 +1099,9 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
-            Some(&metadata),
-            &near_allowlist(),
-            &require_signed_policy(),
-        )
-        .expect("signed entry must still be registered under the strict posture");
+        let registry =
+            extract_registry(Some(&metadata), &near_allowlist(), &require_signed_policy())
+                .expect("signed entry must still be registered under the strict posture");
         let meta = registry.by_asset_id.get(ASSET_ID).expect("present");
         assert_eq!(meta.symbol, "USDC.e");
         assert!(
@@ -1153,7 +1196,7 @@ mod tests {
                 )]),
             })),
         };
-        let registry = try_extract_from_chain_metadata(
+        let registry = extract_registry(
             Some(&metadata),
             &near_allowlist(),
             &accept_unsigned_policy(),
@@ -1187,7 +1230,7 @@ mod tests {
         };
         // No allowlist authorizes the dev seed used above.
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &empty_allowlists(),
                 &accept_unsigned_policy()
@@ -1212,7 +1255,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1237,7 +1280,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1266,7 +1309,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1291,7 +1334,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1319,7 +1362,7 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
@@ -1348,13 +1391,205 @@ mod tests {
             })),
         };
         assert!(
-            try_extract_from_chain_metadata(
+            extract_registry(
                 Some(&metadata),
                 &near_allowlist(),
                 &accept_unsigned_policy()
             )
             .is_none()
         );
+    }
+
+    /// Every refusal path reports itself in `rejected`, keyed by asset id.
+    ///
+    /// A refused entry that reported nothing would leave the signer looking at
+    /// an amount rendered without the metadata they supplied, with the reason
+    /// only in an operator log.
+    #[test]
+    fn every_refusal_path_reports_the_rejected_entry() {
+        let signed_by_dev_key = |asset_id: &str, value: &str| {
+            Some(sign_token_metadata_ed25519(
+                asset_id,
+                value,
+                &DEV_NEAR_SIGNING_KEY_SEED,
+                visualsign::signing::near_token_metadata_prehash,
+            ))
+        };
+
+        // (case, asset id, entry, policy, expected reason fragment)
+        let cases: Vec<(&str, &str, TokenMetadataEntry, MetadataTrustPolicy, &str)> = vec![
+            (
+                "oversized value",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: format!(
+                        r#"{{"symbol":"X","decimals":6,"pad":"{}"}}"#,
+                        "p".repeat(1100)
+                    ),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "exceeds size limit",
+            ),
+            (
+                "unsigned under require-signed",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                require_signed_policy(),
+                "requires signed entries",
+            ),
+            (
+                "unsigned override of a curated seed",
+                ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "would override a curated seed",
+            ),
+            (
+                "signature from an unlisted signer",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: VALUE.to_string(),
+                    signature: signed_by_dev_key(UNSEEDED_ASSET_ID, VALUE),
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "signer not in allowlist",
+            ),
+            (
+                "value that isn't the expected JSON",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: "not json at all".to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "invalid value JSON",
+            ),
+            (
+                "decimals past the formatting bound",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"X","decimals":39}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "decimals 39 out of range",
+            ),
+            (
+                "empty symbol",
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"","decimals":6}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+                accept_unsigned_policy(),
+                "symbol length 0 out of range",
+            ),
+        ];
+
+        for (case, asset_id, entry, policy, expected_reason) in cases {
+            // An allowlist with no entries at all, so the "unlisted signer"
+            // case is refused on identity rather than on a bad signature.
+            let allowlists = TokenMetadataSignerAllowlists {
+                near: SignerAllowlist::new(),
+                ethereum: SignerAllowlist::new(),
+                solana: SignerAllowlist::new(),
+            };
+            let metadata = chain_metadata_with(vec![(asset_id, entry)]);
+            let extraction = try_extract_from_chain_metadata(Some(&metadata), &allowlists, &policy);
+
+            assert!(
+                extraction.registry.is_none(),
+                "{case}: entry must be refused, not registered"
+            );
+            assert_eq!(
+                extraction.rejected.len(),
+                1,
+                "{case}: expected exactly one reported rejection, got {:?}",
+                extraction.rejected
+            );
+            assert_eq!(
+                extraction.rejected[0].asset_id, asset_id,
+                "{case}: rejection must name the asset id it was keyed under"
+            );
+            assert!(
+                extraction.rejected[0].reason.contains(expected_reason),
+                "{case}: reason should mention '{expected_reason}', got '{}'",
+                extraction.rejected[0].reason
+            );
+        }
+    }
+
+    /// An accepted entry reports no rejection, so the diagnostic can't fire on
+    /// the happy path.
+    #[test]
+    fn an_accepted_entry_reports_no_rejection() {
+        let metadata = chain_metadata_with(vec![(
+            UNSEEDED_ASSET_ID,
+            TokenMetadataEntry {
+                value: VALUE.to_string(),
+                signature: None,
+                origin_chain: None,
+            },
+        )]);
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+        assert!(extraction.registry.is_some(), "entry should be accepted");
+        assert!(
+            extraction.rejected.is_empty(),
+            "an accepted entry must report no rejection, got {:?}",
+            extraction.rejected
+        );
+    }
+
+    /// One refused entry doesn't take the surviving ones down with it.
+    #[test]
+    fn a_refused_entry_does_not_discard_the_entries_beside_it() {
+        let good = "nep141:good-unlisted-token.near";
+        let metadata = chain_metadata_with(vec![
+            (
+                good,
+                TokenMetadataEntry {
+                    value: r#"{"symbol":"GOOD","decimals":6}"#.to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+            ),
+            (
+                UNSEEDED_ASSET_ID,
+                TokenMetadataEntry {
+                    value: "not json".to_string(),
+                    signature: None,
+                    origin_chain: None,
+                },
+            ),
+        ]);
+
+        let extraction = try_extract_from_chain_metadata(
+            Some(&metadata),
+            &near_allowlist(),
+            &accept_unsigned_policy(),
+        );
+        let registry = extraction.registry.expect("the good entry should survive");
+        assert!(registry.by_asset_id.contains_key(good));
+        assert_eq!(extraction.rejected.len(), 1);
+        assert_eq!(extraction.rejected[0].asset_id, UNSEEDED_ASSET_ID);
     }
 
     /// A CLI-signed entry must verify under `authorized_token_metadata_signers`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -114,9 +114,14 @@ fn usable(meta: TokenMeta) -> Option<TokenMeta> {
     (meta.decimals <= MAX_DECIMALS).then_some(meta)
 }
 
-/// Whether `asset_id` has a compiled-in, verified entry in [`SEEDS`].
-pub(crate) fn is_seeded(asset_id: &str) -> bool {
-    SEEDS.iter().any(|(id, _, _)| *id == asset_id)
+/// The curated `decimals` for `asset_id`, or `None` when [`SEEDS`] does not
+/// cover it. A refusal quotes this against the proposed value, so the signer
+/// sees what was attempted rather than only that something was dropped.
+pub(crate) fn seeded_decimals(asset_id: &str) -> Option<u8> {
+    SEEDS
+        .iter()
+        .find(|(id, _, _)| *id == asset_id)
+        .map(|(_, _, decimals)| *decimals)
 }
 
 /// Resolve an asset id to its metadata: request-scoped override layer first
@@ -286,9 +291,12 @@ mod tests {
     }
 
     #[test]
-    fn is_seeded_matches_seeds_table() {
-        assert!(is_seeded("nep141:wrap.near"));
-        assert!(!is_seeded("nep141:not-a-real-token.near"));
+    /// The extraction path quotes this value against a proposed one when
+    /// refusing an unattributed override, so it has to be the seed's own
+    /// `decimals` and `None` for an asset the table does not cover.
+    fn seeded_decimals_matches_seeds_table() {
+        assert_eq!(seeded_decimals("nep141:wrap.near"), Some(24));
+        assert_eq!(seeded_decimals("nep141:not-a-real-token.near"), None);
     }
 
     #[test]

--- a/src/parser/app/Cargo.toml
+++ b/src/parser/app/Cargo.toml
@@ -46,8 +46,8 @@ tron = ["dep:visualsign-tron"]
 unspecified = ["dep:visualsign-unspecified"]
 diagnostics = [
     "visualsign/diagnostics",
-    "visualsign-solana?/diagnostics",
     "visualsign-near?/diagnostics",
+    "visualsign-solana?/diagnostics",
 ]
 vsock = ["qos_core/vm"]
 

--- a/src/parser/cli-core/Cargo.toml
+++ b/src/parser/cli-core/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [features]
 # Exposes test helper utilities for use in downstream crates' test suites.
 test-utils = []
+# Renders `SignablePayloadField::Diagnostic`, which the core crate only defines
+# under its own `diagnostics` feature.
+diagnostics = ["visualsign/diagnostics"]
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }

--- a/src/parser/cli-core/src/output.rs
+++ b/src/parser/cli-core/src/output.rs
@@ -253,9 +253,11 @@ pub fn parse_and_display(
     Ok(())
 }
 
+/// Named for the variant it covers rather than the file, so it can sit
+/// alongside `output.rs`'s general formatter tests without colliding.
 #[cfg(all(test, feature = "diagnostics"))]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-mod tests {
+mod diagnostic_tests {
     use super::*;
     use visualsign::{SignablePayloadFieldCommon, SignablePayloadFieldDiagnostic};
 

--- a/src/parser/cli-core/src/output.rs
+++ b/src/parser/cli-core/src/output.rs
@@ -138,6 +138,22 @@ impl<'a> HumanReadableFormatter<'a> {
                     prefix, common.label, address_v2.address
                 )?;
             }
+            // Rendered rather than falling through to the `Unknown` arm below:
+            // a diagnostic printed as "Field: Unknown" tells the reader nothing,
+            // which defeats the point of emitting it. `--output json` carries the
+            // full structured form; this is the human view of the same finding.
+            #[cfg(feature = "diagnostics")]
+            SignablePayloadField::Diagnostic { diagnostic, .. } => {
+                let index = diagnostic
+                    .instruction_index
+                    .map(|i| format!(" (instruction {i})"))
+                    .unwrap_or_default();
+                writeln!(
+                    writer,
+                    "{} [{}] {}{}: {}",
+                    prefix, diagnostic.level, diagnostic.rule, index, diagnostic.message
+                )?;
+            }
             _ => {
                 writeln!(writer, "{} Field: {}", prefix, common_label(field))?;
             }
@@ -235,4 +251,75 @@ pub fn parse_and_display(
         eprintln!("{}", hex::encode(bytes));
     }
     Ok(())
+}
+
+#[cfg(all(test, feature = "diagnostics"))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use visualsign::{SignablePayloadFieldCommon, SignablePayloadFieldDiagnostic};
+
+    fn diagnostic_field(
+        rule: &str,
+        level: &str,
+        message: &str,
+        instruction_index: Option<u32>,
+    ) -> SignablePayloadField {
+        SignablePayloadField::Diagnostic {
+            common: SignablePayloadFieldCommon {
+                fallback_text: format!("{level}: {message}"),
+                label: rule.to_string(),
+            },
+            diagnostic: SignablePayloadFieldDiagnostic {
+                rule: rule.to_string(),
+                domain: "test".to_string(),
+                level: level.to_string(),
+                message: message.to_string(),
+                instruction_index,
+            },
+        }
+    }
+
+    fn render(fields: Vec<SignablePayloadField>) -> String {
+        let payload =
+            SignablePayload::new(0, "Test".to_string(), None, fields, "TestTx".to_string());
+        HumanReadableFormatter::new(&payload, false).to_string()
+    }
+
+    /// A diagnostic has to say what it found. Falling through to the catch-all
+    /// arm prints "Field: Unknown", which reports that something was emitted
+    /// while withholding every part a reader needs.
+    #[test]
+    fn human_output_renders_a_diagnostic_rule_level_and_message() {
+        let rendered = render(vec![diagnostic_field(
+            "deadline",
+            "warn",
+            "deadline has passed",
+            None,
+        )]);
+        assert!(
+            rendered.contains("[warn] deadline: deadline has passed"),
+            "diagnostic should render its level, rule, and message: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Field: Unknown"),
+            "diagnostic must not fall through to the unknown-field arm: {rendered}"
+        );
+    }
+
+    /// Solana's diagnostics carry the instruction they came from; dropping it
+    /// leaves the reader unable to tell which instruction to look at.
+    #[test]
+    fn human_output_includes_a_diagnostics_instruction_index() {
+        let rendered = render(vec![diagnostic_field(
+            "transaction::oob_account_index",
+            "warn",
+            "index 7 out of bounds",
+            Some(2),
+        )]);
+        assert!(
+            rendered.contains("(instruction 2)"),
+            "an indexed diagnostic should name its instruction: {rendered}"
+        );
+    }
 }

--- a/src/parser/cli-core/src/output.rs
+++ b/src/parser/cli-core/src/output.rs
@@ -138,6 +138,15 @@ impl<'a> HumanReadableFormatter<'a> {
                     prefix, common.label, address_v2.address
                 )?;
             }
+            // Rendered rather than falling through to the accessor arm below,
+            // which would reduce a diagnostic to its label and fallback text and
+            // drop the level, rule and instruction index that carry most of its
+            // meaning. `--output json` carries the full structured form; this is
+            // the human view of the same finding.
+            #[cfg(feature = "diagnostics")]
+            SignablePayloadField::Diagnostic { diagnostic, .. } => {
+                write_diagnostic(diagnostic, writer, prefix)?;
+            }
             // Every remaining variant renders from the accessors, which are
             // exhaustive over the enum. A variant added later prints its
             // label and value rather than silently reading as "Unknown".
@@ -153,6 +162,27 @@ impl<'a> HumanReadableFormatter<'a> {
         }
         Ok(())
     }
+}
+
+/// Render one diagnostic as `[level] rule (instruction N): message`.
+///
+/// Split out of `format_field` so that arm stays a single line there: the match
+/// covers every field variant and is already at the length clippy allows.
+#[cfg(feature = "diagnostics")]
+fn write_diagnostic(
+    diagnostic: &visualsign::SignablePayloadFieldDiagnostic,
+    writer: &mut dyn std::fmt::Write,
+    prefix: &str,
+) -> std::fmt::Result {
+    let index = diagnostic
+        .instruction_index
+        .map(|i| format!(" (instruction {i})"))
+        .unwrap_or_default();
+    writeln!(
+        writer,
+        "{} [{}] {}{}: {}",
+        prefix, diagnostic.level, diagnostic.rule, index, diagnostic.message
+    )
 }
 
 impl std::fmt::Display for HumanReadableFormatter<'_> {
@@ -234,7 +264,6 @@ pub fn parse_and_display(
     }
     Ok(())
 }
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -242,6 +271,8 @@ mod tests {
     use visualsign::field_builders::{
         create_amount_field, create_number_field, create_preview_layout, create_text_field,
     };
+    #[cfg(feature = "diagnostics")]
+    use visualsign::{SignablePayloadFieldCommon, SignablePayloadFieldDiagnostic};
 
     fn payload_of(fields: Vec<SignablePayloadField>) -> SignablePayload {
         SignablePayload::new(0, "Test".to_string(), None, fields, "TestTx".to_string())
@@ -298,5 +329,66 @@ mod tests {
         let out = render(vec![layout.signable_payload_field]);
         assert!(out.contains("Slippage: 50 bps"), "{out}");
         assert!(!out.contains("Unknown"), "{out}");
+    }
+
+    #[cfg(feature = "diagnostics")]
+    fn diagnostic_field(
+        rule: &str,
+        level: &str,
+        message: &str,
+        instruction_index: Option<u32>,
+    ) -> SignablePayloadField {
+        SignablePayloadField::Diagnostic {
+            common: SignablePayloadFieldCommon {
+                fallback_text: format!("{level}: {message}"),
+                label: rule.to_string(),
+            },
+            diagnostic: SignablePayloadFieldDiagnostic {
+                rule: rule.to_string(),
+                domain: "test".to_string(),
+                level: level.to_string(),
+                message: message.to_string(),
+                instruction_index,
+            },
+        }
+    }
+
+    /// A diagnostic has to say what it found. Falling through to the catch-all
+    /// arm prints "Field: Unknown", which reports that something was emitted
+    /// while withholding every part a reader needs.
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn human_output_renders_a_diagnostic_rule_level_and_message() {
+        let rendered = render(vec![diagnostic_field(
+            "deadline",
+            "warn",
+            "deadline has passed",
+            None,
+        )]);
+        assert!(
+            rendered.contains("[warn] deadline: deadline has passed"),
+            "diagnostic should render its level, rule, and message: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Field: Unknown"),
+            "diagnostic must not fall through to the unknown-field arm: {rendered}"
+        );
+    }
+
+    /// Solana's diagnostics carry the instruction they came from; dropping it
+    /// leaves the reader unable to tell which instruction to look at.
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn human_output_includes_a_diagnostics_instruction_index() {
+        let rendered = render(vec![diagnostic_field(
+            "transaction::oob_account_index",
+            "warn",
+            "index 7 out of bounds",
+            Some(2),
+        )]);
+        assert!(
+            rendered.contains("(instruction 2)"),
+            "an indexed diagnostic should name its instruction: {rendered}"
+        );
     }
 }

--- a/src/parser/cli/Cargo.toml
+++ b/src/parser/cli/Cargo.toml
@@ -12,8 +12,9 @@ near = ["dep:visualsign-near", "visualsign-near/dev-signing"]
 tron = ["dep:visualsign-tron"]
 diagnostics = [
     "visualsign/diagnostics",
-    "visualsign-solana?/diagnostics",
+    "parser_cli_core/diagnostics",
     "visualsign-near?/diagnostics",
+    "visualsign-solana?/diagnostics",
 ]
 serve = ["dep:axum", "dep:tokio", "dep:serde", "dep:serde_json"]
 

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -52,6 +52,8 @@ fn test_cli_with_fixtures() {
     let disabled_chain_prefixes: &[&str] = &[
         #[cfg(not(feature = "ethereum"))]
         "ethereum",
+        #[cfg(not(feature = "near"))]
+        "near",
         #[cfg(not(feature = "solana"))]
         "solana",
         #[cfg(not(feature = "tron"))]

--- a/src/parser/cli/tests/fixtures/near-json.diagnostics.expected
+++ b/src/parser/cli/tests/fixtures/near-json.diagnostics.expected
@@ -1,0 +1,3 @@
+[
+  { "rule": "deadline", "level": "warn" }
+]

--- a/src/parser/cli/tests/fixtures/near-json.display.expected
+++ b/src/parser/cli/tests/fixtures/near-json.display.expected
@@ -1,6 +1,14 @@
 {
   "Fields": [
     {
+      "FallbackText": "NEAR Mainnet",
+      "Label": "Network",
+      "TextV2": {
+        "Text": "NEAR Mainnet"
+      },
+      "Type": "text_v2"
+    },
+    {
       "FallbackText": "alice.near",
       "Label": "Signer",
       "TextV2": {

--- a/src/parser/cli/tests/fixtures/near-json.display.expected
+++ b/src/parser/cli/tests/fixtures/near-json.display.expected
@@ -1,0 +1,64 @@
+{
+  "Fields": [
+    {
+      "FallbackText": "alice.near",
+      "Label": "Signer",
+      "TextV2": {
+        "Text": "alice.near"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "FallbackText": "intents.near",
+      "Label": "Verifying Contract",
+      "TextV2": {
+        "Text": "intents.near"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "FallbackText": "2020-01-01T00:00:00+00:00",
+      "Label": "Deadline",
+      "TextV2": {
+        "Text": "2020-01-01T00:00:00+00:00"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "FallbackText": "0x5d5a0a7e649c6f71be5ea1fd91efdf4a527fdf13b9f6c3610b18691bcdb5047f",
+      "Label": "Nonce",
+      "TextV2": {
+        "Text": "0x5d5a0a7e649c6f71be5ea1fd91efdf4a527fdf13b9f6c3610b18691bcdb5047f"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "FallbackText": "wrap.near",
+      "Label": "Token",
+      "TextV2": {
+        "Text": "wrap.near"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "FallbackText": "bob.near",
+      "Label": "To",
+      "TextV2": {
+        "Text": "bob.near"
+      },
+      "Type": "text_v2"
+    },
+    {
+      "AmountV2": {
+        "Abbreviation": "wNEAR",
+        "Amount": "1"
+      },
+      "FallbackText": "1 wNEAR",
+      "Label": "Amount",
+      "Type": "amount_v2"
+    }
+  ],
+  "PayloadType": "NearTx",
+  "Title": "NEAR Intent",
+  "Version": "0"
+}

--- a/src/parser/cli/tests/fixtures/near-json.input
+++ b/src/parser/cli/tests/fixtures/near-json.input
@@ -1,0 +1,7 @@
+decode
+--chain
+near
+-o
+json
+-t
+{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2020-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}


### PR DESCRIPTION
Turns on the `diagnostics` feature for `visualsign-near` and closes the one gap
that needed new code rather than a flag flip: token-metadata entries the parser
refuses are reported to the signer instead of only to an operator log.

Stacked on #437 (`near-e-cli-token-metadata`).

## What was already in place, and what wasn't

`visualsign-near` declares `diagnostics = ["visualsign/diagnostics"]`, and
`render.rs` routes every soft finding (`signature`, `account-binding`,
`deadline`, `extraction`, `unverified-token-metadata`) through one
feature-aware `diagnostic()` helper. But nothing enabled that feature: neither
`parser_cli`'s nor `parser_app`'s `diagnostics` propagated into the crate, so
the structured half of that helper was dead code.

Refused token-metadata entries were the real gap.
`try_extract_from_chain_metadata` dropped them with a `tracing::warn!` and
returned only the survivors. A caller supplying metadata the parser then threw
away learned nothing from the payload: the signer saw an amount in raw base
units against an `unresolved` asset id, or resolved from a seed instead of the
supplied override, and the reason lived in a log the caller cannot read.

## Changes

**Extraction reports refusals.** It returns
`TokenMetadataExtraction { registry, rejected }`. A `reject!` macro binds each
refusal to its `continue`, so a new rejection path cannot be added without
reporting it — all nine paths (oversized value, unrecognized `origin_chain`,
unattributable under require-signed, unattributable seed override, unrecognized
signer under require-signed, malformed value JSON, decimals out of range, symbol
length, symbol outside printable ASCII) are covered by one table-driven test.
A mapping over the entry cap is refused as a unit and reports one rejection
covering the whole map, rather than one per entry.

**Rendering.** `rejected_metadata_diagnostics` emits a new
`rejected-token-metadata` rule per refused entry, alongside the intents rather
than replacing them — the refusal protects the render, it doesn't invalidate
it. Both halves of the message pass through `charset_safe`: the asset id is a
caller-controlled map key and the reason can quote it back (a JSON parse error,
a length), so an embedded newline would otherwise render as extra apparent
fields on the signing screen. That is the same class already fixed for
`memo`/`msg`/`method_name`, reached through a different field, and it has its
own regression test.

**One registry per conversion.** It was built inside `decode_intents`, once per
action. Since the metadata is request-scoped, a two-action transaction would
have repeated every rejection. Built once in `render_on_chain` now, with a test
pinning the count.

**Feature propagation and CI.** `parser_cli`, `parser_cli_core` and
`parser_app` propagate `diagnostics` to `visualsign-near`. `make test` and
`make lint` gained `-p visualsign-near --features diagnostics --lib` and the
`parser_cli_core` equivalent, matching the convention in
`docs/contributor-guides/lint-diagnostics.mdx`. A `near-json` CLI fixture pair
(`.display.expected` + `.diagnostics.expected`, generated from real output)
covers the rendered form, and the fixture harness's chain skip-list gained the
`near` entry it was missing, so a `--no-default-features` build skips it
correctly.

**The CLI human view flattens diagnostics.** `format_field`'s accessor arm
renders any variant it has no case for from `label()`/`fallback_text()`, which
for a diagnostic drops the level, rule and instruction index — most of what it
carries. A `Diagnostic` arm now prints all of them, which improves Solana's
diagnostics in that view too:

```
   ├─ [warn] rejected-token-metadata: token metadata supplied for nep141:my-token.near was rejected and not used: invalid value JSON: missing field `symbol`
   ├─ [warn] deadline: deadline has passed; the intents would be rejected
```

The arm's body lives in `write_diagnostic` so `format_field` stays within
clippy's line limit — its match already covers every field variant. The arm and
its two tests are gated on a new `parser_cli_core/diagnostics` feature, because
`visualsign` only defines the `Diagnostic` variant under its own.

## Payload shape

A refused entry adds one field where there was none. With `diagnostics` off —
`parser_app`, the production shape HSMs and wallets derive a metadata digest
from — that is a `Warning` text field, matching how NEAR's other soft findings
already degrade. Requests that supply no metadata, or whose metadata is
accepted, are unchanged.

## Docs

`lint-diagnostics.mdx` gains NEAR in the feature list and CI-invocation
description, plus a per-chain rule table. The NEAR section explains the two
ways NEAR differs from Solana's convention: bare rule names rather than
`domain::rule_name`, and a `Warning`-text fallback instead of dropping the
finding when the feature is off.

`make lint` and `make test` are green across the workspace in both feature
states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

