### PR TITLE
feat(parser_http_server): validate X-Stamp in the enclave

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "tonic 0.10.2",
  "tracing",
  "tracing-test",
+ "turnkey_api_key_stamper",
  "visualsign-solana",
 ]
 
@@ -6600,14 +6601,20 @@ dependencies = [
  "borsh 1.6.0",
  "clap",
  "generated",
+ "hex",
  "host_primitives",
+ "k256 0.13.4",
+ "p256",
  "parser_app",
  "qos_core",
  "qos_hex",
  "qos_p256",
  "serde",
  "serde_json",
+ "subtle",
  "tokio",
+ "turnkey_api_key_stamper",
+ "visualsign",
 ]
 
 [[package]]
@@ -13827,6 +13834,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+]
+
+[[package]]
+name = "turnkey_api_key_stamper"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0ca5df1b0c48a971fc24dfd83323b8f75a2671776bb4842e07c9a87e31b874"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "k256 0.13.4",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "qos_p256",
  "qos_test_primitives",
  "rand 0.9.2",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -6588,6 +6589,25 @@ dependencies = [
  "qos_p256",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "parser_http_server"
+version = "0.1.0"
+dependencies = [
+ "axum 0.8.8",
+ "base64 0.22.1",
+ "borsh 1.6.0",
+ "clap",
+ "generated",
+ "host_primitives",
+ "parser_app",
+ "qos_core",
+ "qos_hex",
+ "qos_p256",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "parser/cli-core",
   "parser/gateway",
   "parser/grpc-server",
+  "parser/http-server",
   "visualsign",
   "chain_parsers/visualsign-ethereum",
   "chain_parsers/visualsign-near",

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -46,6 +46,7 @@ hex = { workspace = true }
 visualsign-solana = { path = "../chain_parsers/visualsign-solana" }
 tracing = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
+turnkey_api_key_stamper = "0.10"
 
 [lints]
 workspace = true

--- a/src/integration/Cargo.toml
+++ b/src/integration/Cargo.toml
@@ -45,6 +45,7 @@ hex = { workspace = true }
 [dev-dependencies]
 visualsign-solana = { path = "../chain_parsers/visualsign-solana" }
 tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 
 [lints]
 workspace = true

--- a/src/integration/tests/http_server.rs
+++ b/src/integration/tests/http_server.rs
@@ -1,0 +1,189 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+use std::fs;
+use std::process::Command;
+use std::time::Duration;
+
+use integration::{ChildWrapper, find_free_port, wait_until_port_is_bound};
+use qos_p256::P256Pair;
+
+// Same Ethereum signed legacy transaction used by
+// `integration::tests::parser_ethereum_native_transfer_e2e`.
+const ETH_TX_HEX: &str = "0xf86c808504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83";
+
+/// Spins up a `parser_http_server` instance under a private working
+/// directory (so its default, non-`vsock` ephemeral-key path
+/// `./local-enclave/qos.ephemeral.key` doesn't collide with other tests),
+/// waits for it to bind, and returns the base URL plus the generated key.
+struct RunningServer {
+    base_url: String,
+    ephemeral_key: P256Pair,
+    _child: ChildWrapper,
+    work_dir: String,
+}
+
+impl RunningServer {
+    async fn start() -> Self {
+        let test_id = format!("{:?}", rand::random::<u64>());
+        let work_dir = format!("./{test_id}-http-server-workdir");
+        let enclave_dir = format!("{work_dir}/local-enclave");
+        fs::create_dir_all(&enclave_dir).expect("failed to create local-enclave dir");
+
+        let ephemeral_key = P256Pair::generate().expect("failed to generate ephemeral key");
+        ephemeral_key
+            .to_hex_file(format!("{enclave_dir}/qos.ephemeral.key"))
+            .expect("failed to write ephemeral key");
+
+        let port = find_free_port().expect("no free port available");
+
+        // Unlike the other integration tests, this one also sets
+        // `current_dir` on the child (so the server's default,
+        // non-`vsock` ephemeral-key path resolves under `work_dir`), and a
+        // relative program path is not resolved against that new cwd, so
+        // canonicalize it against the test binary's own cwd first.
+        let binary = fs::canonicalize("../target/debug/parser_http_server")
+            .expect("parser_http_server binary not found; run `cargo build` first");
+
+        let mut child = Command::new(binary)
+            .arg("--port")
+            .arg(port.to_string())
+            .current_dir(&work_dir)
+            .spawn()
+            .expect("failed to spawn parser_http_server");
+
+        // Fail fast if the server died instead of binding. `wait_until_port_is_bound`
+        // polls forever, so without this check a server that panics at startup hangs
+        // the test run rather than failing it. That is exactly what happens when the
+        // binary was built with the `vsock` feature: `EPHEMERAL_KEY_FILE` becomes the
+        // absolute in-enclave path, the key we wrote under `work_dir` is invisible,
+        // and the process exits before it ever listens.
+        for _ in 0..100 {
+            if let Some(status) = child.try_wait().expect("failed to poll server status") {
+                panic!(
+                    "parser_http_server exited before binding to port {port} (status {status}). \
+                     If the binary was built with --features vsock, rebuild without it: \
+                     the test relies on the dev ephemeral-key path."
+                );
+            }
+            if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        let child: ChildWrapper = child.into();
+        wait_until_port_is_bound(port);
+        // wait_until_port_is_bound only proves the port is no longer free;
+        // give the server a brief moment to finish accepting connections.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        Self {
+            base_url: format!("http://127.0.0.1:{port}"),
+            ephemeral_key,
+            _child: child,
+            work_dir,
+        }
+    }
+}
+
+impl Drop for RunningServer {
+    fn drop(&mut self) {
+        drop(fs::remove_dir_all(&self.work_dir));
+    }
+}
+
+fn boot_proof_keys(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("bootProof")
+        .and_then(|v| v.as_object())
+        .expect("response missing bootProof object")
+        .keys()
+        .cloned()
+        .collect()
+}
+
+#[tokio::test]
+async fn http_server_serves_health_parse_and_errors() {
+    let server = RunningServer::start().await;
+    let client = reqwest::Client::new();
+
+    // 1. GET /health returns 200.
+    let health = client
+        .get(format!("{}/health", server.base_url))
+        .send()
+        .await
+        .expect("health request failed");
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+    let body = serde_json::json!({
+        "request": {
+            "chain": "CHAIN_ETHEREUM",
+            "unsigned_payload": ETH_TX_HEX,
+        }
+    });
+
+    // 2. v1 parse succeeds, signature.publicKey matches the generated key,
+    //    and bootProof has exactly six keys.
+    let v1 = client
+        .post(format!("{}/visualsign/api/v1/parse", server.base_url))
+        .json(&body)
+        .send()
+        .await
+        .expect("v1 request failed");
+    assert_eq!(v1.status(), reqwest::StatusCode::OK);
+    let v1_value: serde_json::Value = v1.json().await.expect("v1 response was not valid JSON");
+
+    let expected_pubkey_hex = qos_hex::encode(&server.ephemeral_key.public_key().to_bytes());
+    let v1_pubkey = v1_value
+        .get("response")
+        .and_then(|r| r.get("parsedTransaction"))
+        .and_then(|t| t.get("signature"))
+        .and_then(|s| s.get("publicKey"))
+        .and_then(|v| v.as_str())
+        .expect("v1 response missing signature.publicKey");
+    assert_eq!(v1_pubkey, expected_pubkey_hex);
+
+    let mut v1_boot_proof_keys = boot_proof_keys(&v1_value);
+    v1_boot_proof_keys.sort();
+    let mut expected_keys = vec![
+        "awsAttestationDocB64".to_string(),
+        "qosManifestB64".to_string(),
+        "qosManifestEnvelopeB64".to_string(),
+        "ephemeralPublicKeyHex".to_string(),
+        "enclaveApp".to_string(),
+        "deploymentLabel".to_string(),
+    ];
+    expected_keys.sort();
+    assert_eq!(v1_boot_proof_keys, expected_keys);
+
+    // 3. v2 behaves identically to v1 (open in this PR).
+    let v2 = client
+        .post(format!("{}/visualsign/api/v2/parse", server.base_url))
+        .json(&body)
+        .send()
+        .await
+        .expect("v2 request failed");
+    assert_eq!(v2.status(), reqwest::StatusCode::OK);
+    let v2_value: serde_json::Value = v2.json().await.expect("v2 response was not valid JSON");
+    assert_eq!(v1_value, v2_value);
+
+    // 4. A malformed body returns 400 with a bootProof present.
+    let malformed = client
+        .post(format!("{}/visualsign/api/v1/parse", server.base_url))
+        .header("content-type", "application/json")
+        .body("not json")
+        .send()
+        .await
+        .expect("malformed request failed");
+    assert_eq!(malformed.status(), reqwest::StatusCode::BAD_REQUEST);
+    let malformed_value: serde_json::Value = malformed
+        .json()
+        .await
+        .expect("malformed response was not valid JSON");
+    assert!(
+        malformed_value.get("bootProof").is_some(),
+        "error response must still carry bootProof"
+    );
+    let mut malformed_keys = boot_proof_keys(&malformed_value);
+    malformed_keys.sort();
+    assert_eq!(malformed_keys, expected_keys);
+}

--- a/src/integration/tests/http_server.rs
+++ b/src/integration/tests/http_server.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use integration::{ChildWrapper, find_free_port, wait_until_port_is_bound};
 use qos_p256::P256Pair;
+use turnkey_api_key_stamper::{Stamp, TurnkeyP256ApiKey};
 
 // Same Ethereum signed legacy transaction used by
 // `integration::tests::parser_ethereum_native_transfer_e2e`.
@@ -23,6 +24,12 @@ struct RunningServer {
 
 impl RunningServer {
     async fn start() -> Self {
+        Self::start_with_args(&[]).await
+    }
+
+    /// Same as `start`, but with extra CLI args appended (e.g.
+    /// `--allowed-stamp-pubkeys-hex <csv>`).
+    async fn start_with_args(extra_args: &[&str]) -> Self {
         let test_id = format!("{:?}", rand::random::<u64>());
         let work_dir = format!("./{test_id}-http-server-workdir");
         let enclave_dir = format!("{work_dir}/local-enclave");
@@ -46,6 +53,7 @@ impl RunningServer {
         let mut child = Command::new(binary)
             .arg("--port")
             .arg(port.to_string())
+            .args(extra_args)
             .current_dir(&work_dir)
             .spawn()
             .expect("failed to spawn parser_http_server");
@@ -186,4 +194,67 @@ async fn http_server_serves_health_parse_and_errors() {
     let mut malformed_keys = boot_proof_keys(&malformed_value);
     malformed_keys.sort();
     assert_eq!(malformed_keys, expected_keys);
+}
+
+#[tokio::test]
+async fn http_server_enforces_x_stamp_when_allowlist_is_configured() {
+    let allowed = TurnkeyP256ApiKey::generate();
+    let other = TurnkeyP256ApiKey::generate();
+    let allowlist_hex = hex::encode(allowed.compressed_public_key());
+
+    let server =
+        RunningServer::start_with_args(&["--allowed-stamp-pubkeys-hex", &allowlist_hex]).await;
+    let client = reqwest::Client::new();
+
+    let body = serde_json::json!({
+        "request": {
+            "chain": "CHAIN_ETHEREUM",
+            "unsigned_payload": ETH_TX_HEX,
+        }
+    });
+    // Sign the exact bytes sent over the wire, not a re-serialized copy:
+    // this is what the pivot verifies against.
+    let raw_body = serde_json::to_vec(&body).expect("failed to serialize body");
+
+    // 1. No X-Stamp header: 401 with bootProof present.
+    let unstamped = client
+        .post(format!("{}/visualsign/api/v1/parse", server.base_url))
+        .header("content-type", "application/json")
+        .body(raw_body.clone())
+        .send()
+        .await
+        .expect("unstamped request failed");
+    assert_eq!(unstamped.status(), reqwest::StatusCode::UNAUTHORIZED);
+    let unstamped_value: serde_json::Value = unstamped
+        .json()
+        .await
+        .expect("unstamped response was not valid JSON");
+    assert!(
+        unstamped_value.get("bootProof").is_some(),
+        "401 response must still carry bootProof"
+    );
+
+    // 2. Stamped by a listed key: 200.
+    let stamp = allowed.stamp(&raw_body).expect("failed to stamp body");
+    let listed = client
+        .post(format!("{}/visualsign/api/v1/parse", server.base_url))
+        .header("content-type", "application/json")
+        .header(stamp.name, stamp.value)
+        .body(raw_body.clone())
+        .send()
+        .await
+        .expect("listed-key request failed");
+    assert_eq!(listed.status(), reqwest::StatusCode::OK);
+
+    // 3. Stamped by an unlisted key: 401.
+    let other_stamp = other.stamp(&raw_body).expect("failed to stamp body");
+    let unlisted = client
+        .post(format!("{}/visualsign/api/v1/parse", server.base_url))
+        .header("content-type", "application/json")
+        .header(other_stamp.name, other_stamp.value)
+        .body(raw_body)
+        .send()
+        .await
+        .expect("unlisted-key request failed");
+    assert_eq!(unlisted.status(), reqwest::StatusCode::UNAUTHORIZED);
 }

--- a/src/parser/http-server/Cargo.toml
+++ b/src/parser/http-server/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "parser_http_server"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[features]
+# Chain visualizers compiled into the binary. Mirrors parser_app's default
+# set; trim with `--no-default-features --features solana` (or any subset)
+# to shrink the image and attestation surface for chain-specific deploys.
+default = ["ethereum", "solana", "sui", "tron", "unspecified"]
+ethereum = ["parser_app/ethereum"]
+solana = ["parser_app/solana"]
+sui = ["parser_app/sui"]
+tron = ["parser_app/tron"]
+unspecified = ["parser_app/unspecified"]
+# Switch qos_core constants (notably `EPHEMERAL_KEY_FILE`) to their in-enclave
+# paths (`/qos.ephemeral.key` instead of `./local-enclave/qos.ephemeral.key`).
+# parser_http_server only ever runs as a TVC pivot, so this must be on for
+# production builds. Without it the pivot crashes at startup trying to read
+# the dev path, which surfaces as `Healthy / Desired Replicas: 0/N`. The
+# name mirrors parser_app's identically-named feature for consistency,
+# even though http-server doesn't speak vsock itself.
+vsock = ["qos_core/vm"]
+
+[dependencies]
+# Internal - same parse logic + envelope shapes the gRPC server already uses.
+# `default-features = false` so http-server's [features] above is the single
+# place chains get enabled; otherwise parser_app would auto-pull all chains
+# regardless of what http-server selects.
+parser_app = { path = "../app", default-features = false }
+generated = { path = "../../generated", features = ["tonic_types", "serde_derive"] }
+host_primitives = { path = "../../host_primitives" }
+
+# Crypto / hashing / manifest re-encoding for the boot-proof seam.
+qos_core = { workspace = true }
+qos_hex = { workspace = true }
+qos_p256 = { workspace = true }
+borsh = { version = "1", features = ["std", "derive"], default-features = false }
+
+# HTTP + serialization.
+axum = { version = "0.8", features = ["http1", "http2", "tokio", "json"], default-features = false }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time", "net"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+
+# CLI args. TVC pivots receive config via `pivotArgs`, not env vars; clap's
+# `env = "..."` attribute keeps compose + integration tests working unchanged.
+clap = { version = "4.0", features = ["derive", "env"] }
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "parser_http_server"
+path = "src/main.rs"

--- a/src/parser/http-server/Cargo.toml
+++ b/src/parser/http-server/Cargo.toml
@@ -31,12 +31,19 @@ vsock = ["qos_core/vm"]
 parser_app = { path = "../app", default-features = false }
 generated = { path = "../../generated", features = ["tonic_types", "serde_derive"] }
 host_primitives = { path = "../../host_primitives" }
+visualsign = { path = "../../visualsign" }
 
 # Crypto / hashing / manifest re-encoding for the boot-proof seam.
 qos_core = { workspace = true }
 qos_hex = { workspace = true }
 qos_p256 = { workspace = true }
 borsh = { version = "1", features = ["std", "derive"], default-features = false }
+
+# X-Stamp verification (see src/stamp.rs).
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
+subtle = { version = "2", default-features = false }
+hex = { workspace = true }
 
 # HTTP + serialization.
 axum = { version = "0.8", features = ["http1", "http2", "tokio", "json"], default-features = false }
@@ -48,6 +55,9 @@ base64 = { workspace = true }
 # CLI args. TVC pivots receive config via `pivotArgs`, not env vars; clap's
 # `env = "..."` attribute keeps compose + integration tests working unchanged.
 clap = { version = "4.0", features = ["derive", "env"] }
+
+[dev-dependencies]
+turnkey_api_key_stamper = "0.10"
 
 [lints]
 workspace = true

--- a/src/parser/http-server/build.rs
+++ b/src/parser/http-server/build.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let git_dir = workspace_root.join(".git");
+
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("logs/HEAD").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/main").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("refs/remotes/origin/master").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("scripts/auto-version.sh").display()
+    );
+
+    if let Some(version) = std::env::var("VERSION").ok().filter(|v| !v.is_empty()) {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    if let Some(version) = Command::new(workspace_root.join("scripts/auto-version.sh"))
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+    {
+        println!("cargo:rustc-env=VERSION={version}");
+        return Ok(());
+    }
+
+    println!("cargo:rustc-env=VERSION=dev");
+    Ok(())
+}

--- a/src/parser/http-server/src/boot_proof.rs
+++ b/src/parser/http-server/src/boot_proof.rs
@@ -1,0 +1,103 @@
+//! Where a response's `bootProof` comes from.
+//!
+//! PR 3 ships [`StaticBootProof`] (real ephemeral key + real manifest bytes,
+//! empty attestation doc); a later PR adds an NSM-backed implementation that
+//! fills the attestation doc in.
+
+use host_primitives::turnkey::TurnkeyBootProof;
+use qos_core::protocol::services::boot::ManifestEnvelope;
+use qos_p256::P256Pair;
+
+/// Errors surfaced while assembling a boot proof. `Encode` and `Nsm` are
+/// declared here (unused in this PR) so a later NSM-backed `BootProofSource`
+/// only has to touch its own file, not this shared enum.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum BootProofError {
+    Manifest(String),
+    Encode(String),
+    Nsm(String),
+}
+
+/// Where a response's `bootProof` comes from.
+pub trait BootProofSource {
+    fn boot_proof(&self) -> TurnkeyBootProof;
+}
+
+pub struct StaticBootProof {
+    ephemeral_public_key_hex: String,
+    qos_manifest_b64: String,
+    qos_manifest_envelope_b64: String,
+    enclave_app: String,
+    deployment_label: String,
+}
+
+impl StaticBootProof {
+    pub fn from_enclave_files(
+        ephemeral: &P256Pair,
+        enclave_app: String,
+        deployment_label: String,
+    ) -> Self {
+        let (qos_manifest_b64, qos_manifest_envelope_b64) = read_manifest_borsh_b64();
+        Self {
+            ephemeral_public_key_hex: qos_hex::encode(&ephemeral.public_key().to_bytes()),
+            qos_manifest_b64,
+            qos_manifest_envelope_b64,
+            enclave_app,
+            deployment_label,
+        }
+    }
+}
+
+impl BootProofSource for StaticBootProof {
+    fn boot_proof(&self) -> TurnkeyBootProof {
+        TurnkeyBootProof {
+            // Filled by the NSM-backed source in a later PR. Empty, never
+            // faked: a strict verifier must reject an unattested response
+            // outright.
+            aws_attestation_doc_b64: String::new(),
+            qos_manifest_b64: self.qos_manifest_b64.clone(),
+            qos_manifest_envelope_b64: self.qos_manifest_envelope_b64.clone(),
+            ephemeral_public_key_hex: self.ephemeral_public_key_hex.clone(),
+            enclave_app: self.enclave_app.clone(),
+            deployment_label: self.deployment_label.clone(),
+        }
+    }
+}
+
+/// `/qos.manifest` holds JSON at qos rev 365ba7ed, but the wallet contract's
+/// `qosManifestB64` / `qosManifestEnvelopeB64` are *borsh* bytes: the Go
+/// verifier borsh-deserializes both (visualsign-turnkeyclient
+/// manifest/parser.go), and the attestation doc's `user_data` is
+/// sha256(borsh(manifest)). Base64-ing the file bytes directly would produce
+/// fields no verifier can read. So: read JSON, re-encode with borsh.
+///
+/// Shared by `StaticBootProof` and (in a later PR) an NSM-backed source,
+/// which also needs the envelope for `manifest.qos_hash()`.
+pub fn read_manifest_envelope() -> Result<ManifestEnvelope, BootProofError> {
+    let contents = std::fs::read(qos_core::MANIFEST_FILE)
+        .map_err(|e| BootProofError::Manifest(format!("{}: {e}", qos_core::MANIFEST_FILE)))?;
+    serde_json::from_slice(&contents)
+        .map_err(|e| BootProofError::Manifest(format!("manifest json: {e}")))
+}
+
+/// Returns empty strings when the manifest is unreadable (local dev outside an
+/// enclave), which keeps the six keys present and obviously unverifiable.
+fn read_manifest_borsh_b64() -> (String, String) {
+    use base64::Engine as _;
+    let Ok(envelope) = read_manifest_envelope() else {
+        eprintln!(
+            "boot proof: {} unreadable, manifest fields empty",
+            qos_core::MANIFEST_FILE
+        );
+        return (String::new(), String::new());
+    };
+    let engine = base64::engine::general_purpose::STANDARD;
+    let manifest_b64 = borsh::to_vec(&envelope.manifest)
+        .map(|b| engine.encode(b))
+        .unwrap_or_default();
+    let envelope_b64 = borsh::to_vec(&envelope)
+        .map(|b| engine.encode(b))
+        .unwrap_or_default();
+    (manifest_b64, envelope_b64)
+}

--- a/src/parser/http-server/src/main.rs
+++ b/src/parser/http-server/src/main.rs
@@ -1,0 +1,327 @@
+// TODO(#231): Remove these exemptions and fix violations in a follow-up PR.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
+//! HTTP+JSON server wrapping `parser_app::routes::parse::parse` - the
+//! single-binary variant intended for Turnkey TVC deployment.
+//!
+//! Turnkey's TVC public ingress accepts HTTP only - Cloudflare in front of
+//! `app-<uuid>.turnkey.cloud` rejects gRPC with 403 (verified 2026-05-16).
+//! So the binary deployed as the TVC pivot must speak HTTP+JSON natively.
+//! parser_app's gRPC interface remains how vsock IPC happens internally;
+//! this binary is the public face.
+//!
+//! Routes:
+//! - `GET /health` - 200 OK for Turnkey's HTTP health check
+//!   (`healthCheckType: TVC_HEALTH_CHECK_TYPE_HTTP`).
+//! - `POST /visualsign/api/v1/parse` - Turnkey-envelope JSON in/out.
+//!   Mirrors `parser_gateway`'s v1 route exactly; the Turnkey wire
+//!   envelope types are reused from `host_primitives::turnkey` so the Go
+//!   visualsign-turnkey-client (and any HTTP-only client) keeps working
+//!   byte-for-byte.
+//! - `POST /visualsign/api/v2/parse` - same payload. Open in this PR; a
+//!   later PR adds X-Stamp enforcement and payment enforcement here.
+//!
+//! Configuration (CLI args; env vars listed are clap fallbacks):
+//! - `--port <u16>` / `HTTP_PORT` (default 3000) - Turnkey TVC public ingress.
+//! - `--enclave-app <name>` / `ENCLAVE_APP` (default `visualsign-parser`).
+//! - `--deployment-label <label>` / `DEPLOYMENT_LABEL`.
+//!
+//! The ephemeral key is read from `qos_core::EPHEMERAL_KEY_FILE` (provisioned
+//! by QOS inside the enclave). No override flag - if a deployment ever needs
+//! a non-canonical path, bind-mount it instead.
+
+mod boot_proof;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use base64::Engine as _;
+use boot_proof::{BootProofSource, StaticBootProof};
+use clap::Parser;
+use generated::parser::{Chain, ChainMetadata, SignatureScheme};
+use host_primitives::turnkey::{
+    TurnkeyParsedTransaction, TurnkeyPayload, TurnkeyRequestWrapper, TurnkeyResponse,
+    TurnkeyResponseWrapper, TurnkeySignature, error_response,
+};
+use parser_app::routes::parse::parse;
+use qos_core::handles::EphemeralKeyHandle;
+use qos_p256::P256Pair;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+#[derive(Parser, Debug)]
+#[command(version = env!("VERSION"))]
+struct Args {
+    /// HTTP port to listen on.
+    #[arg(long, env = "HTTP_PORT", default_value_t = 3000)]
+    port: u16,
+
+    /// Enclave app identifier reported in every response's `bootProof`.
+    #[arg(long, env = "ENCLAVE_APP", default_value = "visualsign-parser")]
+    enclave_app: String,
+
+    /// Deployment label reported in every response's `bootProof`.
+    #[arg(long, env = "DEPLOYMENT_LABEL", default_value = "")]
+    deployment_label: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    ephemeral_key: Arc<P256Pair>,
+    boot_proof: Arc<dyn BootProofSource + Send + Sync>,
+}
+
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+// Handlers take raw bytes, never `Json<T>`. A later PR verifies an X-Stamp
+// signature over the exact request bytes; a `Json<T>` extractor re-serializes
+// before the handler body runs, changing key order / whitespace / unicode
+// escaping and invalidating every signature. Both routes share one body.
+async fn parse_v1(
+    State(state): State<AppState>,
+    body: axum::body::Bytes,
+) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
+    handle_parse(&state, &body)
+}
+
+/// v2 is byte-identical to v1 in this PR. Registering it now keeps the
+/// deployed URL stable across the stack as later PRs add enforcement here.
+async fn parse_v2(
+    State(state): State<AppState>,
+    body: axum::body::Bytes,
+) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
+    handle_parse(&state, &body)
+}
+
+/// Deserialize the envelope from the original bytes. Kept separate so the
+/// caller still owns the untouched slice (see the X-Stamp seam test).
+fn parse_envelope(body: &[u8]) -> Result<TurnkeyRequestWrapper, serde_json::Error> {
+    serde_json::from_slice(body)
+}
+
+fn handle_parse(state: &AppState, body: &[u8]) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
+    // A later PR inserts the X-Stamp check here, before anything else touches `body`.
+    let wrapper = match parse_envelope(body) {
+        Ok(w) => w,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(error_response(
+                    format!("invalid request body: {e}"),
+                    state.boot_proof.boot_proof(),
+                )),
+            );
+        }
+    };
+
+    let chain = match Chain::from_str_name(&wrapper.request.chain) {
+        Some(c) => c as i32,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(error_response(
+                    format!("unknown chain: {}", wrapper.request.chain),
+                    state.boot_proof.boot_proof(),
+                )),
+            );
+        }
+    };
+
+    let proto_req = generated::parser::ParseRequest {
+        unsigned_payload: wrapper.request.unsigned_payload,
+        chain,
+        chain_metadata: wrapper.request.chain_metadata.map(ChainMetadata::from),
+        include_intermediate_output: wrapper.request.include_intermediate_output,
+    };
+
+    let proto_resp = match parse(&proto_req, &state.ephemeral_key) {
+        Ok(r) => r,
+        Err(e) => {
+            let http_status = match e.code {
+                generated::google::rpc::Code::InvalidArgument => StatusCode::BAD_REQUEST,
+                generated::google::rpc::Code::NotFound => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            return (
+                http_status,
+                Json(error_response(e.message, state.boot_proof.boot_proof())),
+            );
+        }
+    };
+
+    let parsed_tx = match proto_resp.parsed_transaction {
+        Some(tx) => tx,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(error_response(
+                    "parser_app returned no parsed_transaction".to_string(),
+                    state.boot_proof.boot_proof(),
+                )),
+            );
+        }
+    };
+    let payload = match parsed_tx.payload {
+        Some(p) => p,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(error_response(
+                    "parser_app returned no payload".to_string(),
+                    state.boot_proof.boot_proof(),
+                )),
+            );
+        }
+    };
+    let signature = parsed_tx.signature.map(|sig| {
+        let scheme = match sig.scheme {
+            x if x == SignatureScheme::TurnkeyP256EphemeralKey as i32 => {
+                SignatureScheme::TurnkeyP256EphemeralKey
+            }
+            _ => SignatureScheme::Unspecified,
+        };
+        TurnkeySignature {
+            message: sig.message,
+            public_key: sig.public_key,
+            scheme: scheme.as_str_name().to_string(),
+            signature: sig.signature,
+        }
+    });
+
+    (
+        StatusCode::OK,
+        Json(TurnkeyResponseWrapper {
+            boot_proof: state.boot_proof.boot_proof(),
+            response: TurnkeyResponse {
+                parsed_transaction: TurnkeyParsedTransaction {
+                    payload: TurnkeyPayload {
+                        signable_payload: payload.parsed_payload,
+                        metadata_digest: payload.metadata_digest,
+                        input_payload_digest: payload.input_payload_digest,
+                        // base64 of an empty Vec is "", which serde omits (see
+                        // skip_serializing_if) so the non-intermediate response
+                        // is unchanged.
+                        intermediate_output: base64::engine::general_purpose::STANDARD
+                            .encode(&payload.intermediate_output),
+                    },
+                    signature,
+                },
+            },
+            error: None,
+        }),
+    )
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let handle = EphemeralKeyHandle::new(qos_core::EPHEMERAL_KEY_FILE.to_string());
+    let ephemeral_key = handle
+        .get_ephemeral_key()
+        .expect("failed to load ephemeral key");
+    eprintln!(
+        "parser_http_server {} loaded ephemeral key from {}",
+        env!("VERSION"),
+        qos_core::EPHEMERAL_KEY_FILE,
+    );
+
+    let boot_proof = StaticBootProof::from_enclave_files(
+        &ephemeral_key,
+        args.enclave_app,
+        args.deployment_label,
+    );
+
+    let state = AppState {
+        ephemeral_key: Arc::new(ephemeral_key),
+        boot_proof: Arc::new(boot_proof),
+    };
+
+    // 64 KiB caps every parse-request body the TVC pivot will accept.
+    // axum's default is 2 MiB; a real parse envelope is hundreds of bytes,
+    // and accepting more lets an attacker force expensive sync parsing
+    // (block_in_place) on the enclave's CPU per call. Same cap as the
+    // gateway in front of us, so a properly-formed request that passes the
+    // gateway can't be rejected here.
+    const PIVOT_BODY_LIMIT_BYTES: usize = 64 * 1024;
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/visualsign/api/v1/parse", post(parse_v1))
+        .route("/visualsign/api/v2/parse", post(parse_v2))
+        .layer(axum::extract::DefaultBodyLimit::max(PIVOT_BODY_LIMIT_BYTES))
+        .with_state(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], args.port));
+    eprintln!("parser_http_server listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to register SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    ctrl_c.await.expect("failed to listen for ctrl-c");
+    eprintln!("parser_http_server shutting down");
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_is_parsed_from_raw_bytes_not_reserialized() {
+        // A later PR verifies an X-Stamp signature over the exact request
+        // bytes. If a handler ever takes `Json<T>` and re-serializes, the
+        // bytes change (key order, whitespace, unicode escaping) and every
+        // stamp fails. Locking the seam here means that PR adds one call and
+        // no signature churn.
+        let raw = br#"{"request":{"chain":"CHAIN_ETHEREUM","unsigned_payload":"0x02","include_intermediate_output":false}}"#;
+        let parsed = parse_envelope(raw).unwrap();
+        assert_eq!(parsed.request.chain, "CHAIN_ETHEREUM");
+        // Re-serializing must NOT be how we get bytes back: prove they differ,
+        // so a future refactor that leans on serde output gets caught.
+        let reserialized = serde_json::to_vec(&parsed).unwrap();
+        assert_ne!(
+            reserialized.as_slice(),
+            raw.as_slice(),
+            "serde round-trip changes the bytes; verification must use the original slice"
+        );
+    }
+
+    #[test]
+    fn static_boot_proof_has_the_six_keys_and_a_real_ephemeral_pubkey() {
+        let pair = qos_p256::P256Pair::generate().unwrap();
+        let expected_hex = qos_hex::encode(&pair.public_key().to_bytes());
+        let source = StaticBootProof::from_enclave_files(
+            &pair,
+            "visualsign-parser".to_string(),
+            "test".to_string(),
+        );
+        let bp = source.boot_proof();
+        assert_eq!(bp.ephemeral_public_key_hex, expected_hex);
+        // A later PR fills the doc; until then it is explicitly empty, never a fake.
+        assert!(bp.aws_attestation_doc_b64.is_empty());
+        let value = serde_json::to_value(&bp).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 6);
+    }
+}

