### PR TITLE
test(prs-556): add integration tests and docs for deploy-time posture

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -196,6 +196,11 @@ jobs:
             echo "#   \"expectedPivotDigest\": \"${digest}\""
             echo "#   \"qosVersion\": \"${qos_version}\""
             echo '#   "appId": "<env-specific>"'
+            # parser_app refuses to start without an ABI trust posture, and the
+            # posture must be visible in the manifest so a signer can verify which
+            # mode the deployment runs (PRS-556). Pick exactly one.
+            echo '#   "pivotArgs": ["--host-ip", "0.0.0.0", "--host-port", "3000", "--accept-unsigned-abis"]'
+            echo '#     ^ or "--accept-signatures-from-pubkey", "<hex-secp256k1-pubkey>" to reject unsigned ABI mappings'
             echo 'tvc deploy create tvc-deploy.json'
             echo '```'
           } > "$deploy_md"

--- a/.github/workflows/tvc-deploy.yml
+++ b/.github/workflows/tvc-deploy.yml
@@ -45,6 +45,10 @@ on:
         description: "parser_app listen port"
         required: false
         default: "3000"
+      abi_signer_pubkey:
+        description: "ABI trust posture: hex secp256k1 signer pubkey to require-signed ABI mappings, or the literal 'unsigned' to explicitly deploy --accept-unsigned-abis. No default: workflow_dispatch must state a posture (app_id is free text here, so a blank default could silently deploy the permissive posture to a non-test app)."
+        required: false
+        default: ""
       turnkey_client_version:
         description: "turnkey-client image tag for the smoke check (approved version, not latest)"
         required: false
@@ -114,7 +118,23 @@ jobs:
           QOS_VERSION: ${{ inputs.qos_version || '0.12.0' }}
           HOST_IP: ${{ inputs.host_ip || '0.0.0.0' }}
           HOST_PORT: ${{ inputs.host_port || '3000' }}
+          # ABI trust posture, baked into the manifest's pivotArgs. The PR-label
+          # path has no `inputs` context (always blank here) and only ever
+          # targets the dev TEST app, so it keeps the permissive default. A
+          # workflow_dispatch run takes a free-text app_id, so it must state the
+          # posture explicitly: pass a hex signer pubkey, or the literal
+          # "unsigned" to opt into --accept-unsigned-abis on purpose.
+          ABI_SIGNER_PUBKEY: ${{ inputs.abi_signer_pubkey || '' }}
         run: |
