### PR TITLE
ci(stagex): build parser_http_server and parser_grpc_server images

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -151,33 +151,34 @@ jobs:
           tvc_tag="${SEMVER_TAG:-$SHA_TAG}"
           container_url="ghcr.io/anchorageoss/${TARGET_NAME}:${tvc_tag}"
           container_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${container_url}" | cut -d '@' -f 2)
-          docker create --name tmp-extract-${TARGET_NAME} "${container_url}" /bin/true
-          docker cp "tmp-extract-${TARGET_NAME}:/${TARGET_NAME}" "/tmp/${TARGET_NAME}"
-          docker rm "tmp-extract-${TARGET_NAME}"
-          digest=$(sha256sum "/tmp/${TARGET_NAME}" | awk '{print $1}')
+          docker create --name tmp-extract "${container_url}" /bin/true
+          docker cp "tmp-extract:/${TARGET_NAME}" /tmp/binary
+          docker rm tmp-extract
+          digest=$(sha256sum /tmp/binary | awk '{print $1}')
           pinned_url="${container_url}@${container_digest}"
           # Hardcoded: TVC currently only supports this QOS version.
           qos_version="0.12.0"
 
-          # parser_app is the enclave-side binary (signs responses).
-          # parser_gateway is the host-side binary (verifies the signature
-          # against a pinned pubkey + handles x402 settlement). Operators
-          # need both digests pinned to actually establish the trust pair.
+          # Per-target context for operators establishing the TVC trust
+          # boundary: parser_app / parser_http_server are enclave-side pivot
+          # binaries; parser_gateway is the host-side counterpart that signs
+          # payment verification for the enclave to check.
           case "${TARGET_NAME}" in
             parser_app)
-              role_note=$'\nThe enclave-side binary that speaks gRPC over vsock to QOS. Use this as the TVC pivot when your callers reach the app via Turnkey-internal routing.'
+              role_note='The enclave-side binary that speaks gRPC over vsock to QOS. Use this as the TVC pivot when your callers reach the app via Turnkey-internal routing.'
               ;;
             parser_http_server)
-              role_note=$'\nThe HTTP+JSON enclave-side binary intended for TVC public ingress. Cloudflare in front of `app-<uuid>.turnkey.cloud` only accepts HTTP, so this is the variant to pivot when external clients call the app directly. Routes: `GET /health` (Turnkey HTTP health check), `POST /visualsign/api/v1/parse` (open), `POST /visualsign/api/v2/parse` (TVC-enforced when `GATEWAY_SIGNING_PUBKEY_HEX` is set). Deploy with `healthCheckType: TVC_HEALTH_CHECK_TYPE_HTTP`, `publicIngressPort: 3000`.'
+              role_note='The HTTP+JSON enclave-side binary intended for TVC public ingress. Cloudflare in front of `app-<uuid>.turnkey.cloud` only accepts HTTP, so this is the variant to pivot when external clients call the app directly. Routes: `GET /health` (Turnkey HTTP health check), `POST /visualsign/api/v1/parse` (open), `POST /visualsign/api/v2/parse` (TVC-enforced when `GATEWAY_SIGNING_PUBKEY_HEX` is set). Deploy with `healthCheckType: TVC_HEALTH_CHECK_TYPE_HTTP`, `publicIngressPort: 3000`.'
               ;;
             parser_gateway)