--- a/src/parser/http-server/src/main.rs
+++ b/src/parser/http-server/src/main.rs
@@ -33,11 +33,12 @@
 //! a non-canonical path, bind-mount it instead.
 
 mod boot_proof;
+mod stamp;
 
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
 use base64::Engine as _;
@@ -51,6 +52,7 @@ use host_primitives::turnkey::{
 use parser_app::routes::parse::parse;
 use qos_core::handles::EphemeralKeyHandle;
 use qos_p256::P256Pair;
+use stamp::Allowlist;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -68,36 +70,48 @@ struct Args {
     /// Deployment label reported in every response's `bootProof`.
     #[arg(long, env = "DEPLOYMENT_LABEL", default_value = "")]
     deployment_label: String,
+
+    /// Comma-separated compressed SEC1 hex pubkeys allowed to call the parse
+    /// routes. Absent means the routes stay open (today's behavior);
+    /// present means every request must carry a valid X-Stamp from a listed
+    /// key. Delivered via `pivotArgs` at deploy time.
+    #[arg(long, env = "ALLOWED_STAMP_PUBKEYS_HEX")]
+    allowed_stamp_pubkeys_hex: Option<String>,
 }
 
 #[derive(Clone)]
 struct AppState {
     ephemeral_key: Arc<P256Pair>,
     boot_proof: Arc<dyn BootProofSource + Send + Sync>,
+    allowlist: Option<Arc<Allowlist>>,
 }
 
 async fn health() -> StatusCode {
     StatusCode::OK
 }
 
-// Handlers take raw bytes, never `Json<T>`. A later PR verifies an X-Stamp
-// signature over the exact request bytes; a `Json<T>` extractor re-serializes
+// Handlers take raw bytes, never `Json<T>`. The X-Stamp signature is verified
+// against the exact request bytes; a `Json<T>` extractor re-serializes
 // before the handler body runs, changing key order / whitespace / unicode
 // escaping and invalidating every signature. Both routes share one body.
+// `headers` comes before `body` because axum requires body-consuming
+// extractors last.
 async fn parse_v1(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
-    handle_parse(&state, &body)
+    handle_parse(&state, &headers, &body)
 }
 
 /// v2 is byte-identical to v1 in this PR. Registering it now keeps the
-/// deployed URL stable across the stack as later PRs add enforcement here.
+/// deployed URL stable across the stack as later PRs add payment enforcement here.
 async fn parse_v2(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
-    handle_parse(&state, &body)
+    handle_parse(&state, &headers, &body)
 }
 
 /// Deserialize the envelope from the original bytes. Kept separate so the
@@ -106,8 +120,27 @@ fn parse_envelope(body: &[u8]) -> Result<TurnkeyRequestWrapper, serde_json::Erro
     serde_json::from_slice(body)
 }
 
