### PR TITLE
feat(parser_http_server): real bootProof from NSM

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -6608,6 +6608,7 @@ dependencies = [
  "parser_app",
  "qos_core",
  "qos_hex",
+ "qos_nsm",
  "qos_p256",
  "serde",
  "serde_json",

--- a/src/parser/http-server/Cargo.toml
+++ b/src/parser/http-server/Cargo.toml
@@ -36,6 +36,7 @@ visualsign = { path = "../../visualsign" }
 # Crypto / hashing / manifest re-encoding for the boot-proof seam.
 qos_core = { workspace = true }
 qos_hex = { workspace = true }
+qos_nsm = { workspace = true }
 qos_p256 = { workspace = true }
 borsh = { version = "1", features = ["std", "derive"], default-features = false }
 
@@ -58,6 +59,11 @@ clap = { version = "4.0", features = ["derive", "env"] }
 
 [dev-dependencies]
 turnkey_api_key_stamper = "0.10"
+# `ManifestEnvelope` (and its nested types) only derive `Default` under
+# qos_core's own "mock" feature; the boot-proof tests need that to build a
+# throwaway manifest fixture without hand-writing every nested field. Cargo's
+# feature unification only applies this to test targets, not the release bin.
+qos_core = { workspace = true, features = ["mock"] }
 
 [lints]
 workspace = true

--- a/src/parser/http-server/src/boot_proof.rs
+++ b/src/parser/http-server/src/boot_proof.rs
@@ -1,16 +1,17 @@
 //! Where a response's `bootProof` comes from.
 //!
-//! PR 3 ships [`StaticBootProof`] (real ephemeral key + real manifest bytes,
-//! empty attestation doc); a later PR adds an NSM-backed implementation that
-//! fills the attestation doc in.
+//! [`StaticBootProof`] carries a real ephemeral key and real manifest bytes
+//! but an empty attestation doc; [`NsmBootProof`] fills the doc in from a
+//! real `/dev/nsm` call.
 
 use host_primitives::turnkey::TurnkeyBootProof;
 use qos_core::protocol::services::boot::ManifestEnvelope;
 use qos_p256::P256Pair;
 
-/// Errors surfaced while assembling a boot proof. `Encode` and `Nsm` are
-/// declared here (unused in this PR) so a later NSM-backed `BootProofSource`
-/// only has to touch its own file, not this shared enum.
+/// Errors surfaced while assembling a boot proof. Every variant carries a
+/// message that is only ever surfaced through the derived `Debug` impl (a log
+/// line or an `eprintln!`), which the dead-code checker does not count as a
+/// read, hence the blanket allow.
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum BootProofError {
@@ -100,4 +101,182 @@ fn read_manifest_borsh_b64() -> (String, String) {
         .map(|b| engine.encode(b))
         .unwrap_or_default();
     (manifest_b64, envelope_b64)
+}
+
+/// NSM-backed boot proof: the real AWS Nitro attestation document, generated
+/// once at construction and reused for every response.
+///
+/// Reproduces qos_core's post-boot attestation call
+/// (`protocol/services/attestation.rs::get_post_boot_attestation_doc`): the
+/// manifest hash goes in `user_data`, the ephemeral pubkey in `public_key`,
+/// and `nonce` stays `None`. That makes the document not request-bound, so
+/// generating it once at startup (rather than per request) is correct, not
+/// just cheap: our reference verifier (`visualsign-turnkeyclient
+/// cmd/verify.go`) sets `SkipTimestampCheck: true`, so there is no freshness
+/// window to satisfy.
+pub struct NsmBootProof {
+    aws_attestation_doc_b64: String,
+    qos_manifest_b64: String,
+    qos_manifest_envelope_b64: String,
+    ephemeral_public_key_hex: String,
+    enclave_app: String,
+    deployment_label: String,
+}
+
+impl NsmBootProof {
+    /// Production constructor: calls the real `/dev/nsm` device.
+    pub fn new(
+        ephemeral: &P256Pair,
+        enclave_app: String,
+        deployment_label: String,
+    ) -> Result<Self, BootProofError> {
+        Self::with_attestor(qos_nsm::Nsm, ephemeral, enclave_app, deployment_label)
+    }
+
+    /// Test seam: takes any `NsmProvider` so unit tests can assert the
+    /// attestor is called exactly once without touching `/dev/nsm`.
+    pub fn with_attestor<A: qos_nsm::NsmProvider>(
+        attestor: A,
+        ephemeral: &P256Pair,
+        enclave_app: String,
+        deployment_label: String,
+    ) -> Result<Self, BootProofError> {
+        use base64::Engine as _;
+        use qos_core::protocol::QosHash;
+        use qos_nsm::types::{NsmRequest, NsmResponse};
+
+        let envelope = read_manifest_envelope()?;
+        let manifest_hash = envelope.manifest.qos_hash().to_vec();
+        let ephemeral_public_key = ephemeral.public_key().to_bytes();
+
+        let response = attestor.nsm_process_request(NsmRequest::Attestation {
+            user_data: Some(manifest_hash),
+            nonce: None,
+            public_key: Some(ephemeral_public_key.clone()),
+        });
+        let document = match response {
+            NsmResponse::Attestation { document } => document,
+            other => return Err(BootProofError::Nsm(format!("{other:?}"))),
+        };
+
+        let engine = base64::engine::general_purpose::STANDARD;
+        let qos_manifest_b64 = engine.encode(
+            borsh::to_vec(&envelope.manifest)
+                .map_err(|e| BootProofError::Encode(format!("manifest borsh: {e}")))?,
+        );
+        let qos_manifest_envelope_b64 = engine.encode(
+            borsh::to_vec(&envelope)
+                .map_err(|e| BootProofError::Encode(format!("envelope borsh: {e}")))?,
+        );
+
+        Ok(Self {
+            aws_attestation_doc_b64: engine.encode(document),
+            qos_manifest_b64,
+            qos_manifest_envelope_b64,
+            ephemeral_public_key_hex: qos_hex::encode(&ephemeral_public_key),
+            enclave_app,
+            deployment_label,
+        })
+    }
+}
+
+impl BootProofSource for NsmBootProof {
+    fn boot_proof(&self) -> TurnkeyBootProof {
+        TurnkeyBootProof {
+            aws_attestation_doc_b64: self.aws_attestation_doc_b64.clone(),
+            qos_manifest_b64: self.qos_manifest_b64.clone(),
+            qos_manifest_envelope_b64: self.qos_manifest_envelope_b64.clone(),
+            ephemeral_public_key_hex: self.ephemeral_public_key_hex.clone(),
+            enclave_app: self.enclave_app.clone(),
+            deployment_label: self.deployment_label.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use qos_nsm::NsmProvider;
+    use qos_nsm::nitro::AttestError;
+    use qos_nsm::types::{NsmRequest, NsmResponse};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// `read_manifest_envelope` reads a real file path (`qos_core::MANIFEST_FILE`),
+    /// so the test writes a throwaway manifest there and removes it on drop.
+    /// `ManifestEnvelope::default()` only exists under qos_core's "mock"
+    /// feature (see this crate's `[dev-dependencies]`), which is exactly the
+    /// scope this fixture needs it in.
+    struct ManifestFixture;
+
+    impl ManifestFixture {
+        fn write() -> Self {
+            let path = std::path::Path::new(qos_core::MANIFEST_FILE);
+            if let Some(dir) = path.parent() {
+                std::fs::create_dir_all(dir).unwrap();
+            }
+            let envelope = qos_core::protocol::services::boot::ManifestEnvelope::default();
+            std::fs::write(path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+            Self
+        }
+    }
+
+    impl Drop for ManifestFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(qos_core::MANIFEST_FILE);
+        }
+    }
+
+    struct CountingAttestor {
+        calls: Arc<AtomicUsize>,
+        document: Vec<u8>,
+    }
+
+    impl NsmProvider for CountingAttestor {
+        fn nsm_process_request(&self, _request: NsmRequest) -> NsmResponse {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            NsmResponse::Attestation {
+                document: self.document.clone(),
+            }
+        }
+
+        fn timestamp_ms(&self) -> Result<u64, AttestError> {
+            Ok(0)
+        }
+    }
+
+    #[test]
+    fn nsm_boot_proof_generates_once_and_reuses_the_document() {
+        // The production route passes nonce: None, so the doc is not
+        // request-bound and can be generated at startup. Our own verifier
+        // does not check the timestamp either (visualsign-turnkeyclient
+        // cmd/verify.go sets SkipTimestampCheck: true), so caching is safe
+        // rather than merely cheap.
+        let _fixture = ManifestFixture::write();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let source = NsmBootProof::with_attestor(
+            CountingAttestor {
+                calls: calls.clone(),
+                document: vec![0xAA; 64],
+            },
+            &qos_p256::P256Pair::generate().unwrap(),
+            "visualsign-parser".to_string(),
+            "test".to_string(),
+        )
+        .unwrap();
+
+        let first = source.boot_proof();
+        let second = source.boot_proof();
+        assert_eq!(
+            first.aws_attestation_doc_b64,
+            second.aws_attestation_doc_b64
+        );
+        assert!(!first.aws_attestation_doc_b64.is_empty());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "doc must be generated once"
+        );
+    }
 }

--- a/src/parser/http-server/src/main.rs
+++ b/src/parser/http-server/src/main.rs
@@ -27,6 +27,9 @@
 //! - `--port <u16>` / `HTTP_PORT` (default 3000) - Turnkey TVC public ingress.
 //! - `--enclave-app <name>` / `ENCLAVE_APP` (default `visualsign-parser`).
 //! - `--deployment-label <label>` / `DEPLOYMENT_LABEL`.
+//! - `--boot-proof-source <static|nsm>` / `BOOT_PROOF_SOURCE` (default
+//!   `static`) - `nsm` calls the real `/dev/nsm` device once at startup for
+//!   the response `bootProof`'s attestation document.
 //!
 //! The ephemeral key is read from `qos_core::EPHEMERAL_KEY_FILE` (provisioned
 //! by QOS inside the enclave). No override flag - if a deployment ever needs
@@ -42,7 +45,7 @@ use axum::{
     routing::{get, post},
 };
 use base64::Engine as _;
-use boot_proof::{BootProofSource, StaticBootProof};
+use boot_proof::{BootProofSource, NsmBootProof, StaticBootProof};
 use clap::Parser;
 use generated::parser::{Chain, ChainMetadata, SignatureScheme};
 use host_primitives::turnkey::{
@@ -77,6 +80,21 @@ struct Args {
     /// key. Delivered via `pivotArgs` at deploy time.
     #[arg(long, env = "ALLOWED_STAMP_PUBKEYS_HEX")]
     allowed_stamp_pubkeys_hex: Option<String>,
+
+    /// Where each response's `bootProof` attestation document comes from.
+    /// `static` (default) leaves it empty, which is what local dev and CI
+    /// run with since they have no `/dev/nsm`. `nsm` calls the real NSM
+    /// device once at startup and reuses the resulting document for every
+    /// response.
+    #[arg(long, env = "BOOT_PROOF_SOURCE", default_value = "static")]
+    boot_proof_source: BootProofSourceKind,
+}
+
+/// See `Args::boot_proof_source`.
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum BootProofSourceKind {
+    Static,
+    Nsm,
 }
 
 #[derive(Clone)]
@@ -266,11 +284,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         qos_core::EPHEMERAL_KEY_FILE,
     );
 
-    let boot_proof = StaticBootProof::from_enclave_files(
-        &ephemeral_key,
-        args.enclave_app,
-        args.deployment_label,
-    );
+    let boot_proof: Arc<dyn BootProofSource + Send + Sync> = match args.boot_proof_source {
+        BootProofSourceKind::Static => Arc::new(StaticBootProof::from_enclave_files(
+            &ephemeral_key,
+            args.enclave_app,
+            args.deployment_label,
+        )),
+        BootProofSourceKind::Nsm => Arc::new(
+            NsmBootProof::new(&ephemeral_key, args.enclave_app, args.deployment_label)
+                .expect("failed to generate NSM boot proof"),
+        ),
+    };
 
     // Absent means the routes stay open (today's behavior); present means
     // every request must carry a valid X-Stamp from a listed key.
@@ -281,7 +305,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let state = AppState {
         ephemeral_key: Arc::new(ephemeral_key),
-        boot_proof: Arc::new(boot_proof),
+        boot_proof,
         allowlist,
     };
 


### PR DESCRIPTION
## Why

Turnkey's gateway attaches `bootProof` to every response today. Once the pivot is the front door it has to produce that itself, or every attestation-verifying consumer breaks. The x402 branch's HTTP envelope has no `bootProof` field at all, so this is the piece that closes the wallet contract on the new path.

## What

Reproduces qos_core's post-boot attestation call directly against `/dev/nsm`: manifest hash in `user_data`, ephemeral pubkey in `public_key`, `nonce: None`. Same shape as `qos_core/src/protocol/services/attestation.rs`, which is what production serves today.

- `NsmBootProof` implementing the `BootProofSource` trait from #450, with a `with_attestor` seam so the behavior is testable without an enclave.
- The document is generated **once at startup** and reused. `nonce: None` means it is not request-bound, and our reference verifier does not check its timestamp (`visualsign-turnkeyclient` `cmd/verify.go` sets `SkipTimestampCheck: true`), so there is no freshness window to satisfy. No TTL, no refresh.
- `--boot-proof-source <static|nsm>` / `BOOT_PROOF_SOURCE`, defaulting to `static`, so local dev and CI are untouched and `NsmBootProof::new` failing outside an enclave cannot break the default path.

The manifest fields are borsh, not the JSON at `/qos.manifest`. The Go verifier borsh-deserializes both and compares `sha256(borsh(manifest))` against the doc's `user_data`, so base64-ing the file bytes would produce fields nothing can verify.

## Test evidence

```
cargo test -p parser_http_server -> 3 passed
  nsm_boot_proof_generates_once_and_reuses_the_document  (asserts exactly one attestor call)
cargo test -p integration --test http_server -> 1 passed
cargo build -p parser_http_server --features vsock -> compiles
make -C src test / fmt / lint -> clean
```

`qos_core`'s `mock` feature is enabled only under `[dev-dependencies]` (needed for `ManifestEnvelope::default()` in the test fixture). Verified with `cargo tree` that resolver 3 keeps it out of the normal build: a non-test build resolves `qos_core` with `vm` only, and `mock,vm` appears exclusively in test builds. Upstream labels that feature "never use in production", so this was worth checking rather than assuming.

## DO NOT MERGE until the NSM reachability probe passes

This implements **option A**: the pivot calls `/dev/nsm` itself. Whether a pivot process can reach that device under TVC, and whether concurrent use alongside qos_core is safe, has **not** been verified against a real deployment. `Nsm` does `nsm_init`/`nsm_exit` per call so it is probably fine, but it needs a real observation.

If the probe fails, this approach is replaced by **option B**: ask Turnkey to expose the attestation doc to the pivot (a unix socket route or a file written post-boot), which is an upstream QOS change and should ride with the QOS bump.

Two acceptance criteria also remain outstanding because they need a live enclave, not a mock:
- boot-proof latency delta measured and recorded (expected to be zero per request given startup generation, but the number should be taken rather than assumed)
- `visualsign-turnkeyclient verify` passing against a real Nitro doc, including "Raw manifest hash matches UserData in attestation". If that hash mismatches, the V1/V2 manifest layout is wrong for this QOS rev.

## Rollback

Revert the commit, or leave `--boot-proof-source` at its `static` default: the NSM path is opt-in and unused unless explicitly selected.

## Linear

PRS-581

Stacked on #450. #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