-              role_note=$'\nThe host-side gateway that performs x402 verify+settle and signs a `VerifiedPaymentMarker` for the enclave to verify. Pairs with `parser_http_server`\'s `/v2` route; the gateway\'s P256 sign pubkey is pinned in the enclave\'s `GATEWAY_SIGNING_PUBKEY_HEX` env.'
+              role_note='The host-side gateway that performs x402 verify+settle and signs a `VerifiedPaymentMarker` for the enclave to verify. Pairs with `parser_http_server`'\''s `/v2` route; the gateway'\''s P256 sign pubkey is pinned in the enclave'\''s `GATEWAY_SIGNING_PUBKEY_HEX` env.'
               ;;
           esac
 
           deploy_md="${RUNNER_TEMP}/tvc_deploy_${TARGET_NAME}.md"
           {
             echo "## TVC Deployment Details: ${TARGET_NAME}"
+            echo ""
             echo "${role_note}"
             echo ""
             echo "- **Container Image URL**: \`${pinned_url}\`"
@@ -219,28 +220,56 @@ jobs:
           cat "$deploy_md" >> "$GITHUB_STEP_SUMMARY"
 
           # Mirror onto the GitHub release for this semver, when it exists.
-          # Each target uses its own sentinel pair so parser_app and
-          # parser_gateway can publish independently without clobbering each
-          # other when stagex runs them in parallel.
+          # Each target uses its own sentinel pair so the matrix targets can
+          # publish independently without clobbering each other when stagex
+          # runs them in parallel.
           begin_sentinel="<!-- BEGIN_TVC_DEPLOY_${TARGET_NAME} -->"
           end_sentinel="<!-- END_TVC_DEPLOY_${TARGET_NAME} -->"
           if [ -n "$SEMVER_TAG" ] && gh release view "$SEMVER_TAG" >/dev/null 2>&1; then
-            existing_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
-            preserved=$(printf '%s\n' "$existing_body" | awk -v b="$begin_sentinel" -v e="$end_sentinel" '
-              $0 == b { skipping = 1; next }
-              $0 == e { skipping = 0; next }
-              !skipping
-            ')
+            # Other matrix legs (parser_app / parser_gateway / parser_http_server)
+            # run this same read-modify-write concurrently against one release
+            # body. Sentinels keep each leg's own block idempotent across
+            # re-runs, but they don't stop a lost update: two legs can both
+            # read the body before either writes, and whichever `gh release
+            # edit` lands last clobbers the other's block. Retry with a fresh
+            # read each time and verify our write actually stuck before
+            # declaring success, so a leg that gets raced past re-applies its
+            # block on top of whatever is live instead of silently losing it.
             new_body="${RUNNER_TEMP}/release_notes_${TARGET_NAME}.md"
-            {
-              printf '%s\n\n' "$preserved"
-              echo "$begin_sentinel"
-              cat "$deploy_md"
-              echo "$end_sentinel"
-            } > "$new_body"
-            gh release edit "$SEMVER_TAG" --notes-file "$new_body" \
-              --repo "${GITHUB_REPOSITORY}"
-            echo "Updated release $SEMVER_TAG with TVC deployment details for ${TARGET_NAME}."
+            max_attempts=5
+            attempt=1
+            while :; do
+              existing_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
+              preserved=$(printf '%s\n' "$existing_body" | awk -v b="$begin_sentinel" -v e="$end_sentinel" '
+                $0 == b { skipping = 1; next }
+                $0 == e { skipping = 0; next }
+                !skipping
+              ')
+              {
+                printf '%s\n\n' "$preserved"
+                echo "$begin_sentinel"
+                cat "$deploy_md"
+                echo "$end_sentinel"
+              } > "$new_body"
+
+              if gh release edit "$SEMVER_TAG" --notes-file "$new_body" --repo "${GITHUB_REPOSITORY}"; then
+                post_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
+                if [ "$post_body" = "$(cat "$new_body")" ]; then
+                  echo "Updated release $SEMVER_TAG with TVC deployment details for ${TARGET_NAME}."
+                  break
+                fi
+                echo "Release $SEMVER_TAG body changed under us (concurrent matrix leg); retrying (attempt ${attempt}/${max_attempts})."
+              else
+                echo "gh release edit failed for $SEMVER_TAG; retrying (attempt ${attempt}/${max_attempts})."
+              fi
+
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "ERROR: could not update release $SEMVER_TAG with TVC deployment details for ${TARGET_NAME} after ${max_attempts} attempts (lost the race with concurrent matrix legs)." >&2
+                exit 1
+              fi
+              attempt=$((attempt + 1))
+              sleep $(( (RANDOM % 5) + 1 ))
+            done
           else
             echo "No release to update (SEMVER_TAG='${SEMVER_TAG:-<unset>}'); skipping release-notes update."
           fi

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -47,6 +47,8 @@ jobs:
           - name: parser_cli
             label: "parser_cli (Solana)"
           - name: parser_gateway
+          - name: parser_grpc_server
+          - name: parser_http_server
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -135,9 +137,10 @@ jobs:
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
 
       - name: TVC deployment details
-        if: matrix.target.name == 'parser_app'
+        if: matrix.target.name == 'parser_app' || matrix.target.name == 'parser_gateway' || matrix.target.name == 'parser_http_server'
         shell: bash
         env:
+          TARGET_NAME: ${{ matrix.target.name }}
           SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
           SHA_TAG: ${{ steps.build.outputs.sha_tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,26 +149,39 @@ jobs:
           # the always-unique commit SHA on PR/branch builds where SEMVER
           # isn't reproducible. Both reference the same digest below.
           tvc_tag="${SEMVER_TAG:-$SHA_TAG}"
-          container_url="ghcr.io/anchorageoss/parser_app:${tvc_tag}"
+          container_url="ghcr.io/anchorageoss/${TARGET_NAME}:${tvc_tag}"
           container_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${container_url}" | cut -d '@' -f 2)
-          docker create --name tmp-extract "${container_url}" /bin/true
-          docker cp tmp-extract:/parser_app /tmp/binary
-          docker rm tmp-extract
-          digest=$(sha256sum /tmp/binary | awk '{print $1}')
+          docker create --name tmp-extract-${TARGET_NAME} "${container_url}" /bin/true
+          docker cp "tmp-extract-${TARGET_NAME}:/${TARGET_NAME}" "/tmp/${TARGET_NAME}"
+          docker rm "tmp-extract-${TARGET_NAME}"
+          digest=$(sha256sum "/tmp/${TARGET_NAME}" | awk '{print $1}')
           pinned_url="${container_url}@${container_digest}"
           # Hardcoded: TVC currently only supports this QOS version.
           qos_version="0.12.0"
 
-          # Build the deployment block once, then fan it out to both the run
-          # summary and (when a matching GitHub release exists) the release
-          # body. Operators reading either surface get the same paste-ready
-          # values.
-          deploy_md="${RUNNER_TEMP}/tvc_deploy.md"
+          # parser_app is the enclave-side binary (signs responses).
+          # parser_gateway is the host-side binary (verifies the signature
+          # against a pinned pubkey + handles x402 settlement). Operators
+          # need both digests pinned to actually establish the trust pair.
+          case "${TARGET_NAME}" in
+            parser_app)
+              role_note=$'\nThe enclave-side binary that speaks gRPC over vsock to QOS. Use this as the TVC pivot when your callers reach the app via Turnkey-internal routing.'
+              ;;
+            parser_http_server)
+              role_note=$'\nThe HTTP+JSON enclave-side binary intended for TVC public ingress. Cloudflare in front of `app-<uuid>.turnkey.cloud` only accepts HTTP, so this is the variant to pivot when external clients call the app directly. Routes: `GET /health` (Turnkey HTTP health check), `POST /visualsign/api/v1/parse` (open), `POST /visualsign/api/v2/parse` (TVC-enforced when `GATEWAY_SIGNING_PUBKEY_HEX` is set). Deploy with `healthCheckType: TVC_HEALTH_CHECK_TYPE_HTTP`, `publicIngressPort: 3000`.'
+              ;;
+            parser_gateway)
+              role_note=$'\nThe host-side gateway that performs x402 verify+settle and signs a `VerifiedPaymentMarker` for the enclave to verify. Pairs with `parser_http_server`\'s `/v2` route; the gateway\'s P256 sign pubkey is pinned in the enclave\'s `GATEWAY_SIGNING_PUBKEY_HEX` env.'
+              ;;
+          esac
+
+          deploy_md="${RUNNER_TEMP}/tvc_deploy_${TARGET_NAME}.md"
           {
-            echo "## TVC Deployment Details"
+            echo "## TVC Deployment Details: ${TARGET_NAME}"
+            echo "${role_note}"
             echo ""
             echo "- **Container Image URL**: \`${pinned_url}\`"
-            echo "- **Executable path**: \`/parser_app\`"
+            echo "- **Executable path**: \`/${TARGET_NAME}\`"
             # Plain hex, no `sha256:` prefix — that's what QOS' Manifest schema
             # decodes for the pivot hash, and what `tvc deploy create` then
             # forwards verbatim into the server-side manifest. A `sha256:`
@@ -179,7 +195,7 @@ jobs:
             echo '```bash'
             echo "export CONTAINER_URL=\"${pinned_url}\""
             echo 'cid=$(docker create "$CONTAINER_URL" /bin/true)'
-            echo 'docker cp "$cid:/parser_app" /tmp/binary'
+            echo "docker cp \"\$cid:/${TARGET_NAME}\" /tmp/binary"
             echo 'docker rm "$cid"'
             echo 'sha256sum /tmp/binary'
             echo '```'
@@ -192,7 +208,7 @@ jobs:
             echo 'tvc deploy init -o tvc-deploy.json'
             echo '# Edit tvc-deploy.json to set:'
             echo "#   \"pivotContainerImageUrl\": \"${pinned_url}\""
-            echo '#   "pivotPath": "/parser_app"'
+            echo "#   \"pivotPath\": \"/${TARGET_NAME}\""
             echo "#   \"expectedPivotDigest\": \"${digest}\""
             echo "#   \"qosVersion\": \"${qos_version}\""
             echo '#   "appId": "<env-specific>"'
@@ -203,32 +219,28 @@ jobs:
           cat "$deploy_md" >> "$GITHUB_STEP_SUMMARY"
 
           # Mirror onto the GitHub release for this semver, when it exists.
-          # PR/branch builds have no SEMVER_TAG and no matching release;
-          # push-triggered stagex on main may race release.yml (which creates
-          # the release for the same commit); in either case just skip — the
-          # release-dispatched stagex run will populate it.
-          #
-          # Re-running stagex for the same release (manual UI re-run) must be
-          # idempotent: strip any existing block bracketed by our sentinel
-          # comments before appending the freshly-built one. The sentinels
-          # render as nothing in the release body.
+          # Each target uses its own sentinel pair so parser_app and
+          # parser_gateway can publish independently without clobbering each
+          # other when stagex runs them in parallel.
+          begin_sentinel="<!-- BEGIN_TVC_DEPLOY_${TARGET_NAME} -->"
+          end_sentinel="<!-- END_TVC_DEPLOY_${TARGET_NAME} -->"
           if [ -n "$SEMVER_TAG" ] && gh release view "$SEMVER_TAG" >/dev/null 2>&1; then
             existing_body=$(gh release view "$SEMVER_TAG" --json body --jq .body)
-            preserved=$(printf '%s\n' "$existing_body" | awk '
-              /<!-- BEGIN_TVC_DEPLOY -->/ { skipping = 1; next }
-              /<!-- END_TVC_DEPLOY -->/   { skipping = 0; next }
+            preserved=$(printf '%s\n' "$existing_body" | awk -v b="$begin_sentinel" -v e="$end_sentinel" '
+              $0 == b { skipping = 1; next }
+              $0 == e { skipping = 0; next }
               !skipping
             ')
-            new_body="${RUNNER_TEMP}/release_notes.md"
+            new_body="${RUNNER_TEMP}/release_notes_${TARGET_NAME}.md"
             {
               printf '%s\n\n' "$preserved"
-              echo "<!-- BEGIN_TVC_DEPLOY -->"
+              echo "$begin_sentinel"
               cat "$deploy_md"
-              echo "<!-- END_TVC_DEPLOY -->"
+              echo "$end_sentinel"
             } > "$new_body"
             gh release edit "$SEMVER_TAG" --notes-file "$new_body" \
               --repo "${GITHUB_REPOSITORY}"
-            echo "Updated release $SEMVER_TAG with TVC deployment details."
+            echo "Updated release $SEMVER_TAG with TVC deployment details for ${TARGET_NAME}."
           else
             echo "No release to update (SEMVER_TAG='${SEMVER_TAG:-<unset>}'); skipping release-notes update."
           fi

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ out/parser_gateway/index.json: \
 	$(shell git ls-files images/parser_gateway src)
 	$(call build,parser_gateway)
 
+out/parser_grpc_server/index.json: \
+	$(shell git ls-files images/parser_grpc_server src)
+	$(call build,parser_grpc_server)
+
+out/parser_http_server/index.json: \
+	$(shell git ls-files images/parser_http_server src)
+	$(call build,parser_http_server)
+
 .PHONY: non-oci-docker-images
 non-oci-docker-images:
 	docker buildx build --load --tag anchorageoss-visualsign-parser/parser_app -f images/parser_app/Containerfile .

--- a/images/parser_grpc_server/Containerfile
+++ b/images/parser_grpc_server/Containerfile
@@ -1,0 +1,31 @@
+FROM stagex/pallet-rust:1.88.0@sha256:b9021d2b75eac64fe8b931d96dde63ef11792e5023cee77c3471ccc34a95a377 AS build
+
+# Rust configuration
+ENV RUSTFLAGS='-C target-feature=+crt-static'
+ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locked --release'
+
+# Directory for Rust artifacts
+ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
+
+# Version injected at build time via --build-arg (set by make VERSION=...)
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Load Rust sources
+ADD src /src
+WORKDIR /src/
+
+# pre-fetch all workspace deps; we need them to build with `--network=none` later
+RUN cargo fetch
+
+WORKDIR /src/parser/grpc-server
+RUN --network=none <<-EOF
+    set -eu
+    cargo build ${CARGOFLAGS}
+    mkdir -p /rootfs
+    mv ${RELEASE_DIR}/parser_grpc_server /rootfs/
+EOF
+
+# Use busybox as a base so we can easily cp the pivot binary if needed
+FROM stagex/core-busybox:1.36.1@sha256:cac5d773db1c69b832d022c469ccf5f52daf223b91166e6866d42d6983a3b374 AS package
+COPY --from=build /rootfs/. .

--- a/images/parser_http_server/Containerfile
+++ b/images/parser_http_server/Containerfile
@@ -1,0 +1,42 @@
+FROM stagex/pallet-rust:1.88.0@sha256:b9021d2b75eac64fe8b931d96dde63ef11792e5023cee77c3471ccc34a95a377 AS build
+
+# Rust configuration
+ENV RUSTFLAGS='-C target-feature=+crt-static'
+ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locked --release'
+
+# Directory for Rust artifacts
+ENV RELEASE_DIR=/src/target/x86_64-unknown-linux-musl/release
+
+# Version injected at build time via --build-arg (set by make VERSION=...)
+ARG VERSION
+ENV VERSION=$VERSION
+
+# Chain visualizers compiled into this image. Override per deployment with
+# --build-arg CHAIN_FEATURES="<space-separated subset>". CARGOFLAGS above
+# passes --no-default-features, so chains not listed here are NOT linked into
+# the binary, shrinking both the image and the attestation surface. Default
+# mirrors parser_http_server/Cargo.toml's `default` feature set.
+ARG CHAIN_FEATURES="ethereum solana sui tron unspecified"
+ENV CHAIN_FEATURES=$CHAIN_FEATURES
+
+# Load Rust sources
+ADD src /src
+WORKDIR /src/
+
+# pre-fetch all workspace deps; we need them to build with `--network=none` later
+RUN cargo fetch
+
+WORKDIR /src/parser/http-server
+RUN --network=none <<-EOF
+    set -eu
+    # `vsock` switches qos_core constants to in-enclave paths
+    # (`/qos.ephemeral.key`). Without it the pivot reads the dev path and
+    # crash-loops at startup, showing `Healthy / Desired Replicas: 0/N`.
+    cargo build ${CARGOFLAGS} --features "vsock ${CHAIN_FEATURES}"
+    mkdir -p /rootfs
+    mv ${RELEASE_DIR}/parser_http_server /rootfs/
+EOF
+
+# Use busybox as a base so we can easily cp the pivot binary if needed
+FROM stagex/core-busybox:1.36.1@sha256:cac5d773db1c69b832d022c469ccf5f52daf223b91166e6866d42d6983a3b374 AS package
+COPY --from=build /rootfs/. .


### PR DESCRIPTION
## Why

PRS-581 deploys `parser_http_server` as the TVC pivot. The stagex "TVC deployment details" step hardcodes `parser_app`, so it is the only binary that ever gets a reproducible executable digest and a paste-ready deploy block. Without this, the pivot cannot be deployed or probed at all, which blocks the `/dev/nsm` reachability probe and every later step in the stack.

Landing it early so image builds are never the thing holding the stack up.

## What

- Adds `parser_grpc_server` and `parser_http_server` to the stagex build matrix.
- Generalizes the deployment-details step over the matrix target: `TARGET_NAME` env, per-target container URL, per-target extract container and binary path, per-target deploy-md and release-note sentinels so parallel matrix legs cannot clobber each other's release body edits.
- Adds `images/parser_http_server/Containerfile`, mirroring `parser_app`'s. It keeps `--features "vsock ${CHAIN_FEATURES}"`, which is load-bearing: `vsock` switches `qos_core::EPHEMERAL_KEY_FILE` to the in-enclave path, and without it the deployed pivot panics at startup and TVC reports 0 healthy replicas.

Two changes from the x402 branch were deliberately NOT taken, because they belong to other PRs:
- the PR-label rename `ci:stagex` to `stagex`. Main's label is kept.
- `qos_version="v2026.2.6"`. Main's `0.12.0` is kept; the QOS bump is its own PR in this stack.

## Test evidence

The stagex path only runs on a labelled PR, so this needs the `ci:stagex` label to be validated. What was verified locally:

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/stagex.yml'))"  -> parses
grep 'label.name' stagex.yml  -> 'ci:stagex'  (unchanged from main)
grep -c 'v2026.2.6' stagex.yml -> 0
```

I have NOT run the stagex build itself. Please add `ci:stagex` and confirm all matrix legs go green, including the two new ones, before merging.

## Rollback

Revert the commit. CI-only change plus one new Containerfile; nothing is deployed by merging it.

## Linear

PRS-581

Stack position: independent of the rest of the stack, based on `main`. Can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