+          if [ -z "$ABI_SIGNER_PUBKEY" ] && [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "::error::abi_signer_pubkey is required for workflow_dispatch: pass a hex secp256k1 signer pubkey, or the literal 'unsigned' to explicitly deploy --accept-unsigned-abis."
+            exit 1
+          fi
+          if [ "$ABI_SIGNER_PUBKEY" = "unsigned" ] || [ -z "$ABI_SIGNER_PUBKEY" ]; then
+            abi_trust_args=(--accept-unsigned-abis)
+          else
+            abi_trust_args=(--accept-signatures-from-pubkey "$ABI_SIGNER_PUBKEY")
+          fi
           ./tools/tvc-deploy/target/release/tvc-deploy deploy \
             --app-id "$APP_ID" \
             --image-url "$IMAGE_URL" \
@@ -123,7 +143,8 @@ jobs:
             --operator-seed "$RUNNER_TEMP/operator.seed" \
             --qos-version "$QOS_VERSION" \
             --host-ip "$HOST_IP" \
-            --host-port "$HOST_PORT"
+            --host-port "$HOST_PORT" \
+            "${abi_trust_args[@]}"
 
       # Post-deploy smoke: against the live dev endpoint (/visualsign-dev), run
       # `turnkey-client verify` on a V0+ALT tx and assert it both RENDERS and

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/superpowers/
 lcov.info
 *.profraw
 *.profdata
+.pi/

--- a/docs/adding-new-chain.mdx
+++ b/docs/adding-new-chain.mdx
@@ -240,9 +240,14 @@ mod tests {
    visualsign-<your-chain> = { path = "../../chain_parsers/visualsign-<your-chain>"}
    ```
 
-6. Register your converter in `src/parser/app/src/routes/parse.rs`:
+6. Register your converter in `src/parser/app/src/registry.rs`:
    ```rust
-   fn create_registry() -> visualsign::registry::TransactionConverterRegistry {
+   // `config` carries the deploy-time trust posture for caller-supplied metadata.
+   // Chains that accept no caller metadata can ignore it; the Ethereum converter
+   // threads it through as `EthereumVisualSignConverter::with_policy`.
+   pub fn create_registry(
+       config: &crate::config::ParserConfig,
+   ) -> visualsign::registry::TransactionConverterRegistry {
        let mut registry = visualsign::registry::TransactionConverterRegistry::new();
 
        // ...existing registrations...

--- a/docs/wallet-integration/dapps/ethereum.mdx
+++ b/docs/wallet-integration/dapps/ethereum.mdx
@@ -120,9 +120,16 @@ The metadata bag must contain at least `algorithm` (set to `"secp256k1"`) and `p
 
 #### Trust model
 
-Signing proves the ABI was not modified after you signed it. It does **not** prove who signed it; the parser accepts any well-formed signature from any key. To establish identity, wallets verify your public key against an allowlist they maintain (a static config, a registry of audited dApps, or whatever fits their threat model). Publish your signing key alongside your contracts so wallets can pin it.
+What signing buys you depends on the posture the deployment you're talking to runs. That posture is fixed when the parser is deployed, not per request, so you cannot detect or influence it from your side. There are two:
 
-If signature validation fails, the parser logs a warning and **skips that ABI entry**, falling back to raw-hex rendering for calls to that contract. That means a wrong signature is worse than no signature: users see less information, not more. Ship unsigned ABIs until you're confident the signing pipeline is stable, then add signatures once your wallet integrators are ready to verify them.
+- **Accept-unsigned.** Unsigned ABIs are honoured. A signature that *is* present must still verify against the public key you supply alongside it, so signing proves the ABI was not modified after you signed it, but it does **not** prove who signed it: the signer's identity is not checked against any allowlist. Identity, if anyone establishes it, is established by the wallet.
+- **Require-signed.** Every ABI must carry a signature that verifies *and* whose key is on the deployment's allowlist. Unsigned ABIs and ABIs signed by a key that is not allowlisted are both **dropped**.
+
+Publish your signing key alongside your contracts so wallets and parser operators can pin it.
+
+If an ABI entry is rejected (bad signature under either posture, or unsigned/foreign-signed under require-signed), the parser **skips that entry** and falls back to raw-hex rendering for calls to that contract. The transaction still parses; users just see less information. Nothing in the response distinguishes a dropped entry from one you never sent, so you cannot detect this from the parse result alone.
+
+Practically: a wrong signature is worse than no signature under accept-unsigned, and equally bad under require-signed. Sign your ABIs and get your key allowlisted by the operators you integrate with. Shipping unsigned works only against an accept-unsigned deployment, so treat it as a local development shortcut rather than a rollout strategy.
 
 ## Design calldata that visualizes well
 

--- a/docs/wallet-integration/grpc-server/getting-started.mdx
+++ b/docs/wallet-integration/grpc-server/getting-started.mdx
@@ -50,6 +50,36 @@ EPHEMERAL_FILE=/path/to/key.secret cargo run --bin parser_grpc_server
 
 For development, the binary defaults to `integration/fixtures/ephemeral.secret`.
 
+#### ABI trust posture
+
+Whether caller-supplied Ethereum `abi_mappings` are honoured when they carry no
+signature is chosen at startup, not per request. Pass exactly one of:
+
+```bash
+# Honour unsigned ABI mappings. A signature that IS present must still verify,
+# but its signer is not checked against an allowlist.
+parser_grpc_server --accept-unsigned-abis
+
+# Only honour mappings signed by one of these secp256k1 keys. Repeatable.
+# Unsigned and foreign-signed mappings are dropped.
+parser_grpc_server --accept-signatures-from-pubkey <hex> [--accept-signatures-from-pubkey <hex>]
+```
+
+<Warning>
+With no flag, this binary **defaults to `--accept-unsigned-abis`** and prints a
+notice at startup. That default exists because the standalone server has no
+attestation and no signed deployment manifest to audit the posture against, so
+there is nothing to be gained by refusing to start. It does mean a deployment that
+passes no flag honours unsigned ABI mappings from any caller. The enclave binary
+(`parser_app`) has no such default and refuses to start without an explicit
+posture. If you self-host, state the flag explicitly so the choice is recorded in
+your deployment config rather than inherited from a default.
+</Warning>
+
+A dropped mapping is not an error: the transaction still parses and the affected
+call renders as raw calldata, and nothing in the response distinguishes it from a
+request that supplied no mappings.
+
 ## Building a Docker image
 
 The server binary can be containerized as a single static binary:
@@ -75,7 +105,10 @@ ENV EPHEMERAL_FILE=/etc/visualsign/ephemeral.secret
 
 EXPOSE 44020
 
-CMD ["parser_grpc_server"]
+# State the ABI trust posture explicitly rather than relying on the binary's
+# accept-unsigned default. Swap in --accept-signatures-from-pubkey <hex> to only
+# honour ABI mappings signed by keys you allowlist.
+CMD ["parser_grpc_server", "--accept-unsigned-abis"]
 ```
 
 Build and run:
@@ -109,6 +142,9 @@ spec:
       containers:
       - name: parser
         image: your-registry/visualsign-grpc-server:latest
+        # ABI trust posture, stated explicitly rather than inherited from the
+        # binary's accept-unsigned default.
+        args: ["--accept-unsigned-abis"]
         ports:
         - containerPort: 44020
         env:

--- a/docs/wallet-integration/library/getting-started.mdx
+++ b/docs/wallet-integration/library/getting-started.mdx
@@ -38,14 +38,22 @@ generated = { git = "https://github.com/anchorageoss/visualsign-parser", package
 ### Basic usage
 
 ```rust
+use parser_app::config::ParserConfig;
 use parser_app::registry::create_registry;
 use visualsign::registry::Chain;
+use visualsign::signing::MetadataTrustPolicy;
 use visualsign::vsptrait::{VisualSignOptions, DeveloperConfig};
 use generated::parser::{ChainMetadata, EthereumMetadata, chain_metadata::Metadata};
 
 fn main() {
+    // Pick the trust posture for caller-supplied ABI mappings up front. It is fixed
+    // for the life of the registry, not per call. `AcceptUnsigned` is the permissive
+    // choice and is fine when you supply no ABI mappings, or when you already trust
+    // whoever produced them; see "ABI trust posture" below.
+    let config = ParserConfig::new(MetadataTrustPolicy::AcceptUnsigned);
+
     // Create the parser registry (includes all supported chains)
-    let registry = create_registry();
+    let registry = create_registry(&config);
 
     // Raw transaction hex (with or without 0x prefix)
     // This is a complete EIP-1559 transaction
@@ -163,11 +171,44 @@ let options = VisualSignOptions {
     ..Default::default()
 };
 
-// Parse using the standard registry; ABIs are extracted from metadata automatically
-let registry = create_registry();
+// Parse using the standard registry; ABIs are extracted from metadata automatically.
+// These mappings are unsigned, so the registry must be built on the accept-unsigned
+// posture, otherwise they are dropped and the call renders as raw calldata.
+let config = ParserConfig::new(MetadataTrustPolicy::AcceptUnsigned);
+let registry = create_registry(&config);
 let payload = registry.convert_transaction(&Chain::Ethereum, raw_tx, options)
     .expect("failed to parse transaction");
 ```
+
+### ABI trust posture
+
+Whether caller-supplied ABI mappings are honoured when they carry no signature is a
+property of the registry, chosen once when you build it. It cannot be varied per
+call, and nothing in a transaction or its metadata can move the parser between the
+two postures.
+
+`MetadataTrustPolicy::AcceptUnsigned` registers mappings that carry no signature. A
+signature that *is* present must still verify against the public key supplied
+alongside it, so a payload mutated under an unchanged signature is rejected, but the
+signer's identity is not checked against an allowlist.
+
+`MetadataTrustPolicy::RequireAllowlistedSigner(allowlist)` requires every mapping to
+carry a signature that verifies *and* whose key is in `allowlist`. Unsigned,
+malformed, and foreign-signed mappings are all dropped. An empty allowlist rejects
+everything.
+
+```rust
+use visualsign::signing::{MetadataTrustPolicy, SignerAllowlist};
+
+let mut allowlist = SignerAllowlist::new();
+allowlist.insert(signer_pubkey_bytes); // uncompressed SEC1 secp256k1 public key
+let config = ParserConfig::new(MetadataTrustPolicy::RequireAllowlistedSigner(allowlist));
+let registry = create_registry(&config);
+```
+
+A dropped mapping is not an error. The transaction still parses, and the affected
+call renders as raw calldata rather than decoded fields, so if you deploy the strict
+posture make sure the ABIs you ship are signed by a key in your allowlist.
 
 ### Adding custom IDLs (Solana)
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -6938,6 +6938,7 @@ dependencies = [
  "qos_p256",
  "tokio",
  "tokio-stream",
+ "visualsign",
 ]
 
 [[package]]

--- a/src/integration/src/lib.rs
+++ b/src/integration/src/lib.rs
@@ -139,6 +139,17 @@ impl Builder {
         Self::default()
     }
 
+    /// Start `parser_app` in the strict posture instead: only ABI mappings signed by
+    /// `signer_pubkey_hex` (hex secp256k1) are accepted.
+    #[must_use]
+    pub fn require_signed_abis(mut self, signer_pubkey_hex: &str) -> Self {
+        self.abi_trust_args = vec![
+            "--accept-signatures-from-pubkey".to_string(),
+            signer_pubkey_hex.to_string(),
+        ];
+        self
+    }
+
     /// Execute `test`.
     ///
     /// Note this test env builder relies on binaries from other crates already
@@ -186,7 +197,7 @@ impl Builder {
             .arg("--ephemeral-file")
             .arg("./fixtures/ephemeral.secret")
             // parser_app refuses to start without an explicit ABI trust posture; see
-            // `Builder::default`.
+            // `Builder::default` / `Builder::require_signed_abis`.
             .args(&self.abi_trust_args)
             .spawn()
             .unwrap()

--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 use generated::health::{AppHealthRequest, AppHealthResponse};
-use generated::parser::{Chain, ParseRequest};
+use generated::parser::{
+    Abi, Chain, ChainMetadata, EthereumMetadata, ParseRequest, chain_metadata::Metadata,
+};
 use integration::TestArgs;
 use qos_crypto::sha_256;
 use tonic::Code;
@@ -751,4 +753,256 @@ async fn parser_sui_native_transfer_e2e() {
     }
 
     integration::Builder::new().execute(test).await
+}
+
+// ---------------------------------------------------------------------------
+// Deploy-time ABI trust posture (PRS-556)
+// ---------------------------------------------------------------------------
+//
+// The two tests below send the SAME request to two parser_app instances that
+// differ only in the cmdline they were started with. That is the property the
+// deploy-time flag buys: whether an unverified ABI is honoured is decided by the
+// deployment, not by what the caller put in (or left out of) the request.
+
+/// Unsigned EIP-1559 call to an otherwise-unknown contract, carrying
+/// `frobnicate(uint256,address)` calldata (selector `5c04b43b`). The function is
+/// deliberately one no compiled-in visualizer knows, so whether it renders as a
+/// named call depends ONLY on whether the caller-supplied ABI was honoured.
+const ABI_TX_HEX: &str = "0x02f86c0180830f4240843b9aca00830186a094111111111111111111111111111111111111111180b8445c04b43b00000000000000000000000000000000000000000000000000000000000f4240000000000000000000000000000000000000000000000000000000000000deadc0";
+
+/// The contract `ABI_TX_HEX` calls.
+const ABI_TX_CONTRACT: &str = "0x1111111111111111111111111111111111111111";
+
+/// A valid uncompressed secp256k1 public key (scalar `[0x42; 32]`). Passed to
+/// `--accept-signatures-from-pubkey` to put the parser into the strict posture.
+const ABI_SIGNER_PUBKEY: &str = "0424653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c119fc5009a032aa9fe47f5e149bb8442f71f884ccb516590686d8ff6ab91c613";
+
+/// DER signature over `ABI_JSON` for `ABI_TX_CONTRACT` on chain 1, produced with the
+/// scalar `[0x42; 32]` behind `ABI_SIGNER_PUBKEY`, so the deployed allowlist
+/// authorizes it.
+///
+/// Checked in rather than signed at test time on purpose: signing here would mean
+/// depending on `visualsign-ethereum/dev-signing` from this crate, and because
+/// `integration` is a workspace member, Cargo would then unify that feature ON for
+/// `parser_app` in any workspace-wide invocation. See the keep-out-of-prod note on
+/// the `dev-signing` feature in `visualsign-ethereum/Cargo.toml`. ECDSA signing here
+/// is RFC6979-deterministic, so these are stable. To regenerate, call
+/// `visualsign_ethereum::abi_metadata::sign_abi(ABI_JSON, &address, 1, &seed)` from
+/// a crate that already enables `dev-signing` (e.g. a unit test in that crate).
+const ALLOWLISTED_SIGNER_SIG: &str = "3045022100f64e7822e0762177d0786b7ee513074705b11c13dbef491bc27b7f099b8953dc02201265f573895a648a36158c9a9cf4058bb0e6174cf86681e2441d1a8bbe7aa9f6";
+
+/// The same ABI signed with scalar `[0x43; 32]`, a key the deployment does not
+/// allowlist. The signature itself is valid; only the signer's identity differs.
+const FOREIGN_SIGNER_SIG: &str = "3045022100d6908186f6a67e1ab526f0662ae4190486eba3a8e7a7f33dd367a1511fe2432c02205f95117f3d1a30315206a33bd90b647209a24fbff4df780254dea97b0e3c4472";
+
+/// Uncompressed secp256k1 public key for scalar `[0x43; 32]`.
+const FOREIGN_SIGNER_PUBKEY: &str = "047f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007282870f68031e8772062f4f63cd3ecbf834846787f512738ba15664990af4e20";
+
+/// The ABI both the signed and unsigned fixtures carry.
+const ABI_JSON: &str = r#"[{
+        "type": "function",
+        "name": "frobnicate",
+        "inputs": [
+            {"name": "amount", "type": "uint256"},
+            {"name": "beneficiary", "type": "address"}
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    }]"#;
+
+/// The `SignatureMetadata` for a checked-in `(signature, public key)` pair.
+fn abi_signature_metadata(
+    signature: &str,
+    public_key: &str,
+) -> generated::parser::SignatureMetadata {
+    generated::parser::SignatureMetadata {
+        value: signature.to_string(),
+        metadata: vec![
+            generated::parser::Metadata {
+                key: "algorithm".to_string(),
+                value: "secp256k1".to_string(),
+            },
+            generated::parser::Metadata {
+                key: "public_key".to_string(),
+                value: public_key.to_string(),
+            },
+        ],
+    }
+}
+
+/// A request supplying an ABI mapping signed by the given signer.
+fn signed_abi_parse_request(signature: &str, public_key: &str) -> ParseRequest {
+    let mut abi_mappings = std::collections::BTreeMap::new();
+    abi_mappings.insert(
+        ABI_TX_CONTRACT.to_string(),
+        Abi {
+            value: ABI_JSON.to_string(),
+            signature: Some(abi_signature_metadata(signature, public_key)),
+            ..Default::default()
+        },
+    );
+
+    ParseRequest {
+        include_intermediate_output: false,
+        unsigned_payload: ABI_TX_HEX.to_string(),
+        chain: Chain::Ethereum as i32,
+        chain_metadata: Some(ChainMetadata {
+            metadata: Some(Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: abi_mappings.into_iter().collect(),
+            })),
+        }),
+    }
+}
+
+/// Send `signed_abi_parse_request` and return the rendered payload JSON.
+async fn parsed_payload_for_signed_abi(
+    test_args: TestArgs,
+    signature: &str,
+    public_key: &str,
+) -> String {
+    let parse_response = test_args
+        .parser_client
+        .unwrap()
+        .parse(tonic::Request::new(signed_abi_parse_request(
+            signature, public_key,
+        )))
+        .await
+        .unwrap()
+        .into_inner();
+
+    parse_response
+        .parsed_transaction
+        .unwrap()
+        .payload
+        .unwrap()
+        .parsed_payload
+}
+
+/// A request supplying an UNSIGNED ABI mapping for `ABI_TX_CONTRACT`.
+fn unsigned_abi_parse_request() -> ParseRequest {
+    let mut abi_mappings = std::collections::BTreeMap::new();
+    abi_mappings.insert(
+        ABI_TX_CONTRACT.to_string(),
+        Abi {
+            value: ABI_JSON.to_string(),
+            signature: None,
+            ..Default::default()
+        },
+    );
+
+    ParseRequest {
+        include_intermediate_output: false,
+        unsigned_payload: ABI_TX_HEX.to_string(),
+        chain: Chain::Ethereum as i32,
+        chain_metadata: Some(ChainMetadata {
+            metadata: Some(Metadata::Ethereum(EthereumMetadata {
+                network_id: Some("ETHEREUM_MAINNET".to_string()),
+                abi_mappings: abi_mappings.into_iter().collect(),
+            })),
+        }),
+    }
+}
+
+/// Send `unsigned_abi_parse_request` and return the rendered payload JSON.
+async fn parsed_payload_for_unsigned_abi(test_args: TestArgs) -> String {
+    let parse_response = test_args
+        .parser_client
+        .unwrap()
+        .parse(tonic::Request::new(unsigned_abi_parse_request()))
+        .await
+        .unwrap()
+        .into_inner();
+
+    parse_response
+        .parsed_transaction
+        .unwrap()
+        .payload
+        .unwrap()
+        .parsed_payload
+}
+
+/// A parser deployed with `--accept-unsigned-abis` honours the unsigned ABI: the
+/// calldata is decoded and the function name shows up in the payload.
+#[tokio::test]
+async fn accept_unsigned_abis_deployment_decodes_unsigned_abi() {
+    async fn test(test_args: TestArgs) {
+        let payload = parsed_payload_for_unsigned_abi(test_args).await;
+        assert!(
+            payload.contains("frobnicate"),
+            "accept-unsigned deployment should decode the unsigned ABI, got: {payload}"
+        );
+    }
+
+    integration::Builder::new().execute(test).await
+}
+
+/// The same request against a parser deployed with
+/// `--accept-signatures-from-pubkey` is NOT honoured: the unsigned ABI is dropped,
+/// so the calldata falls back to raw hex and the function name never appears. Only
+/// the cmdline differs from the test above.
+#[tokio::test]
+async fn require_signed_abis_deployment_drops_unsigned_abi() {
+    async fn test(test_args: TestArgs) {
+        let payload = parsed_payload_for_unsigned_abi(test_args).await;
+        assert!(
+            !payload.contains("frobnicate"),
+            "require-signed deployment must not decode an unsigned ABI, got: {payload}"
+        );
+        assert!(
+            payload.contains("5c04b43b"),
+            "the undecoded calldata should fall back to raw hex, got: {payload}"
+        );
+    }
+
+    integration::Builder::new()
+        .require_signed_abis(ABI_SIGNER_PUBKEY)
+        .execute(test)
+        .await
+}
+
+/// The accepting direction of the strict posture: an ABI signed by the very key the
+/// deployment allowlists IS honoured. Without this, a parser that rejected every
+/// caller ABI regardless of signature would still pass the test above.
+#[tokio::test]
+async fn require_signed_abis_deployment_decodes_allowlisted_signed_abi() {
+    async fn test(test_args: TestArgs) {
+        let payload =
+            parsed_payload_for_signed_abi(test_args, ALLOWLISTED_SIGNER_SIG, ABI_SIGNER_PUBKEY)
+                .await;
+        assert!(
+            payload.contains("frobnicate"),
+            "an ABI signed by the allowlisted key must decode, got: {payload}"
+        );
+    }
+
+    integration::Builder::new()
+        .require_signed_abis(ABI_SIGNER_PUBKEY)
+        .execute(test)
+        .await
+}
+
+/// The strict posture gates on signer identity, not merely on a signature being
+/// present: a well-formed signature from a key the deployment does not allowlist is
+/// dropped just like an unsigned entry.
+#[tokio::test]
+async fn require_signed_abis_deployment_drops_foreign_signed_abi() {
+    async fn test(test_args: TestArgs) {
+        let payload =
+            parsed_payload_for_signed_abi(test_args, FOREIGN_SIGNER_SIG, FOREIGN_SIGNER_PUBKEY)
+                .await;
+        assert!(
+            !payload.contains("frobnicate"),
+            "an ABI signed by a non-allowlisted key must not decode, got: {payload}"
+        );
+        assert!(
+            payload.contains("5c04b43b"),
+            "the undecoded calldata should fall back to raw hex, got: {payload}"
+        );
+    }
+
+    integration::Builder::new()
+        .require_signed_abis(ABI_SIGNER_PUBKEY)
+        .execute(test)
+        .await
 }

--- a/src/parser/grpc-server/Cargo.toml
+++ b/src/parser/grpc-server/Cargo.toml
@@ -9,6 +9,7 @@ parser_app = { path = "../app" }
 generated = { path = "../../generated", features = ["tonic_types"] }
 qos_core = { workspace = true }
 qos_p256 = { workspace = true }
+visualsign = { workspace = true }
 
 tokio = { version = "1.0", features = [
   "macros",

--- a/src/parser/grpc-server/src/main.rs
+++ b/src/parser/grpc-server/src/main.rs
@@ -20,6 +20,7 @@ use parser_app::routes::parse::parse;
 use qos_core::handles::EphemeralKeyHandle;
 use qos_p256::P256Pair;
 use std::net::SocketAddr;
+use visualsign::signing::MetadataTrustPolicy;
 
 /// Standalone gRPC service that calls the parser directly
 struct GrpcService {
@@ -31,18 +32,14 @@ struct GrpcService {
 struct HealthService;
 
 impl GrpcService {
-    fn new(ephemeral_file: &str) -> Self {
+    fn new(ephemeral_file: &str, config: ParserConfig) -> Self {
         let handle = EphemeralKeyHandle::new(ephemeral_file.to_string());
         let ephemeral_key = handle
             .get_ephemeral_key()
             .expect("Failed to load ephemeral key");
-        // This dev-only server keeps the historical accept-unsigned posture. A
-        // later commit puts it behind the same cmdline flags parser_app takes.
-        let abi_trust = ParserConfig::abi_trust_from_options(true, &[])
-            .expect("accept-unsigned is always a valid posture");
         Self {
             ephemeral_key,
-            config: ParserConfig::new(abi_trust),
+            config,
         }
     }
 }
@@ -58,6 +55,56 @@ impl ParserService for GrpcService {
             .map(Response::new)
             .map_err(|e| Status::new(tonic::Code::from(e.code as i32), e.message))
     }
+}
+
+/// Cmdline surface of this binary: the ABI trust posture, and nothing else.
+const USAGE: &str = "usage: parser_grpc_server \
+     [--accept-unsigned-abis | --accept-signatures-from-pubkey <hex> ...]";
+
+/// Resolve the ABI trust posture from this server's own cmdline, mirroring
+/// `parser_app`'s `--accept-unsigned-abis` / `--accept-signatures-from-pubkey`.
+///
+/// Unlike `parser_app`, omitting both is allowed and falls back to accept-unsigned
+/// with a loud log line. This binary is the non-TEE deployment: there is no
+/// attestation and no signed manifest to audit the posture against, so the
+/// signer-verifiability argument that makes an explicit choice mandatory in the
+/// enclave does not apply here, and requiring the flag would only break local dev.
+///
+/// Hand-rolled rather than pulled in via clap: two options, and this binary
+/// otherwise has no CLI surface at all.
+fn abi_trust_from_args() -> Result<MetadataTrustPolicy, String> {
+    let mut accept_unsigned = false;
+    let mut signer_pubkeys: Vec<String> = Vec::new();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--accept-unsigned-abis" => accept_unsigned = true,
+            "--accept-signatures-from-pubkey" => {
+                let key = args
+                    .next()
+                    .ok_or("--accept-signatures-from-pubkey needs a hex public key")?;
+                if key.starts_with("--") {
+                    return Err(format!(
+                        "--accept-signatures-from-pubkey expects a hex public key, got flag '{key}'"
+                    ));
+                }
+                signer_pubkeys.push(key);
+            }
+            other => return Err(format!("unexpected argument '{other}'; {USAGE}")),
+        }
+    }
+
+    if !accept_unsigned && signer_pubkeys.is_empty() {
+        println!(
+            "no ABI trust posture given; defaulting to --accept-unsigned-abis. \
+             This is the non-attested dev server; the enclave binary (parser_app) \
+             requires the choice to be explicit."
+        );
+        return Ok(MetadataTrustPolicy::AcceptUnsigned);
+    }
+
+    ParserConfig::abi_trust_from_options(accept_unsigned, &signer_pubkeys)
 }
 
 #[tonic::async_trait]
@@ -89,7 +136,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ephemeral_file = std::env::var("EPHEMERAL_FILE")
         .unwrap_or_else(|_| "integration/fixtures/ephemeral.secret".to_string());
 
-    let svc = GrpcService::new(&ephemeral_file);
+    if std::env::args().skip(1).any(|a| a == "--help" || a == "-h") {
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let abi_trust = abi_trust_from_args().map_err(|e| format!("invalid ABI trust config: {e}"))?;
+    println!("caller-supplied ABI trust: {abi_trust}");
+
+    let svc = GrpcService::new(&ephemeral_file, ParserConfig::new(abi_trust));
 
     let reflection_service = generated::tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(generated::FILE_DESCRIPTOR_SET)

--- a/tools/tvc-deploy/Cargo.lock
+++ b/tools/tvc-deploy/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
+ "k256",
  "qos_p256",
  "serde",
  "serde_json",

--- a/tools/tvc-deploy/Cargo.toml
+++ b/tools/tvc-deploy/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/main.rs"
 anyhow = "1.0.102"
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
+# Used only to reject an off-curve signer pubkey locally, before the key reaches
+# the manifest a quorum signs. Without this the key is only decoded by parser_app
+# at enclave startup, which costs a consensus round and a redeploy to find out.
+k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 qos_p256 = { version = "0.6.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tools/tvc-deploy/README.md
+++ b/tools/tvc-deploy/README.md
@@ -145,6 +145,28 @@ tvc-deploy create-policies --file templates/readonly-policy.json \
 
 ## Deploying
 
+### Choosing the ABI trust posture
+
+Every `deploy` must pick exactly one of:
+
+```
+--accept-unsigned-abis                      # accept caller ABI mappings with no signature
+--accept-signatures-from-pubkey <HEX_PUBKEY>  # only accept mappings signed by this key (repeatable)
+```
+
+The chosen flag is appended to the deployment's `pivotArgs`, so it is part of the
+manifest the operators approve. That is the whole point: a signer verifying a
+deployment reads the posture straight off the manifest, instead of trusting a
+per-request signal or parser logs (Turnkey does not surface those today).
+
+`--accept-signatures-from-pubkey` rejects unsigned mappings outright, plus anything
+signed by a key that was not passed. `--accept-unsigned-abis` accepts unsigned
+mappings; a signature that IS present still has to verify, but its signer is not
+checked, since an attacker facing an identity check would just drop the signature.
+
+Switching posture means a new deployment: the flags live in the manifest, so there
+is no way to flip a running deployment (and no way to flip it per request).
+
 `tvc-deploy deploy` refuses to run if the target `--app-id` already has a
 `create_tvc_deployment` activity awaiting consensus, since Turnkey has no
 dedup for this -- submitting the same deploy twice (e.g. a retry before the

--- a/tools/tvc-deploy/src/main.rs
+++ b/tools/tvc-deploy/src/main.rs
@@ -95,6 +95,13 @@ struct GenOperatorKeyArgs {
 }
 
 #[derive(clap::Args)]
+// The deployed parser's ABI trust posture. Exactly one of the two flags below must
+// be given: they become `pivotArgs` in the manifest the operators sign, so the
+// posture the enclave runs is fixed at deploy time and auditable out of band
+// instead of being implied by what each request happens to contain (PRS-556).
+#[command(group(
+    clap::ArgGroup::new("abi_trust").required(true).multiple(false)
+))]
 struct DeployArgs {
     #[arg(long)]
     app_id: String,
@@ -115,6 +122,14 @@ struct DeployArgs {
     host_ip: String,
     #[arg(long, default_value_t = 3000)]
     host_port: u16,
+    /// Deploy a parser that accepts caller-supplied ABI mappings with no signature
+    /// (integrity and provenance unverified)
+    #[arg(long, group = "abi_trust")]
+    accept_unsigned_abis: bool,
+    /// Deploy a parser that only accepts caller-supplied ABI mappings signed by this
+    /// hex secp256k1 public key. Repeatable
+    #[arg(long, group = "abi_trust", value_name = "HEX_PUBKEY")]
+    accept_signatures_from_pubkey: Vec<String>,
     /// Skip the check for an existing pending deploy activity for this app-id
     #[arg(long)]
     force: bool,
@@ -201,6 +216,9 @@ fn write_secret_file(path: &Path, contents: &str) -> Result<()> {
 
 fn deploy(sh: &Shell, args: &DeployArgs) -> Result<()> {
     validate_digest(&args.expected_digest)?;
+    for key in &args.accept_signatures_from_pubkey {
+        validate_signer_pubkey(key)?;
+    }
 
     if !args.force {
         // Turnkey has no dedup for create_tvc_deployment: submitting the same
@@ -235,13 +253,12 @@ fn deploy(sh: &Shell, args: &DeployArgs) -> Result<()> {
         }
     };
     let cfg_path = temp_path("tvc-deploy", "json");
-    let (app_id, image, digest, operator_id, qos, host_ip, host_port) = (
+    let (app_id, image, digest, operator_id, qos, host_port) = (
         &args.app_id,
         &args.image_url,
         &args.expected_digest,
         &args.operator_id,
         &args.qos_version,
-        &args.host_ip,
         args.host_port,
     );
 
@@ -255,7 +272,7 @@ fn deploy(sh: &Shell, args: &DeployArgs) -> Result<()> {
             "qosVersion": qos,
             "pivotContainerImageUrl": image,
             "pivotPath": "/parser_app",
-            "pivotArgs": ["--host-ip", host_ip, "--host-port", host_port.to_string()],
+            "pivotArgs": pivot_args(args),
             "expectedPivotDigest": digest,
             "debugMode": false,
             "healthCheckType": "TVC_HEALTH_CHECK_TYPE_GRPC",
@@ -292,6 +309,29 @@ fn deploy(sh: &Shell, args: &DeployArgs) -> Result<()> {
     let deploy_id = outcome?;
     println!("deployment {deploy_id} is healthy and live");
     Ok(())
+}
+
+/// Build the pivot cmdline the manifest commits to.
+///
+/// The ABI trust flags are part of it on purpose: a signer verifying a deployment
+/// reads the posture straight off `pivotArgs` instead of trusting a per-request
+/// signal or parser logs (which Turnkey does not surface today). Clap's arg group
+/// guarantees exactly one of the two is set, so this always appends one posture.
+fn pivot_args(args: &DeployArgs) -> Vec<String> {
+    let mut pivot = vec![
+        "--host-ip".to_string(),
+        args.host_ip.to_string(),
+        "--host-port".to_string(),
+        args.host_port.to_string(),
+    ];
+    if args.accept_unsigned_abis {
+        pivot.push("--accept-unsigned-abis".to_string());
+    }
+    for key in &args.accept_signatures_from_pubkey {
+        pivot.push("--accept-signatures-from-pubkey".to_string());
+        pivot.push(key.clone());
+    }
+    pivot
 }
 
 /// Standalone digest gate, for callers that must record the expected digest
@@ -431,6 +471,98 @@ fn validate_digest(d: &str) -> Result<()> {
     }
 }
 
+/// Two-phase validation of a hex signer pubkey.
+///
+/// Phase 1 (format): rejects inputs that aren't even well-formed hex SEC1.
+/// Accepts 33-byte compressed (02/03/05 prefix) and 65-byte uncompressed (04
+/// prefix).  05 is SEC1's "compact" tag: same 33-byte length as compressed, but
+/// the y-coordinate is derived rather than carried, and `canonical_pubkey_from_hex`
+/// (what `parser_app` actually runs on `--accept-signatures-from-pubkey`) accepts
+/// it same as 02/03/04, so it must not be rejected here.
+///
+/// Phase 2 (on-curve): decodes the bytes through `k256::PublicKey::from_sec1_bytes`
+/// to confirm the point is actually on the secp256k1 curve.  Catching an off-curve
+/// key here, at deploy time, avoids burning a consensus round on an enclave that
+/// would immediately fail the same decode at startup and never report healthy.
+fn validate_signer_pubkey(hex_str: &str) -> Result<()> {
+    let stripped = hex_str
+        .strip_prefix("0x")
+        .or_else(|| hex_str.strip_prefix("0X"))
+        .unwrap_or(hex_str);
+    let valid_len = matches!(stripped.len(), 66 | 130);
+    let valid_prefix = match stripped.len() {
+        66 => {
+            stripped.starts_with("02") || stripped.starts_with("03") || stripped.starts_with("05")
+        }
+        130 => stripped.starts_with("04"),
+        _ => false,
+    };
+    if !(valid_len && valid_prefix && stripped.bytes().all(|b| b.is_ascii_hexdigit())) {
+        bail!(
+            "--accept-signatures-from-pubkey must be a 33-byte (02/03/05-prefixed) or \
+             65-byte (04-prefixed) hex secp256k1 public key, got {}",
+            truncate_for_error(hex_str)
+        );
+    }
+
+    // Format alone is not enough: a well-formed hex string can still fail to decode
+    // to a point on the curve. parser_app decodes it for real at startup, so catching
+    // it here is the difference between a local error and a burned quorum round.
+    //
+    // k256::PublicKey::from_sec1_bytes accepts all four SEC1 tags: 02/03 (compressed),
+    // 04 (uncompressed), and 05 (compact — same 33-byte length as compressed, with the
+    // y-coordinate derived rather than carried). Tested explicitly in
+    // `validate_signer_pubkey_compact_through_k256` below; if a future k256 release ever
+    // drops 05 support, that test will catch it before a deployment reaches the enclave.
+    let bytes = decode_hex_bytes(stripped)?;
+    let key_len = bytes.len();
+    if k256::PublicKey::from_sec1_bytes(&bytes).is_err() {
+        let tag = if key_len == 33 {
+            match bytes.first() {
+                Some(0x02) => "02 (compressed)",
+                Some(0x03) => "03 (compressed)",
+                Some(0x05) => "05 (compact)",
+                _ => "unknown",
+            }
+        } else {
+            "04 (uncompressed)"
+        };
+        bail!(
+            "--accept-signatures-from-pubkey is well-formed hex (SEC1 {tag}, {key_len} bytes) \
+             but does not decode to a point on the secp256k1 curve, got {}",
+            truncate_for_error(hex_str)
+        );
+    }
+    Ok(())
+}
+
+/// Decode an even-length ASCII hex string that has already been charset-checked.
+fn decode_hex_bytes(stripped: &str) -> Result<Vec<u8>> {
+    (0..stripped.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&stripped[i..i + 2], 16)
+                .map_err(|e| anyhow::anyhow!("invalid hex byte at offset {i}: {e}"))
+        })
+        .collect()
+}
+
+/// Bound an operator-supplied value echoed back in an error, so a mistaken paste of
+/// a whole file does not land verbatim in CI logs.
+fn truncate_for_error(value: &str) -> String {
+    const MAX: usize = 64;
+    if value.chars().count() <= MAX {
+        format!("{value:?}")
+    } else {
+        // Truncate on char boundaries: the value is operator-supplied and need not be ASCII.
+        let head: String = value.chars().take(MAX).collect();
+        format!(
+            "{head:?} (truncated, {} chars total)",
+            value.chars().count()
+        )
+    }
+}
+
 /// Resolve the operator seed to a file path, returning `(path, cleanup)` or
 /// `None`. Prefers `--operator-seed <path>`; else reads the hex seed from env
 /// `TVC_CI_OPERATOR_SEED` into a temp 0600 file (cleanup=true so the caller
@@ -483,6 +615,122 @@ mod tests {
     #[test]
     fn cli_parses_all_subcommands() {
         Cli::command().debug_assert();
+    }
+
+    /// Parse a `deploy` invocation, returning just its args.
+    fn deploy_args(extra: &[&str]) -> DeployArgs {
+        let digest = "a".repeat(64);
+        let base = [
+            "tvc-deploy",
+            "deploy",
+            "--app-id",
+            "app",
+            "--image-url",
+            "img",
+            "--expected-digest",
+            &digest,
+            "--operator-id",
+            "op",
+        ];
+        let argv: Vec<String> = base
+            .iter()
+            .map(|s| (*s).to_string())
+            .chain(extra.iter().map(|s| (*s).to_string()))
+            .collect();
+        match Cli::parse_from(argv).command {
+            Command::Deploy(args) => args,
+            _ => panic!("expected the deploy subcommand"),
+        }
+    }
+
+    /// Parse a `deploy` invocation expected to fail, returning clap's error kind.
+    fn deploy_error_kind(extra: &[&str]) -> clap::error::ErrorKind {
+        let digest = "a".repeat(64);
+        let base = [
+            "tvc-deploy",
+            "deploy",
+            "--app-id",
+            "app",
+            "--image-url",
+            "img",
+            "--expected-digest",
+            &digest,
+            "--operator-id",
+            "op",
+        ];
+        let argv: Vec<String> = base
+            .iter()
+            .map(|s| (*s).to_string())
+            .chain(extra.iter().map(|s| (*s).to_string()))
+            .collect();
+        Cli::try_parse_from(argv)
+            .map(|_| ())
+            .expect_err("these args must not parse")
+            .kind()
+    }
+
+    /// The permissive posture is appended to the pivot cmdline the manifest commits
+    /// to, so a signer can read the posture straight off the deployment.
+    #[test]
+    fn pivot_args_carry_accept_unsigned() {
+        let args = deploy_args(&["--accept-unsigned-abis"]);
+        assert_eq!(
+            pivot_args(&args),
+            vec![
+                "--host-ip",
+                "0.0.0.0",
+                "--host-port",
+                "3000",
+                "--accept-unsigned-abis"
+            ]
+        );
+    }
+
+    /// Every signer key is carried through, in order, each with its own flag.
+    #[test]
+    fn pivot_args_carry_every_signer_pubkey() {
+        let args = deploy_args(&[
+            "--accept-signatures-from-pubkey",
+            "04aa",
+            "--accept-signatures-from-pubkey",
+            "04bb",
+        ]);
+        assert_eq!(
+            pivot_args(&args),
+            vec![
+                "--host-ip",
+                "0.0.0.0",
+                "--host-port",
+                "3000",
+                "--accept-signatures-from-pubkey",
+                "04aa",
+                "--accept-signatures-from-pubkey",
+                "04bb"
+            ]
+        );
+    }
+
+    /// A deploy with no posture is rejected, so `pivot_args` can never emit a
+    /// cmdline `parser_app` would refuse to start on.
+    #[test]
+    fn deploy_requires_a_posture() {
+        assert_eq!(
+            deploy_error_kind(&[]),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    /// The two postures are mutually exclusive.
+    #[test]
+    fn deploy_rejects_both_postures() {
+        assert_eq!(
+            deploy_error_kind(&[
+                "--accept-unsigned-abis",
+                "--accept-signatures-from-pubkey",
+                "04aa",
+            ]),
+            clap::error::ErrorKind::ArgumentConflict
+        );
     }
 
     #[test]
@@ -540,6 +788,104 @@ Deployment: deploy-123
         assert!(validate_digest(&"a".repeat(65)).is_err());
         assert!(validate_digest(&("g".repeat(64))).is_err());
         assert!(validate_digest("").is_err());
+    }
+
+    fn hex_of(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// A real secp256k1 public key, in the requested SEC1 encoding. Derived rather
+    /// than hardcoded so the fixtures stay on the curve now that `validate_signer_pubkey`
+    /// decodes them for real.
+    fn real_pubkey_hex(compressed: bool) -> String {
+        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        let sk = k256::SecretKey::from_slice(&[0x42u8; 32]).expect("valid scalar");
+        hex_of(sk.public_key().to_encoded_point(compressed).as_bytes())
+    }
+
+    /// SEC1 "compact" form: `0x05 || x`. Built from a real key's x-coordinate, which
+    /// is by construction an x that has a square root.
+    fn real_compact_pubkey_hex() -> String {
+        let uncompressed = real_pubkey_hex(false);
+        // Skip the "04" tag, keep the 32-byte x coordinate.
+        format!("05{}", &uncompressed[2..66])
+    }
+
+    #[test]
+    fn validate_signer_pubkey_accepts_compressed_and_uncompressed() {
+        let compressed = real_pubkey_hex(true);
+        assert!(validate_signer_pubkey(&compressed).is_ok());
+        assert!(validate_signer_pubkey(&real_pubkey_hex(false)).is_ok());
+        // 0x-prefixed, case-insensitive.
+        assert!(
+            validate_signer_pubkey(&format!("0x{}", real_pubkey_hex(false).to_uppercase())).is_ok()
+        );
+        // SEC1 "compact" tag: same 33-byte length as compressed, and accepted by
+        // `canonical_pubkey_from_hex` (what parser_app actually runs), so a false
+        // rejection here would block a legitimate deployment.
+        assert!(validate_signer_pubkey(&real_compact_pubkey_hex()).is_ok());
+    }
+
+    /// Prove `k256::PublicKey::from_sec1_bytes` accepts SEC1 "compact" form (05
+    /// prefix). The format-only check passes 05 through; this test ensures the
+    /// downstream k256 decode the error message names does the same. If a future
+    /// k256 release ever drops compact support, this test will catch it before the
+    /// error message becomes misleading.
+    #[test]
+    fn validate_signer_pubkey_compact_through_k256() {
+        let compact = real_compact_pubkey_hex();
+        let bytes = (0..compact.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&compact[i..i + 2], 16).expect("valid hex"))
+            .collect::<Vec<u8>>();
+        assert_eq!(bytes[0], 0x05, "compact tag");
+        assert_eq!(bytes.len(), 33, "compact is 33 bytes");
+        k256::PublicKey::from_sec1_bytes(&bytes).expect("k256 must accept SEC1 compact (05) form");
+    }
+
+    #[test]
+    fn validate_signer_pubkey_rejects_truncated_or_malformed() {
+        // The exact truncated shape used elsewhere in this file's own tests.
+        assert!(validate_signer_pubkey("04aa").is_err());
+        assert!(validate_signer_pubkey("").is_err());
+        assert!(validate_signer_pubkey(&format!("06{}", "a".repeat(64))).is_err());
+        assert!(validate_signer_pubkey(&format!("02{}", "g".repeat(64))).is_err());
+        // Wrong length for its prefix (compressed prefix, uncompressed length).
+        assert!(validate_signer_pubkey(&format!("02{}", "a".repeat(128))).is_err());
+    }
+
+    #[test]
+    fn validate_signer_pubkey_rejects_well_formed_hex_that_is_off_curve() {
+        // Correct length and tag, valid hex, but not a point on secp256k1. This is the
+        // case the format-only check used to wave through into the signed manifest.
+        // `ff..ff` exceeds the field prime, so it is not even a valid x coordinate.
+        let err = validate_signer_pubkey(&format!("02{}", "f".repeat(64)))
+            .expect_err("an off-curve key must be rejected locally");
+        assert!(
+            err.to_string().contains("does not decode to a point"),
+            "unexpected error: {err}"
+        );
+        assert!(validate_signer_pubkey(&format!("04{}", "f".repeat(128))).is_err());
+    }
+
+    #[test]
+    fn validate_signer_pubkey_error_truncates_a_huge_paste() {
+        let huge = format!("02{}", "a".repeat(4096));
+        let err = validate_signer_pubkey(&huge).expect_err("wrong length must be rejected");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("truncated"),
+            "unexpected error: {rendered}"
+        );
+        assert!(
+            !rendered.contains(&huge),
+            "error must not echo the whole paste verbatim"
+        );
+        assert!(
+            rendered.len() < 300,
+            "error should stay bounded, got {} chars",
+            rendered.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
> Replaces #444, which GitHub closed as merged when it was merged into its parent
> stack branch instead of being rebased.

## Why am I making this PR?

The deploy-time posture needs end-to-end integration test evidence and the published docs must reflect the new requirement.

## What am I changing?

Four new integration tests covering all posture+signature combinations. Fix two vacuous tests that were passing under the wrong posture. Update docs: library getting-started, add-a-chain guide, dApp integration page, and gRPC server page all document the deploy-time posture choice.

One change from the original #444: the `examples/library_integration_test.rs`
call-site update for `create_registry(&ParserConfig)` now lands in the parser_app
commit, which is where that signature changes. #444 left the example uncompilable
across three commits.

## What is the Linear ticket?

PRS-556

## What are the rollback steps?

Revert the commit.

## Is this change backwards compatible?

Yes, tests and docs only.

## Does this require cross-team/service coordination?

No.

## How do I know it works as designed? Which tests exercise this code?

The four new integration tests. Existing doc build pipeline verifies snippets compile.

Verified at this commit: `cargo clippy --all-targets -- -D warnings` clean, and the
tree here is byte-identical to the pre-rebuild stack tip.