-fn handle_parse(state: &AppState, body: &[u8]) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
-    // A later PR inserts the X-Stamp check here, before anything else touches `body`.
+fn handle_parse(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> (StatusCode, Json<TurnkeyResponseWrapper>) {
+    if let Some(allowlist) = state.allowlist.as_deref() {
+        if let Err(e) = stamp::verify(headers, body, allowlist) {
+            eprintln!("rejected request: {e:?}");
+            // Deliberately coarse: the client learns "not authenticated", not
+            // which check failed, so the error text cannot be used to probe
+            // the allowlist.
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(error_response(
+                    "invalid or missing X-Stamp".to_string(),
+                    state.boot_proof.boot_proof(),
+                )),
+            );
+        }
+    }
+
     let wrapper = match parse_envelope(body) {
         Ok(w) => w,
         Err(e) => {
@@ -239,9 +272,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.deployment_label,
     );
 
+    // Absent means the routes stay open (today's behavior); present means
+    // every request must carry a valid X-Stamp from a listed key.
+    let allowlist = args
+        .allowed_stamp_pubkeys_hex
+        .map(|csv| Allowlist::from_hex_list(&csv).expect("invalid --allowed-stamp-pubkeys-hex"))
+        .map(Arc::new);
+
     let state = AppState {
         ephemeral_key: Arc::new(ephemeral_key),
         boot_proof: Arc::new(boot_proof),
+        allowlist,
     };
 
     // 64 KiB caps every parse-request body the TVC pivot will accept.

--- a/src/parser/http-server/src/stamp.rs
+++ b/src/parser/http-server/src/stamp.rs
@@ -1,0 +1,240 @@
+//! Validates the `X-Stamp` header Turnkey's stamper attaches to a request.
+//!
+//! The stamp covers the raw request body only: no timestamp, no nonce, no
+//! method or path. Verification must run against the exact bytes the client
+//! sent, never a re-serialized form (see `handle_parse` in `main.rs` and the
+//! `signature_is_checked_against_raw_bytes_not_reserialized_json` test below).
+
+use axum::http::HeaderMap;
+use base64::Engine as _;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use serde::Deserialize;
+use subtle::ConstantTimeEq;
+
+/// Header and scheme names are fixed by Turnkey's stamper
+/// (turnkey_api_key_stamper 0.10: API_KEY_STAMP_HEADER_NAME,
+/// SIGNATURE_SCHEME_P256, SIGNATURE_SCHEME_SECP256K1).
+const STAMP_HEADER: &str = "X-Stamp";
+const SCHEME_P256: &str = "SIGNATURE_SCHEME_TK_API_P256";
+const SCHEME_SECP256K1: &str = "SIGNATURE_SCHEME_TK_API_SECP256K1";
+
+/// `Malformed` and `UnsupportedScheme` carry context read only via `{e:?}`
+/// in `main.rs`'s deliberately coarse client-facing error (see `verify`'s
+/// callsite); same pattern as `boot_proof::BootProofError`.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum StampError {
+    Missing,
+    Malformed(String),
+    UnsupportedScheme(String),
+    UnknownKey,
+    BadSignature,
+}
+
+/// Wire form of the header value: base64url-no-pad JSON.
+///
+/// Deliberately NOT `deny_unknown_fields`: the producer is Turnkey's stamper,
+/// and a field added on their side would otherwise fail every request. The
+/// three fields we read are the ones the signature scheme is defined over.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiStamp {
+    public_key: String,
+    signature: String,
+    scheme: String,
+}
+
+/// Compressed SEC1 pubkeys permitted to call the parse routes. Delivered via
+/// `pivotArgs` at deploy time, the same mechanism that pins the gateway signing
+/// key, so rotation costs a redeploy but no rebuild. A signed allowlist
+/// document (option c in PRS-581) is the follow-up if that hurts.
+pub struct Allowlist {
+    keys: Vec<Vec<u8>>,
+}
+
+impl Allowlist {
+    pub fn from_hex_list(csv: &str) -> Result<Self, StampError> {
+        let mut keys = Vec::new();
+        for entry in csv.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let bytes = visualsign::encodings::decode_hex(entry)
+                .map_err(|e| StampError::Malformed(format!("allowlist entry {entry}: {e}")))?;
+            if bytes.len() != 33 {
+                return Err(StampError::Malformed(format!(
+                    "allowlist entry {entry} is {} bytes, expected 33 (compressed SEC1)",
+                    bytes.len()
+                )));
+            }
+            keys.push(bytes);
+        }
+        if keys.is_empty() {
+            return Err(StampError::Malformed("allowlist is empty".to_string()));
+        }
+        Ok(Self { keys })
+    }
+
+    /// Constant-time membership: a timing signal here would leak which keys are
+    /// allowlisted. Same posture as parser_gateway's auth/attestation compares.
+    fn contains(&self, candidate: &[u8]) -> bool {
+        let mut found = subtle::Choice::from(0u8);
+        for key in &self.keys {
+            found |= key.as_slice().ct_eq(candidate);
+        }
+        found.into()
+    }
+}
+
+/// Verify the `X-Stamp` header against the **raw** request bytes.
+///
+/// The stamp covers the body only: no timestamp, no nonce, no method or path.
+/// It is replayable by design, which is acceptable for a stateless read-only
+/// parse. Combined with x402, a replayed body plus its original VPM is a free
+/// re-parse of the same transaction; the VPM commits to request_hash, so it
+/// cannot be redirected at a different one.
+pub fn verify(headers: &HeaderMap, body: &[u8], allowlist: &Allowlist) -> Result<(), StampError> {
+    let raw = headers.get(STAMP_HEADER).ok_or(StampError::Missing)?;
+    let decoded = BASE64_URL_SAFE_NO_PAD
+        .decode(raw.as_bytes())
+        .map_err(|e| StampError::Malformed(format!("base64url: {e}")))?;
+    let stamp: ApiStamp = serde_json::from_slice(&decoded)
+        .map_err(|e| StampError::Malformed(format!("stamp json: {e}")))?;
+
+    let pubkey = visualsign::encodings::decode_hex(&stamp.public_key)
+        .map_err(|e| StampError::Malformed(format!("publicKey hex: {e}")))?;
+    if !allowlist.contains(&pubkey) {
+        return Err(StampError::UnknownKey);
+    }
+    let sig_der = visualsign::encodings::decode_hex(&stamp.signature)
+        .map_err(|e| StampError::Malformed(format!("signature hex: {e}")))?;
+
+    match stamp.scheme.as_str() {
+        SCHEME_P256 => {
+            use p256::ecdsa::{DerSignature, VerifyingKey, signature::Verifier};
+            let key = VerifyingKey::from_sec1_bytes(&pubkey)
+                .map_err(|e| StampError::Malformed(format!("p256 pubkey: {e}")))?;
+            let sig = DerSignature::from_bytes(&sig_der)
+                .map_err(|e| StampError::Malformed(format!("p256 der: {e}")))?;
+            key.verify(body, &sig).map_err(|_| StampError::BadSignature)
+        }
+        SCHEME_SECP256K1 => {
+            use k256::ecdsa::{DerSignature, VerifyingKey, signature::Verifier};
+            let key = VerifyingKey::from_sec1_bytes(&pubkey)
+                .map_err(|e| StampError::Malformed(format!("k256 pubkey: {e}")))?;
+            let sig = DerSignature::from_bytes(&sig_der)
+                .map_err(|e| StampError::Malformed(format!("k256 der: {e}")))?;
+            key.verify(body, &sig).map_err(|_| StampError::BadSignature)
+        }
+        other => Err(StampError::UnsupportedScheme(other.to_string())),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue};
+    use turnkey_api_key_stamper::{Stamp, TurnkeyP256ApiKey};
+
+    fn headers_for(key: &TurnkeyP256ApiKey, body: &[u8]) -> HeaderMap {
+        let stamp = key.stamp(body).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Stamp", HeaderValue::from_str(&stamp.value).unwrap());
+        headers
+    }
+
+    #[test]
+    fn accepts_a_stamp_from_an_allowlisted_key() {
+        let key = TurnkeyP256ApiKey::generate();
+        let allowlist =
+            Allowlist::from_hex_list(&hex::encode(key.compressed_public_key())).unwrap();
+        let body = br#"{"request":{"chain":"CHAIN_ETHEREUM","unsigned_payload":"0x02"}}"#;
+        verify(&headers_for(&key, body), body, &allowlist).unwrap();
+    }
+
+    #[test]
+    fn rejects_a_stamp_from_an_unlisted_key() {
+        let signer = TurnkeyP256ApiKey::generate();
+        let other = TurnkeyP256ApiKey::generate();
+        let allowlist =
+            Allowlist::from_hex_list(&hex::encode(other.compressed_public_key())).unwrap();
+        let body = br#"{"request":{}}"#;
+        let err = verify(&headers_for(&signer, body), body, &allowlist).unwrap_err();
+        assert!(matches!(err, StampError::UnknownKey));
+    }
+
+    #[test]
+    fn signature_is_checked_against_raw_bytes_not_reserialized_json() {
+        // The acceptance criterion for this PR. The stamp is signed over the
+        // exact bytes; serde's output differs in key order and whitespace, so
+        // verifying the re-serialized form must fail.
+        let key = TurnkeyP256ApiKey::generate();
+        let allowlist =
+            Allowlist::from_hex_list(&hex::encode(key.compressed_public_key())).unwrap();
+        // `serde_json::Value` preserves key insertion order in this workspace
+        // (some dependency turns on serde_json's `preserve_order` feature,
+        // and Cargo unifies it for every user of the crate), so a re-ordered
+        // fixture round-trips byte-identical and would make this test pass
+        // for the wrong reason. The whitespace this fixture adds is the part
+        // `serde_json::to_vec`'s compact output always drops, so the
+        // round-trip is guaranteed to differ regardless of that feature.
+        let raw = br#"{"request": {"chain":"CHAIN_ETHEREUM", "unsigned_payload": "0x02"}}"#;
+        let headers = headers_for(&key, raw);
+
+        verify(&headers, raw, &allowlist).unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(raw).unwrap();
+        let reserialized = serde_json::to_vec(&value).unwrap();
+        assert_ne!(
+            reserialized.as_slice(),
+            raw.as_slice(),
+            "fixture must actually differ"
+        );
+        let err = verify(&headers, &reserialized, &allowlist).unwrap_err();
+        assert!(matches!(err, StampError::BadSignature));
+    }
+
+    #[test]
+    fn rejects_missing_header_and_malformed_encodings() {
+        let key = TurnkeyP256ApiKey::generate();
+        let allowlist =
+            Allowlist::from_hex_list(&hex::encode(key.compressed_public_key())).unwrap();
+        let body = br#"{}"#;
+        assert!(matches!(
+            verify(&HeaderMap::new(), body, &allowlist),
+            Err(StampError::Missing)
+        ));
+
+        let mut bad_b64 = HeaderMap::new();
+        bad_b64.insert("X-Stamp", HeaderValue::from_static("!!!not-base64url!!!"));
+        assert!(matches!(
+            verify(&bad_b64, body, &allowlist),
+            Err(StampError::Malformed(_))
+        ));
+
+        let mut bad_json = HeaderMap::new();
+        let payload = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(b"{\"nope\":1}");
+        bad_json.insert("X-Stamp", HeaderValue::from_str(&payload).unwrap());
+        assert!(matches!(
+            verify(&bad_json, body, &allowlist),
+            Err(StampError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_an_unsupported_scheme() {
+        let key = TurnkeyP256ApiKey::generate();
+        let allowlist =
+            Allowlist::from_hex_list(&hex::encode(key.compressed_public_key())).unwrap();
+        let stamp = serde_json::json!({
+            "publicKey": hex::encode(key.compressed_public_key()),
+            "signature": "3006020100020100",
+            "scheme": "SIGNATURE_SCHEME_TK_API_ED25519",
+        });
+        let mut headers = HeaderMap::new();
+        let value = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(stamp.to_string());
+        headers.insert("X-Stamp", HeaderValue::from_str(&value).unwrap());
+        assert!(matches!(
+            verify(&headers, b"{}", &allowlist),
+            Err(StampError::UnsupportedScheme(_))
+        ));
+    }
+}


### PR DESCRIPTION
## Why

Today Turnkey's gateway authenticates every caller: it validates `X-Stamp` against Turnkey's own DB before the request reaches us. When the pivot becomes the front door, we lose that, and the pivot currently has **zero** authentication (the runbook's smoke test is a plain `curl`).

This keeps the `X-Stamp` wire shape and moves validation into the enclave, against a pubkey allowlist pinned at deploy time.

## What

- `stamp.rs`: `Allowlist`, `StampError`, and `verify(&HeaderMap, &[u8], &Allowlist)`. Header value is base64url-no-pad JSON `{publicKey, signature, scheme}`, `publicKey` hex compressed SEC1, `signature` hex DER, over the raw body. Both P256 and secp256k1 schemes.
- Allowlist arrives via `--allowed-stamp-pubkeys-hex` / `ALLOWED_STAMP_PUBKEYS_HEX`, delivered through `pivotArgs`, the same mechanism that already pins the gateway signing pubkey. Rotation costs a redeploy but no rebuild and no new trust root.
- Absent allowlist means the routes stay open, which is today's behavior, so this cannot break the existing deployment on merge.
- Constant-time pubkey comparison via `subtle`. A timing signal here leaks which keys are allowlisted.
- 401 responses carry `bootProof` like every other response, and the error text is deliberately coarse ("invalid or missing X-Stamp") so it cannot be used to probe the allowlist.

## Test evidence

```
cargo test -p parser_http_server -> 7 passed (5 new stamp tests)
  accepts_a_stamp_from_an_allowlisted_key
  rejects_a_stamp_from_an_unlisted_key
  signature_is_checked_against_raw_bytes_not_reserialized_json
  rejects_missing_header_and_malformed_encodings
  rejects_an_unsupported_scheme
cargo test -p integration --test http_server -> 2 passed
  unstamped -> 401 with bootProof; stamped by a listed key -> 200; unlisted key -> 401
make -C src test / fmt / lint -> clean
```

Stamps in tests are produced by `turnkey_api_key_stamper` itself, so the real producer is exercised rather than our own re-implementation of it.

One thing worth flagging in review: the raw-bytes test initially passed for the wrong reason. This workspace builds `serde_json` with `preserve_order` (it pulls `indexmap`), so an alphabetically-ordered fixture round-trips byte-identical through `Value` and the test proved nothing. The fixture now differs by insignificant whitespace, which compact output always drops regardless of key ordering, so the test has real teeth.

## Open questions before this merges

- **Blocking: does anything between client and pivot rewrite request bodies?** The stamp signs the body, so if Cloudflare normalizes, recompresses, or re-chunks it, body-signed stamps cannot survive the hop and this design has to change. Needs a probe against the live app before merge.
- The stamp covers the body only: no timestamp, no nonce, no method or path. It is replayable by design, which is acceptable for a stateless read-only parse. With x402, a replayed body plus its original VPM is a free re-parse, but the VPM commits to `request_hash`, so it cannot be redirected at a different transaction.
- What we give up versus Turnkey's DB check: per-org and per-user identity, activity-level policy, instant revocation. Acceptable while the caller set is small and known.
- Recommendation on the gateway's `GATEWAY_AUTH_BEARER_TOKEN`: **keep it**. The gateway is internet-facing and sees unauthenticated x402 discovery traffic before any stamp exists on a request. It is a different trust boundary from the enclave hop this PR protects, and it is already an optional flag, so there is no cost to keeping defense in depth.

## Rollback

Revert the commit, or simply stop passing `--allowed-stamp-pubkeys-hex`: with no allowlist configured the routes behave exactly as before this PR.

## Linear

PRS-581

Stacked on #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
