### PR TITLE
refactor(host_primitives): single home for the Turnkey wire envelope

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4229,8 +4229,11 @@ name = "host_primitives"
 version = "0.1.0"
 dependencies = [
  "borsh 1.6.0",
+ "generated",
  "prost 0.12.6",
  "qos_core",
+ "serde",
+ "serde_json",
  "tonic 0.10.2",
 ]
 

--- a/src/host_primitives/Cargo.toml
+++ b/src/host_primitives/Cargo.toml
@@ -16,6 +16,11 @@ borsh = { version = "1.0", features = [
   "std",
   "derive",
 ], default-features = false }
+generated = { path = "../generated", features = ["serde_derive"] }
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/host_primitives/src/lib.rs
+++ b/src/host_primitives/src/lib.rs
@@ -9,6 +9,8 @@ use prost::Message;
 use qos_core::protocol::{ProtocolError, msg::ProtocolMsg};
 use tonic::Status;
 
+pub mod turnkey;
+
 /// Buffer size for socket message queue.
 pub static ENCLAVE_QUEUE_CAPACITY: usize = 12;
 /// Maximum gRPC message size. Set to 25MB (25*1024*1024)

--- a/src/host_primitives/src/turnkey.rs
+++ b/src/host_primitives/src/turnkey.rs
@@ -24,8 +24,9 @@ pub struct TurnkeyRequest {
     pub include_intermediate_output: bool,
 }
 
-// ChainMetadataInput needs Serialize too so parser_gateway can build the
-// outbound HTTP body symmetrically with what parser_http_server parses.
+// Serialize is derived on the request types (not just Deserialize) for a future
+// caller that builds this envelope symmetrically to what parses it; no in-tree
+// consumer serializes a request today.
 
 /// Tagged representation of chain metadata for unambiguous JSON deserialization.
 ///
@@ -138,6 +139,22 @@ pub fn error_response(msg: String, boot_proof: TurnkeyBootProof) -> TurnkeyRespo
             },
         },
         error: Some(msg),
+    }
+}
+
+/// Success envelope. `boot_proof` is injected by the caller for the same reason as
+/// in [`error_response`].
+pub fn success_response(
+    boot_proof: TurnkeyBootProof,
+    payload: TurnkeyPayload,
+    signature: Option<TurnkeySignature>,
+) -> TurnkeyResponseWrapper {
+    TurnkeyResponseWrapper {
+        boot_proof,
+        response: TurnkeyResponse {
+            parsed_transaction: TurnkeyParsedTransaction { payload, signature },
+        },
+        error: None,
     }
 }
 

--- a/src/host_primitives/src/turnkey.rs
+++ b/src/host_primitives/src/turnkey.rs
@@ -1,0 +1,230 @@
+//! Turnkey-compatible request/response envelope for parse endpoints.
+
+use generated::parser::{ChainMetadata, EthereumMetadata, SolanaMetadata, chain_metadata};
+use serde::{Deserialize, Serialize};
+
+/// SHA-256 of empty input: used as the canonical "no data" sentinel for digest fields
+/// in error responses, where we have no real payload to digest.
+pub const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+#[derive(Deserialize, Serialize)]
+pub struct TurnkeyRequestWrapper {
+    pub request: TurnkeyRequest,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct TurnkeyRequest {
+    pub unsigned_payload: String,
+    pub chain: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_metadata: Option<ChainMetadataInput>,
+    /// Opt-in for the chain-specific `intermediate_output` blob. Defaults to
+    /// false so existing REST callers that omit it behave exactly as before.
+    #[serde(default)]
+    pub include_intermediate_output: bool,
+}
+
+// ChainMetadataInput needs Serialize too so parser_gateway can build the
+// outbound HTTP body symmetrically with what parser_http_server parses.
+
+/// Tagged representation of chain metadata for unambiguous JSON deserialization.
+///
+/// The generated `ChainMetadata` uses `serde(untagged)` on the inner oneof enum, which means
+/// serde tries Ethereum first. A Solana payload with only `networkId` would be silently
+/// decoded as `EthereumMetadata`. This wrapper uses an explicit `chain` discriminator.
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "chain", rename_all = "camelCase")]
+pub enum ChainMetadataInput {
+    #[serde(rename = "CHAIN_ETHEREUM")]
+    Ethereum(EthereumMetadata),
+    #[serde(rename = "CHAIN_SOLANA")]
+    Solana(SolanaMetadata),
+}
+
+impl From<ChainMetadataInput> for ChainMetadata {
+    fn from(input: ChainMetadataInput) -> Self {
+        let metadata = match input {
+            ChainMetadataInput::Ethereum(eth) => chain_metadata::Metadata::Ethereum(eth),
+            ChainMetadataInput::Solana(sol) => chain_metadata::Metadata::Solana(sol),
+        };
+        ChainMetadata {
+            metadata: Some(metadata),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeyResponseWrapper {
+    /// Top-level boot proof, matching the production Turnkey visualsign API
+    /// response shape that wallet integrators consume. Injected by the caller
+    /// because the value is deployment-specific: `parser_gateway` supplies a
+    /// stable local-dev mock, `parser_http_server` supplies the real attested
+    /// one. See issue #337.
+    pub boot_proof: TurnkeyBootProof,
+    pub response: TurnkeyResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Boot proof object shape, matching the production Turnkey visualsign API
+/// that wallet integrators consume. The reference Go client uses the same
+/// field names — see [visualsign-turnkeyclient/api/types.go::TurnkeyBootProof][types].
+///
+/// [types]: https://github.com/anchorageoss/visualsign-turnkeyclient/blob/main/api/types.go#L128
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeyBootProof {
+    pub aws_attestation_doc_b64: String,
+    pub qos_manifest_b64: String,
+    pub qos_manifest_envelope_b64: String,
+    pub ephemeral_public_key_hex: String,
+    pub enclave_app: String,
+    pub deployment_label: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeyResponse {
+    pub parsed_transaction: TurnkeyParsedTransaction,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeyParsedTransaction {
+    pub payload: TurnkeyPayload,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<TurnkeySignature>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeyPayload {
+    pub signable_payload: String,
+    pub metadata_digest: String,
+    pub input_payload_digest: String,
+    /// Chain-specific, borsh-serialized structured decode, base64-encoded (proto
+    /// `bytes` JSON convention). Empty and omitted from the response when the
+    /// request did not opt in or the chain has no intermediate output, so
+    /// responses to existing consumers stay byte-identical.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub intermediate_output: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnkeySignature {
+    pub message: String,
+    pub public_key: String,
+    pub scheme: String,
+    pub signature: String,
+}
+
+/// Error envelope. `boot_proof` is injected by the caller because the value is
+/// deployment-specific: `parser_gateway` supplies a stable local-dev mock,
+/// `parser_http_server` supplies the real attested one.
+pub fn error_response(msg: String, boot_proof: TurnkeyBootProof) -> TurnkeyResponseWrapper {
+    TurnkeyResponseWrapper {
+        boot_proof,
+        response: TurnkeyResponse {
+            parsed_transaction: TurnkeyParsedTransaction {
+                payload: TurnkeyPayload {
+                    signable_payload: String::new(),
+                    metadata_digest: EMPTY_SHA256.to_string(),
+                    input_payload_digest: EMPTY_SHA256.to_string(),
+                    intermediate_output: String::new(),
+                },
+                signature: None,
+            },
+        },
+        error: Some(msg),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn probe_boot_proof() -> TurnkeyBootProof {
+        TurnkeyBootProof {
+            aws_attestation_doc_b64: "doc".to_string(),
+            qos_manifest_b64: "man".to_string(),
+            qos_manifest_envelope_b64: "env".to_string(),
+            ephemeral_public_key_hex: "02ab".to_string(),
+            enclave_app: "visualsign-parser".to_string(),
+            deployment_label: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn boot_proof_wire_shape_is_exactly_six_camel_case_keys() {
+        // Wallet contract, issue #337. Field set is fixed by
+        // visualsign-turnkeyclient/api/types.go::TurnkeyBootProof.
+        let value = serde_json::to_value(probe_boot_proof()).unwrap();
+        let keys: std::collections::BTreeSet<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let expected: std::collections::BTreeSet<&str> = [
+            "awsAttestationDocB64",
+            "qosManifestB64",
+            "qosManifestEnvelopeB64",
+            "ephemeralPublicKeyHex",
+            "enclaveApp",
+            "deploymentLabel",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            keys, expected,
+            "bootProof field set must match production wire shape exactly"
+        );
+    }
+
+    #[test]
+    fn error_response_carries_the_supplied_boot_proof() {
+        // Strict consumers reject any response without bootProof, including errors.
+        let resp = error_response("oops".to_string(), probe_boot_proof());
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            value.get("bootProof").unwrap().get("enclaveApp").unwrap(),
+            "visualsign-parser"
+        );
+        assert_eq!(value.get("error").unwrap(), "oops");
+        assert_eq!(
+            value
+                .get("response")
+                .unwrap()
+                .get("parsedTransaction")
+                .unwrap()
+                .get("payload")
+                .unwrap()
+                .get("metadataDigest")
+                .unwrap(),
+            EMPTY_SHA256
+        );
+    }
+
+    #[test]
+    fn intermediate_output_empty_is_omitted() {
+        // Byte-identical responses for callers that did not opt in (#414).
+        let payload = TurnkeyPayload {
+            signable_payload: "sp".to_string(),
+            metadata_digest: "md".to_string(),
+            input_payload_digest: "ipd".to_string(),
+            intermediate_output: String::new(),
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert!(value.get("intermediateOutput").is_none());
+    }
+
+    #[test]
+    fn chain_metadata_input_solana_not_misread_as_ethereum() {
+        let json = r#"{"chain":"CHAIN_SOLANA","networkId":"solana-mainnet"}"#;
+        let parsed: ChainMetadataInput = serde_json::from_str(json).unwrap();
+        assert!(matches!(parsed, ChainMetadataInput::Solana(_)));
+    }
+}

--- a/src/host_primitives/src/turnkey.rs
+++ b/src/host_primitives/src/turnkey.rs
@@ -108,7 +108,7 @@ pub struct TurnkeyPayload {
     /// `bytes` JSON convention). Empty and omitted from the response when the
     /// request did not opt in or the chain has no intermediate output, so
     /// responses to existing consumers stay byte-identical.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub intermediate_output: String,
 }
 
@@ -243,5 +243,24 @@ mod tests {
         let json = r#"{"chain":"CHAIN_SOLANA","networkId":"solana-mainnet"}"#;
         let parsed: ChainMetadataInput = serde_json::from_str(json).unwrap();
         assert!(matches!(parsed, ChainMetadataInput::Solana(_)));
+    }
+
+    #[test]
+    fn response_wrapper_round_trips_when_intermediate_output_is_omitted() {
+        // A response with no intermediate_output must still deserialize back into
+        // TurnkeyResponseWrapper, not just serialize cleanly: the omitted key needs
+        // a default on the way back in, since this is the shape every existing
+        // caller produces.
+        let resp = error_response("oops".to_string(), probe_boot_proof());
+        let json = serde_json::to_string(&resp).unwrap();
+        let round_tripped: TurnkeyResponseWrapper = serde_json::from_str(&json).unwrap();
+        assert!(
+            round_tripped
+                .response
+                .parsed_transaction
+                .payload
+                .intermediate_output
+                .is_empty()
+        );
     }
 }

--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -20,9 +20,9 @@ use generated::parser::{
 use generated::tonic;
 use host_primitives::GRPC_MAX_RECV_MSG_SIZE;
 use host_primitives::turnkey::{
-    TurnkeyBootProof, TurnkeyParsedTransaction, TurnkeyPayload, TurnkeyRequestWrapper,
-    TurnkeyResponse, TurnkeyResponseWrapper, TurnkeySignature,
-    error_response as turnkey_error_response,
+    TurnkeyBootProof, TurnkeyPayload, TurnkeyRequestWrapper, TurnkeyResponseWrapper,
+    TurnkeySignature, error_response as turnkey_error_response,
+    success_response as turnkey_success_response,
 };
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -198,25 +198,20 @@ async fn parse_handler(
 
     (
         StatusCode::OK,
-        Json(TurnkeyResponseWrapper {
-            boot_proof: mock_boot_proof(),
-            response: TurnkeyResponse {
-                parsed_transaction: TurnkeyParsedTransaction {
-                    payload: TurnkeyPayload {
-                        signable_payload: payload.parsed_payload,
-                        metadata_digest: payload.metadata_digest,
-                        input_payload_digest: payload.input_payload_digest,
-                        // base64 of an empty Vec is "", which serde omits (see
-                        // skip_serializing_if) so the non-intermediate response
-                        // is unchanged.
-                        intermediate_output: base64::engine::general_purpose::STANDARD
-                            .encode(&payload.intermediate_output),
-                    },
-                    signature,
-                },
+        Json(turnkey_success_response(
+            mock_boot_proof(),
+            TurnkeyPayload {
+                signable_payload: payload.parsed_payload,
+                metadata_digest: payload.metadata_digest,
+                input_payload_digest: payload.input_payload_digest,
+                // base64 of an empty Vec is "", which serde omits (see
+                // skip_serializing_if) so the non-intermediate response
+                // is unchanged.
+                intermediate_output: base64::engine::general_purpose::STANDARD
+                    .encode(&payload.intermediate_output),
             },
-            error: None,
-        }),
+            signature,
+        )),
     )
 }
 
@@ -318,23 +313,6 @@ mod tests {
     }
 
     #[test]
-    fn intermediate_output_empty_is_omitted() {
-        // Existing consumers and existing-parser responses must see byte-identical
-        // JSON when there is no intermediate output: the key is absent, not "".
-        let payload = TurnkeyPayload {
-            signable_payload: "sp".to_string(),
-            metadata_digest: "md".to_string(),
-            input_payload_digest: "ipd".to_string(),
-            intermediate_output: String::new(),
-        };
-        let value = serde_json::to_value(&payload).unwrap();
-        assert!(
-            value.get("intermediateOutput").is_none(),
-            "empty intermediate output must be omitted from the response"
-        );
-    }
-
-    #[test]
     fn error_response_carries_mock_boot_proof() {
         // The wallet-integration contract (see issue #337) requires bootProof
         // be present on every response, including parse errors — strict
@@ -350,45 +328,19 @@ mod tests {
 
     #[test]
     fn mock_boot_proof_matches_production_wire_shape() {
-        // Wire-shape parity with the production response that wallet
-        // integrators consume. Field set and JSON keys mirror
-        // visualsign-turnkeyclient/api/types.go: TurnkeyVisualSignResponse
-        // (bootProof at top level) and TurnkeyBootProof (six camelCase keys).
+        // Top-level wire parity: bootProof must sit alongside response, not
+        // nested. bootProof's own field set is covered by
+        // host_primitives::turnkey::boot_proof_wire_shape_is_exactly_six_camel_case_keys.
         let resp = error_response("x".to_string());
         let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
 
         let top_keys: std::collections::BTreeSet<_> =
             value.as_object().unwrap().keys().cloned().collect();
-        // Top-level: bootProof, response, error (error only present when set).
         assert!(
             top_keys.contains("bootProof"),
             "missing top-level bootProof"
         );
         assert!(top_keys.contains("response"), "missing top-level response");
-
-        let bp = value.get("bootProof").unwrap().as_object().unwrap();
-        let bp_keys: std::collections::BTreeSet<&str> = bp.keys().map(String::as_str).collect();
-        let expected: std::collections::BTreeSet<&str> = [
-            "awsAttestationDocB64",
-            "qosManifestB64",
-            "qosManifestEnvelopeB64",
-            "ephemeralPublicKeyHex",
-            "enclaveApp",
-            "deploymentLabel",
-        ]
-        .into_iter()
-        .collect();
-        assert_eq!(
-            bp_keys, expected,
-            "bootProof field set must match production wire shape exactly"
-        );
-    }
-
-    #[test]
-    fn chain_metadata_input_solana_not_misread_as_ethereum() {
-        let json = r#"{"chain":"CHAIN_SOLANA","networkId":"solana-mainnet"}"#;
-        let parsed: ChainMetadataInput = serde_json::from_str(json).unwrap();
-        assert!(matches!(parsed, ChainMetadataInput::Solana(_)));
     }
 
     #[test]

--- a/src/parser/gateway/src/main.rs
+++ b/src/parser/gateway/src/main.rs
@@ -15,89 +15,17 @@ use generated::grpc::health::v1::{
     HealthCheckRequest, health_check_response::ServingStatus, health_client::HealthClient,
 };
 use generated::parser::{
-    Chain, ChainMetadata, EthereumMetadata, ParseRequest, SignatureScheme, SolanaMetadata,
-    chain_metadata, parser_service_client::ParserServiceClient,
+    Chain, ChainMetadata, ParseRequest, SignatureScheme, parser_service_client::ParserServiceClient,
 };
 use generated::tonic;
 use host_primitives::GRPC_MAX_RECV_MSG_SIZE;
-use serde::{Deserialize, Serialize};
+use host_primitives::turnkey::{
+    TurnkeyBootProof, TurnkeyParsedTransaction, TurnkeyPayload, TurnkeyRequestWrapper,
+    TurnkeyResponse, TurnkeyResponseWrapper, TurnkeySignature,
+    error_response as turnkey_error_response,
+};
 use std::net::SocketAddr;
 use std::time::Duration;
-
-#[derive(Deserialize)]
-struct TurnkeyRequestWrapper {
-    request: TurnkeyRequest,
-}
-
-/// Tagged representation of chain metadata for unambiguous JSON deserialization.
-///
-/// The generated `ChainMetadata` uses `serde(untagged)` on the inner oneof enum, which means
-/// serde tries Ethereum first. A Solana payload with only `networkId` would be silently
-/// decoded as `EthereumMetadata`. This wrapper uses an explicit `chain` discriminator.
-#[derive(Deserialize)]
-#[serde(tag = "chain", rename_all = "camelCase")]
-enum ChainMetadataInput {
-    #[serde(rename = "CHAIN_ETHEREUM")]
-    Ethereum(EthereumMetadata),
-    #[serde(rename = "CHAIN_SOLANA")]
-    Solana(SolanaMetadata),
-}
-
-impl From<ChainMetadataInput> for ChainMetadata {
-    fn from(input: ChainMetadataInput) -> Self {
-        let metadata = match input {
-            ChainMetadataInput::Ethereum(eth) => chain_metadata::Metadata::Ethereum(eth),
-            ChainMetadataInput::Solana(sol) => chain_metadata::Metadata::Solana(sol),
-        };
-        ChainMetadata {
-            metadata: Some(metadata),
-        }
-    }
-}
-
-#[derive(Deserialize)]
-struct TurnkeyRequest {
-    unsigned_payload: String,
-    chain: String,
-    chain_metadata: Option<ChainMetadataInput>,
-    /// Opt-in for the chain-specific `intermediate_output` blob. Defaults to
-    /// false so existing REST callers that omit it behave exactly as before.
-    #[serde(default)]
-    include_intermediate_output: bool,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeyResponseWrapper {
-    /// Top-level boot proof, matching the production Turnkey visualsign API
-    /// response shape that wallet integrators consume. parser_gateway always
-    /// emits a stable mock here — the gateway is only used in non-TEE local
-    /// dev/CI, never wrapping a real enclave, so production deployments never
-    /// see these values. Downstream consumers that perform real attestation
-    /// verification will reject the mock, which is correct: this is for
-    /// contract-shape testing (the field must be present), not for letting
-    /// signing actually succeed. See issue #337.
-    boot_proof: TurnkeyBootProof,
-    response: TurnkeyResponse,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-}
-
-/// Boot proof object shape, matching the production Turnkey visualsign API
-/// that wallet integrators consume. The reference Go client uses the same
-/// field names — see [visualsign-turnkeyclient/api/types.go::TurnkeyBootProof][types].
-///
-/// [types]: https://github.com/anchorageoss/visualsign-turnkeyclient/blob/main/api/types.go#L128
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeyBootProof {
-    aws_attestation_doc_b64: String,
-    qos_manifest_b64: String,
-    qos_manifest_envelope_b64: String,
-    ephemeral_public_key_hex: String,
-    enclave_app: String,
-    deployment_label: String,
-}
 
 /// Stable mock used in every gateway response. The base64 sentinels decode to
 /// "TURNKEY_GATEWAY_MOCK_BOOT_PROOF" and "TURNKEY_GATEWAY_MOCK_QOS_MANIFEST*" —
@@ -121,41 +49,10 @@ fn mock_boot_proof() -> TurnkeyBootProof {
     }
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeyResponse {
-    parsed_transaction: TurnkeyParsedTransaction,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeyParsedTransaction {
-    payload: TurnkeyPayload,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    signature: Option<TurnkeySignature>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeyPayload {
-    signable_payload: String,
-    metadata_digest: String,
-    input_payload_digest: String,
-    /// Chain-specific, borsh-serialized structured decode, base64-encoded (proto
-    /// `bytes` JSON convention). Empty and omitted from the response when the
-    /// request did not opt in or the chain has no intermediate output, so
-    /// responses to existing consumers stay byte-identical.
-    #[serde(skip_serializing_if = "String::is_empty")]
-    intermediate_output: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TurnkeySignature {
-    message: String,
-    public_key: String,
-    scheme: String,
-    signature: String,
+/// Gateway-local error envelope: always the stable mock boot proof. The gateway
+/// only runs in non-TEE local dev and CI, so it never has a real one.
+fn error_response(msg: String) -> TurnkeyResponseWrapper {
+    turnkey_error_response(msg, mock_boot_proof())
 }
 
 type GrpcClient = ParserServiceClient<tonic::transport::Channel>;
@@ -323,27 +220,6 @@ async fn parse_handler(
     )
 }
 
-// SHA-256 of empty input: used as the canonical "no data" sentinel for digest fields.
-const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-
-fn error_response(msg: String) -> TurnkeyResponseWrapper {
-    TurnkeyResponseWrapper {
-        boot_proof: mock_boot_proof(),
-        response: TurnkeyResponse {
-            parsed_transaction: TurnkeyParsedTransaction {
-                payload: TurnkeyPayload {
-                    signable_payload: String::new(),
-                    metadata_digest: EMPTY_SHA256.to_string(),
-                    input_payload_digest: EMPTY_SHA256.to_string(),
-                    intermediate_output: String::new(),
-                },
-                signature: None,
-            },
-        },
-        error: Some(msg),
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let port: u16 = match std::env::var("GATEWAY_PORT") {
@@ -413,6 +289,7 @@ async fn shutdown_signal() {
 mod tests {
     use super::*;
     use generated::parser::{Abi, AbiType, EthereumMetadata, SolanaMetadata};
+    use host_primitives::turnkey::{ChainMetadataInput, EMPTY_SHA256};
 
     #[test]
     fn error_response_has_empty_sha256_digests() {


### PR DESCRIPTION
## Why

Two host binaries have to serve the same Turnkey JSON envelope to the same client.

- `parser_gateway`: REST in front, gRPC to `parser_grpc_server` behind. Non-TEE local dev and CI, so it emits a mock `bootProof`.
- `parser_http_server` (#450): HTTP+JSON inside the enclave, calling `parser_app` in process, no gRPC hop. This is what gets deployed to the TVC, because Cloudflare in front of `app-<uuid>.turnkey.cloud` rejects gRPC with 403. It emits a real attested `bootProof`.

Different transports, different trust levels, one wire contract. The Go [`visualsign-turnkeyclient`](https://github.com/anchorageoss/visualsign-turnkeyclient) and the wallet integrators behind it cannot tell the two apart, and must not be able to.

Two features also land in that envelope during PRS-581: `bootProof` (#337) and `intermediateOutput` (#414). If the definition stays inline in `parser_gateway`, the pivot copies it, and every envelope change from here on gets made twice and kept in sync by hand. The unmerged x402 branch had already grown its own third copy.

So: one home, two importers, and the `bootProof` difference becomes a parameter instead of a fork.

Downstream, #450, #451 and #452 build on `parser_http_server`; #449 builds on `parser_gateway`. Both sides import the envelope from here, which is also what shrinks the PR #304 rebase from "reconcile two envelope definitions" to "add a module".

## What

- `host_primitives::turnkey` becomes the single home for the Turnkey request/response envelope, as the union of both existing definitions.
- `bootProof` is now an injected value rather than a hardcoded mock: `error_response(msg, boot_proof)`. `parser_gateway` keeps its stable local-dev mock through a local shim; the enclave pivot supplies a real attested one.
- Construction moved with the types: `success_response` sits next to `error_response`, so `parse_handler` no longer assembles the success envelope field by field in the gateway.
- `parser_gateway` imports the shared types and keeps the four `MOCK_BOOT_PROOF_*` constants and the tests that are about its own mock and top-level wire shape. Three tests that would have duplicated coverage now living in `host_primitives::turnkey` moved there instead of being maintained in both places.
- `intermediate_output` gained `serde(default)` alongside its existing `skip_serializing_if`. Without it the omitted key serialized fine but failed to deserialize, so a response could be written and not read back. Nothing in tree deserializes a response today (both binaries only emit one), which is why no test caught it. The client-direction derives are there so the envelope is symmetric for the out-of-tree clients that do read it, and the new round-trip test is what keeps it that way. Happy to drop those derives and the `default` until something in tree needs them, if you'd rather not carry them.

No wire change. The gateway's JSON output is byte-identical.

## Test evidence

```
cargo test -p host_primitives -p parser_gateway
  host_primitives: 5 passed
  parser_gateway: 11 passed
cargo fmt --all -- --check: clean
make -C src lint: clean
```

The gateway test count moves from 13 to 11 because three tests relocated to `host_primitives::turnkey`, where the types they cover now live: the six-key `bootProof` assertion (`boot_proof_wire_shape_is_exactly_six_camel_case_keys`), the empty `intermediateOutput` omission check, and the Solana chain-metadata discriminator test. `host_primitives` goes 4 to 5 with the new round-trip test. No coverage was dropped.

The two regression tests that matter both still pass with unchanged constant values: `mock_boot_proof_matches_production_wire_shape`, `error_response_carries_mock_boot_proof`.

The "no wire change" claim was checked rather than assumed: a throwaway test reconstructed the pre-refactor struct definitions verbatim from base and byte-compared `serde_json` output against the new `host_primitives::turnkey` types across success, error, signature-present, and intermediate-output-present cases. All identical.

One trap worth recording: the x402 branch's `TurnkeyResponseWrapper` had no `rename_all = "camelCase"`, which the gateway's inline struct did have. Adding `boot_proof` without it would have serialized as `boot_proof` instead of `bootProof` and silently broken the wallet contract. The six-key wire-shape test catches it.

## Rollback

Revert the commits. No deploy, no migration, no wire change, so a revert restores the previous state exactly.

## Linear

PRS-581

Stack position: base of the PRS-581 stack. #337, #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
