### PR TITLE
fix(near): sanitize untrusted strings on the intents render path

### DIFF
--- a/src/chain_parsers/visualsign-near/src/actions.rs
+++ b/src/chain_parsers/visualsign-near/src/actions.rs
@@ -16,7 +16,7 @@ use visualsign::field_builders::{
     create_text_field,
 };
 
-use crate::fmt::{format_near, format_tgas};
+use crate::fmt::{charset_safe, format_near, format_tgas};
 
 /// NEAR's native token symbol, used for `AmountV2` abbreviations.
 const NEAR_SYMBOL: &str = "NEAR";
@@ -321,28 +321,6 @@ fn push_amount_and_notes(
         fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
     }
     Ok(())
-}
-
-/// Strips everything except printable ASCII and spaces, so a transaction's
-/// JSON args (`memo`, `msg`, `method_name`) cannot smuggle a newline into a
-/// text field's fallback text. The core crate's charset validator permits
-/// `\n` as the wallet's documented multi-line separator, so an unfiltered
-/// attacker-controlled string can render as extra apparent confirmed fields
-/// on the signing screen.
-///
-/// A literal backslash is stripped too, on availability grounds rather than
-/// spoofing: it serializes as `\\`, so a backslash before `u`/`t`/`r`/`b`/`f`
-/// or `/` puts a `FORBIDDEN_JSON_ESCAPES` substring in the serialized payload
-/// and `SignablePayload::validate_charset` rejects the whole transaction.
-///
-/// Double quotes are kept. They serialize as `\"`, which the core validator
-/// deliberately permits so field text can carry real embedded JSON -- and
-/// `ft_transfer_call`'s `msg` is exactly such a field, so deleting its quotes
-/// would strip structure a signer needs to read literally.
-pub(crate) fn charset_safe(text: &str) -> String {
-    text.chars()
-        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
-        .collect()
 }
 
 /// Human-readable label for an action variant.

--- a/src/chain_parsers/visualsign-near/src/actions.rs
+++ b/src/chain_parsers/visualsign-near/src/actions.rs
@@ -16,7 +16,7 @@ use visualsign::field_builders::{
     create_text_field,
 };
 
-use crate::fmt::{format_near, format_tgas};
+use crate::fmt::{charset_safe, format_near, format_tgas};
 
 /// NEAR's native token symbol, used for `AmountV2` abbreviations.
 const NEAR_SYMBOL: &str = "NEAR";
@@ -321,29 +321,6 @@ fn push_amount_and_notes(
         fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
     }
     Ok(())
-}
-
-/// Strips everything except printable ASCII and spaces. Every untrusted string
-/// that becomes field text passes through here first -- a transaction's JSON
-/// args (`memo`, `msg`, `method_name`), and the caller-supplied asset ids a
-/// token-metadata refusal quotes back. The core crate's charset validator
-/// permits `\n` as the wallet's documented multi-line separator, so an
-/// unfiltered attacker-controlled string can render as extra apparent confirmed
-/// fields on the signing screen.
-///
-/// A literal backslash is stripped too, on availability grounds rather than
-/// spoofing: it serializes as `\\`, so a backslash before `u`/`t`/`r`/`b`/`f`
-/// or `/` puts a `FORBIDDEN_JSON_ESCAPES` substring in the serialized payload
-/// and `SignablePayload::validate_charset` rejects the whole transaction.
-///
-/// Double quotes are kept. They serialize as `\"`, which the core validator
-/// deliberately permits so field text can carry real embedded JSON -- and
-/// `ft_transfer_call`'s `msg` is exactly such a field, so deleting its quotes
-/// would strip structure a signer needs to read literally.
-pub(crate) fn charset_safe(text: &str) -> String {
-    text.chars()
-        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
-        .collect()
 }
 
 /// Human-readable label for an action variant.

--- a/src/chain_parsers/visualsign-near/src/actions.rs
+++ b/src/chain_parsers/visualsign-near/src/actions.rs
@@ -576,7 +576,7 @@ mod tests {
             panic!("expected TextV2, got {:?}", fields[0]);
         };
         assert!(!text_v2.text.contains('\n'));
-        assert_eq!(text_v2.text, "depositAmount: 0.000001 NEAR");
+        assert_eq!(text_v2.text, "deposit?Amount: 0.000001 NEAR");
     }
 
     #[test]
@@ -658,7 +658,7 @@ mod tests {
             .iter()
             .find(|f| field_label(f) == "Message")
             .expect("Message field present");
-        assert_eq!(text_of(message), "pay u0041 now");
+        assert_eq!(text_of(message), "pay ?u0041 now");
     }
 
     fn text_of(field: &SignablePayloadField) -> &str {

--- a/src/chain_parsers/visualsign-near/src/fmt.rs
+++ b/src/chain_parsers/visualsign-near/src/fmt.rs
@@ -1,9 +1,22 @@
 //! yoctoNEAR, Tgas, and field-text formatting helpers.
 
-/// Strips everything except printable ASCII and spaces, so a chain-supplied
-/// string (`memo`, `msg`, `method_name`, an NFT/MT token id) cannot smuggle a
-/// newline into a text field's fallback text. The core crate's charset
-/// validator permits `\n` as the wallet's documented multi-line separator
+/// Marker substituted for a character that cannot be rendered.
+///
+/// Substituting rather than deleting keeps distinct inputs distinct: deletion
+/// renders `a\nb` and `ab` identically, so two chain-supplied values a signer
+/// must be able to tell apart can reach the screen as one string. It also
+/// makes the loss visible, instead of presenting what is left as the whole
+/// value.
+///
+/// `visualsign-solana`'s argument renderer marks elided characters the same
+/// way, so a signer reading either chain's fields reads one convention.
+const ELIDED: char = '?';
+
+/// Renders `text` as printable ASCII and spaces, substituting [`ELIDED`] for
+/// every other character, so a chain-supplied string (`memo`, `msg`,
+/// `method_name`, an NFT/MT token id) cannot smuggle a newline into a text
+/// field's fallback text. The core crate's charset validator permits `\n` as
+/// the wallet's documented multi-line separator
 /// (`SignablePayload::validate_charset`), so an unfiltered attacker-controlled
 /// string can render as extra apparent confirmed fields on the signing screen.
 ///
@@ -17,23 +30,32 @@
 /// remainder verbatim into a plain `String`, so an asset id needs filtering
 /// like any other caller-supplied text.
 ///
-/// Filtering rather than rejecting is deliberate. A legitimate memo carrying
-/// an accented character or an emoji loses those characters instead of failing
-/// the whole parse, which keeps a non-ASCII memo from denying the signer their
-/// transaction.
+/// Substituting rather than rejecting is deliberate. A legitimate memo
+/// carrying an accented character or an emoji renders with markers instead of
+/// failing the whole parse, which keeps a non-ASCII memo from denying the
+/// signer their transaction.
 ///
-/// A literal backslash is stripped too, on availability grounds rather than
+/// A literal backslash is marked too, on availability grounds rather than
 /// spoofing: it serializes as `\\`, so a backslash before `u`/`t`/`r`/`b`/`f`
 /// or `/` puts a `FORBIDDEN_JSON_ESCAPES` substring in the serialized payload
 /// and `SignablePayload::validate_charset` rejects the whole transaction.
 ///
-/// Double quotes are kept. They serialize as `\"`, which the core validator
+/// Double quotes are kept, which is where NEAR's allowed set differs from the
+/// Solana renderer's. They serialize as `\"`, which the core validator
 /// deliberately permits so field text can carry real embedded JSON -- and
-/// `ft_transfer_call`'s `msg` is exactly such a field, so deleting its quotes
-/// would strip structure a signer needs to read literally.
+/// `ft_transfer_call`'s `msg` is exactly such a field, so marking its quotes
+/// would obscure structure a signer needs to read literally. The Solana
+/// renderer emits its own `{key:value}` bracketing, where an unescaped quote
+/// is ambiguous, so it marks them.
 pub(crate) fn charset_safe(text: &str) -> String {
     text.chars()
-        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
+        .map(|c| {
+            if c == ' ' || (c.is_ascii_graphic() && c != '\\') {
+                c
+            } else {
+                ELIDED
+            }
+        })
         .collect()
 }
 
@@ -101,35 +123,35 @@ mod tests {
     }
 
     #[test]
-    fn charset_safe_strips_the_wallet_line_separator() {
+    fn charset_safe_marks_the_wallet_line_separator() {
         assert_eq!(
             charset_safe("innocent\nTo: alice.near"),
-            "innocentTo: alice.near"
+            "innocent?To: alice.near"
         );
     }
 
     /// `\t`, `\r`, `\b`, `\f` serialize to `FORBIDDEN_JSON_ESCAPES` substrings,
     /// which make `SignablePayload::validate_charset` refuse the whole
-    /// transaction. Stripping them here keeps one attacker-supplied byte from
+    /// transaction. Marking them here keeps one attacker-supplied byte from
     /// withholding the payload entirely.
     #[test]
-    fn charset_safe_strips_the_other_control_escapes() {
-        assert_eq!(charset_safe("a\tb\rc\u{8}d\u{c}e"), "abcde");
+    fn charset_safe_marks_the_other_control_escapes() {
+        assert_eq!(charset_safe("a\tb\rc\u{8}d\u{c}e"), "a?b?c?d?e");
     }
 
     #[test]
-    fn charset_safe_strips_a_literal_backslash() {
-        assert_eq!(charset_safe(r"a\u0041b"), "au0041b");
+    fn charset_safe_marks_a_literal_backslash() {
+        assert_eq!(charset_safe(r"a\u0041b"), "a?u0041b");
     }
 
     #[test]
-    fn charset_safe_strips_non_ascii() {
+    fn charset_safe_marks_non_ascii() {
         // A bidi override can reorder a rendered line without changing its
         // bytes; an emoji and an accent are simply outside the ASCII range the
         // core validator accepts.
         assert_eq!(
             charset_safe("caf\u{e9} \u{202e}dlrow \u{1f600}"),
-            "caf dlrow "
+            "caf? ?dlrow ?"
         );
     }
 
@@ -148,8 +170,23 @@ mod tests {
         assert_eq!(charset_safe(r#"{"amount":"1"}"#), r#"{"amount":"1"}"#);
     }
 
+    /// An all-non-ASCII string renders as markers rather than as nothing. The
+    /// signer learns the sender attached text they cannot read, which an empty
+    /// result would hide.
     #[test]
-    fn charset_safe_empties_an_all_non_ascii_string() {
-        assert_eq!(charset_safe("\u{e9}\u{e9}\u{e9}"), "");
+    fn charset_safe_marks_an_all_non_ascii_string() {
+        assert_eq!(charset_safe("\u{e9}\u{e9}\u{e9}"), "???");
+    }
+
+    /// Deleting unrenderable characters let distinct values collapse onto one
+    /// rendering. A signer comparing two fields has to be able to tell them
+    /// apart.
+    #[test]
+    fn charset_safe_keeps_distinct_values_distinct() {
+        assert_ne!(
+            charset_safe("innocent\nTo: alice.near"),
+            charset_safe("innocentTo: alice.near"),
+            "a value carrying a line separator must not render as one without it"
+        );
     }
 }

--- a/src/chain_parsers/visualsign-near/src/fmt.rs
+++ b/src/chain_parsers/visualsign-near/src/fmt.rs
@@ -1,4 +1,36 @@
-//! yoctoNEAR, Tgas formatting helpers.
+//! yoctoNEAR, Tgas, and field-text formatting helpers.
+
+/// Strips everything except printable ASCII and spaces, so a chain-supplied
+/// string (`memo`, `msg`, `method_name`, an NFT/MT token id) cannot smuggle a
+/// newline into a text field's fallback text. The core crate's charset
+/// validator permits `\n` as the wallet's documented multi-line separator
+/// (`SignablePayload::validate_charset`), so an unfiltered attacker-controlled
+/// string can render as extra apparent confirmed fields on the signing screen.
+///
+/// Every untrusted string reaching a field on either NEAR path -- the borsh
+/// transaction path and the intents path -- goes through here. Values typed as
+/// `AccountId` do not need it: an id carrying these bytes fails its own
+/// validation during decode.
+///
+/// Filtering rather than rejecting is deliberate. A legitimate memo carrying
+/// an accented character or an emoji loses those characters instead of failing
+/// the whole parse, which keeps a non-ASCII memo from denying the signer their
+/// transaction.
+///
+/// A literal backslash is stripped too, on availability grounds rather than
+/// spoofing: it serializes as `\\`, so a backslash before `u`/`t`/`r`/`b`/`f`
+/// or `/` puts a `FORBIDDEN_JSON_ESCAPES` substring in the serialized payload
+/// and `SignablePayload::validate_charset` rejects the whole transaction.
+///
+/// Double quotes are kept. They serialize as `\"`, which the core validator
+/// deliberately permits so field text can carry real embedded JSON -- and
+/// `ft_transfer_call`'s `msg` is exactly such a field, so deleting its quotes
+/// would strip structure a signer needs to read literally.
+pub(crate) fn charset_safe(text: &str) -> String {
+    text.chars()
+        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '\\'))
+        .collect()
+}
 
 /// Render `units / 10^decimals` as a decimal string with trailing-zero trim.
 ///

--- a/src/chain_parsers/visualsign-near/src/fmt.rs
+++ b/src/chain_parsers/visualsign-near/src/fmt.rs
@@ -9,8 +9,13 @@
 ///
 /// Every untrusted string reaching a field on either NEAR path -- the borsh
 /// transaction path and the intents path -- goes through here. Values typed as
-/// `AccountId` do not need it: an id carrying these bytes fails its own
-/// validation during decode.
+/// `AccountId` are the one exemption: an id carrying these bytes fails its own
+/// validation during decode, so filtering it would be dead code.
+///
+/// `TokenId` is not such a value, despite its account-id-shaped prefix. Its
+/// `FromStr` parses only the contract half as an `AccountId` and takes the
+/// remainder verbatim into a plain `String`, so an asset id needs filtering
+/// like any other caller-supplied text.
 ///
 /// Filtering rather than rejecting is deliberate. A legitimate memo carrying
 /// an accented character or an emoji loses those characters instead of failing
@@ -93,5 +98,58 @@ mod tests {
     #[test]
     fn format_tgas_hundred() {
         assert_eq!(format_tgas(100_000_000_000_000), "100");
+    }
+
+    #[test]
+    fn charset_safe_strips_the_wallet_line_separator() {
+        assert_eq!(
+            charset_safe("innocent\nTo: alice.near"),
+            "innocentTo: alice.near"
+        );
+    }
+
+    /// `\t`, `\r`, `\b`, `\f` serialize to `FORBIDDEN_JSON_ESCAPES` substrings,
+    /// which make `SignablePayload::validate_charset` refuse the whole
+    /// transaction. Stripping them here keeps one attacker-supplied byte from
+    /// withholding the payload entirely.
+    #[test]
+    fn charset_safe_strips_the_other_control_escapes() {
+        assert_eq!(charset_safe("a\tb\rc\u{8}d\u{c}e"), "abcde");
+    }
+
+    #[test]
+    fn charset_safe_strips_a_literal_backslash() {
+        assert_eq!(charset_safe(r"a\u0041b"), "au0041b");
+    }
+
+    #[test]
+    fn charset_safe_strips_non_ascii() {
+        // A bidi override can reorder a rendered line without changing its
+        // bytes; an emoji and an accent are simply outside the ASCII range the
+        // core validator accepts.
+        assert_eq!(
+            charset_safe("caf\u{e9} \u{202e}dlrow \u{1f600}"),
+            "caf dlrow "
+        );
+    }
+
+    #[test]
+    fn charset_safe_keeps_printable_ascii_and_spaces() {
+        assert_eq!(
+            charset_safe("Send 1.5 wNEAR to alice.near (id #7)"),
+            "Send 1.5 wNEAR to alice.near (id #7)"
+        );
+    }
+
+    /// Double quotes survive: they serialize as `\"`, which the core validator
+    /// permits so a field can carry real embedded JSON.
+    #[test]
+    fn charset_safe_keeps_double_quotes() {
+        assert_eq!(charset_safe(r#"{"amount":"1"}"#), r#"{"amount":"1"}"#);
+    }
+
+    #[test]
+    fn charset_safe_empties_an_all_non_ascii_string() {
+        assert_eq!(charset_safe("\u{e9}\u{e9}\u{e9}"), "");
     }
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -12,6 +12,8 @@ use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_amount_field, create_text_field};
 use visualsign::registry::LayeredRegistry;
 
+use crate::fmt::charset_safe;
+
 use super::tokens;
 use super::verify::SignatureCheck;
 use super::{NEAR_DECIMALS, NEAR_SYMBOL, NearTokenRegistry};
@@ -64,7 +66,7 @@ pub(crate) fn rejected_metadata_diagnostics(
     rejected
         .iter()
         .filter_map(|r| {
-            let message = crate::actions::charset_safe(&format!(
+            let message = charset_safe(&format!(
                 "token metadata supplied for {} was rejected and not used: {}",
                 r.asset_id, r.reason
             ));
@@ -250,8 +252,10 @@ fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSig
         )?);
     }
     if let Some(memo) = &td.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
     }
+    // `referral` is an `AccountId`: its own charset rules already exclude
+    // everything `charset_safe` would strip, so filtering it would be dead code.
     if let Some(referral) = &td.referral {
         fields.push(create_text_field("Referral", referral.as_str())?.signable_payload_field);
     }
@@ -269,7 +273,7 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
         )?);
     }
     if let Some(memo) = &t.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
     }
     // A `Transfer`'s optional notification changes what the transfer does
     // beyond moving the named tokens: `msg` calls `mt_on_transfer` on
@@ -277,7 +281,9 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     // `_transfer_call` form), and `state_init` initializes the receiver's
     // contract in the same receipt.
     if let Some(notification) = &t.notification {
-        fields.push(create_text_field("Message", &notification.msg)?.signable_payload_field);
+        fields.push(
+            create_text_field("Message", &charset_safe(&notification.msg))?.signable_payload_field,
+        );
         if notification.state_init.is_some() {
             fields.push(state_init_field()?);
         }
@@ -285,18 +291,23 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     Ok(fields)
 }
 
-/// A withdraw's optional `msg` (switches the call into its `_transfer_call`
-/// form, passing this to the receiver) and `storage_deposit` (a separate,
-/// unconditional wNEAR debit for the receiver's storage on `token`, never
-/// refunded on failure) -- both must render, since either changes what the
-/// withdraw actually does beyond moving the named token/amount.
+/// A withdraw's trailing fields, shared by all three token standards so none
+/// can silently drop one: the optional `memo`, the optional `msg` (switches
+/// the call into its `_transfer_call` form, passing this to the receiver), and
+/// `storage_deposit` (a separate, unconditional wNEAR debit for the receiver's
+/// storage on `token`, never refunded on failure). Each changes what the
+/// withdraw does beyond moving the named token/amount, so each must render.
 fn push_withdraw_call_details(
     fields: &mut Fields,
+    memo: &Option<String>,
     msg: &Option<String>,
     storage_deposit: Option<near_sdk::NearToken>,
 ) -> Result<(), VisualSignError> {
+    if let Some(memo) = memo.as_deref().filter(|m| !m.is_empty()) {
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    }
     if let Some(msg) = msg.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Message", msg)?.signable_payload_field);
+        fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
     }
     if let Some(deposit) = storage_deposit {
         fields.push(near_amount_field(
@@ -318,10 +329,7 @@ fn render_ft_withdraw(w: &FtWithdraw, registry: &Reg) -> Result<Fields, VisualSi
         w.amount.0,
         registry,
     )?);
-    if let Some(memo) = &w.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
-    }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -329,12 +337,12 @@ fn render_nft_withdraw(w: &NftWithdraw) -> Result<Fields, VisualSignError> {
     let mut fields = vec![
         create_text_field("Token", w.token.as_str())?.signable_payload_field,
         create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
-        create_text_field("NFT Token Id", w.token_id.as_str())?.signable_payload_field,
+        // `token_id` is a plain `String` (`non_fungible_token::TokenId`), not
+        // an `AccountId`, so it carries whatever bytes the sender chose.
+        create_text_field("NFT Token Id", &charset_safe(w.token_id.as_str()))?
+            .signable_payload_field,
     ];
-    if let Some(memo) = &w.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
-    }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -351,11 +359,15 @@ fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
         create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
     ];
     for (id, amount) in w.token_ids.iter().zip(w.amounts.iter()) {
+        // As with `nft_withdraw`'s `token_id`, an MT token id is a plain
+        // `String` (`defuse_nep245::TokenId`); filter it before it joins the
+        // composite, so the amount half cannot be pushed onto its own line.
         fields.push(
-            create_text_field("MT Token", &format!("{} x{}", id, amount.0))?.signable_payload_field,
+            create_text_field("MT Token", &format!("{} x{}", charset_safe(id), amount.0))?
+                .signable_payload_field,
         );
     }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -1062,5 +1074,106 @@ mod tests {
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(!labels.contains(&"Message"), "labels: {labels:?}");
         assert!(!labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    /// The text of the first `TextV2` field carrying `label`.
+    fn text_at(fields: &Fields, label: &str) -> String {
+        fields
+            .iter()
+            .find_map(|f| match f {
+                SignablePayloadField::TextV2 { common, text_v2 } if common.label == label => {
+                    Some(text_v2.text.clone())
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no TextV2 field labelled {label}: {fields:?}"))
+    }
+
+    /// An intent-carried string an attacker controls, shaped to read as two
+    /// more confirmed fields on a wallet that renders the documented `\n`
+    /// separator.
+    const SPOOF: &str = r"innocent\nTo: alice.near\nAmount: 0.001 SOL";
+
+    #[test]
+    fn transfer_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
+    }
+
+    #[test]
+    fn transfer_notification_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Message").contains('\n'));
+    }
+
+    #[test]
+    fn token_diff_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"token_diff","diff":{{"nep141:wrap.near":"-1"}},"memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Memo").contains('\n'));
+    }
+
+    #[test]
+    fn ft_withdraw_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Memo").contains('\n'));
+    }
+
+    /// Covers every withdraw variant at once: `msg` renders through the shared
+    /// [`push_withdraw_call_details`].
+    #[test]
+    fn withdraw_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Message").contains('\n'));
+    }
+
+    // `NftWithdraw::token_id` and `MtWithdraw::token_ids` are plain `String`s
+    // (`non_fungible_token::TokenId`, `defuse_nep245::TokenId`), unconstrained
+    // by any account-id charset -- so unlike `token`/`receiver_id`, they carry
+    // an attacker's bytes straight to the field text.
+    #[test]
+    fn nft_withdraw_token_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"nft_withdraw","token":"nft.near","receiver_id":"alice.near","token_id":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "NFT Token Id").contains('\n'));
+    }
+
+    #[test]
+    fn mt_withdraw_token_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["{SPOOF}"],"amounts":["5"]}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "MT Token").contains('\n'));
+    }
+
+    /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`
+    /// carries the same field and must not drop it.
+    #[test]
+    fn mt_withdraw_renders_its_memo() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["1"],"amounts":["5"],"memo":"for invoice 7"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(text_at(&fields, "Memo"), "for invoice 7");
     }
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -12,6 +12,7 @@ use visualsign::errors::VisualSignError;
 use visualsign::field_builders::{create_amount_field, create_text_field};
 use visualsign::registry::LayeredRegistry;
 
+use crate::fmt::charset_safe;
 use crate::networks::NearNetwork;
 
 use super::tokens;
@@ -66,7 +67,7 @@ pub(crate) fn rejected_metadata_diagnostics(
     rejected
         .iter()
         .filter_map(|r| {
-            let message = crate::actions::charset_safe(&format!(
+            let message = charset_safe(&format!(
                 "token metadata supplied for {} was rejected and not used: {}",
                 r.asset_id, r.reason
             ));
@@ -270,8 +271,10 @@ fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSig
         )?);
     }
     if let Some(memo) = &td.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
     }
+    // `referral` is an `AccountId`: its own charset rules already exclude
+    // everything `charset_safe` would strip, so filtering it would be dead code.
     if let Some(referral) = &td.referral {
         fields.push(create_text_field("Referral", referral.as_str())?.signable_payload_field);
     }
@@ -289,7 +292,7 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
         )?);
     }
     if let Some(memo) = &t.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
     }
     // A `Transfer`'s optional notification changes what the transfer does
     // beyond moving the named tokens: `msg` calls `mt_on_transfer` on
@@ -297,7 +300,9 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     // `_transfer_call` form), and `state_init` initializes the receiver's
     // contract in the same receipt.
     if let Some(notification) = &t.notification {
-        fields.push(create_text_field("Message", &notification.msg)?.signable_payload_field);
+        fields.push(
+            create_text_field("Message", &charset_safe(&notification.msg))?.signable_payload_field,
+        );
         if notification.state_init.is_some() {
             fields.push(state_init_field()?);
         }
@@ -305,18 +310,23 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     Ok(fields)
 }
 
-/// A withdraw's optional `msg` (switches the call into its `_transfer_call`
-/// form, passing this to the receiver) and `storage_deposit` (a separate,
-/// unconditional wNEAR debit for the receiver's storage on `token`, never
-/// refunded on failure) -- both must render, since either changes what the
-/// withdraw actually does beyond moving the named token/amount.
+/// A withdraw's trailing fields, shared by all three token standards so none
+/// can silently drop one: the optional `memo`, the optional `msg` (switches
+/// the call into its `_transfer_call` form, passing this to the receiver), and
+/// `storage_deposit` (a separate, unconditional wNEAR debit for the receiver's
+/// storage on `token`, never refunded on failure). Each changes what the
+/// withdraw does beyond moving the named token/amount, so each must render.
 fn push_withdraw_call_details(
     fields: &mut Fields,
+    memo: &Option<String>,
     msg: &Option<String>,
     storage_deposit: Option<near_sdk::NearToken>,
 ) -> Result<(), VisualSignError> {
+    if let Some(memo) = memo.as_deref().filter(|m| !m.is_empty()) {
+        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    }
     if let Some(msg) = msg.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Message", msg)?.signable_payload_field);
+        fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
     }
     if let Some(deposit) = storage_deposit {
         fields.push(near_amount_field(
@@ -338,10 +348,7 @@ fn render_ft_withdraw(w: &FtWithdraw, registry: &Reg) -> Result<Fields, VisualSi
         w.amount.0,
         registry,
     )?);
-    if let Some(memo) = &w.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
-    }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -349,12 +356,12 @@ fn render_nft_withdraw(w: &NftWithdraw) -> Result<Fields, VisualSignError> {
     let mut fields = vec![
         create_text_field("Token", w.token.as_str())?.signable_payload_field,
         create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
-        create_text_field("NFT Token Id", w.token_id.as_str())?.signable_payload_field,
+        // `token_id` is a plain `String` (`non_fungible_token::TokenId`), not
+        // an `AccountId`, so it carries whatever bytes the sender chose.
+        create_text_field("NFT Token Id", &charset_safe(w.token_id.as_str()))?
+            .signable_payload_field,
     ];
-    if let Some(memo) = &w.memo {
-        fields.push(create_text_field("Memo", memo)?.signable_payload_field);
-    }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -371,11 +378,15 @@ fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
         create_text_field("To", w.receiver_id.as_str())?.signable_payload_field,
     ];
     for (id, amount) in w.token_ids.iter().zip(w.amounts.iter()) {
+        // As with `nft_withdraw`'s `token_id`, an MT token id is a plain
+        // `String` (`defuse_nep245::TokenId`); filter it before it joins the
+        // composite, so the amount half cannot be pushed onto its own line.
         fields.push(
-            create_text_field("MT Token", &format!("{} x{}", id, amount.0))?.signable_payload_field,
+            create_text_field("MT Token", &format!("{} x{}", charset_safe(id), amount.0))?
+                .signable_payload_field,
         );
     }
-    push_withdraw_call_details(&mut fields, &w.msg, w.storage_deposit)?;
+    push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
 }
 
@@ -1126,5 +1137,106 @@ mod tests {
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(!labels.contains(&"Message"), "labels: {labels:?}");
         assert!(!labels.contains(&"Storage Deposit"), "labels: {labels:?}");
+    }
+
+    /// The text of the first `TextV2` field carrying `label`.
+    fn text_at(fields: &Fields, label: &str) -> String {
+        fields
+            .iter()
+            .find_map(|f| match f {
+                SignablePayloadField::TextV2 { common, text_v2 } if common.label == label => {
+                    Some(text_v2.text.clone())
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no TextV2 field labelled {label}: {fields:?}"))
+    }
+
+    /// An intent-carried string an attacker controls, shaped to read as two
+    /// more confirmed fields on a wallet that renders the documented `\n`
+    /// separator.
+    const SPOOF: &str = r"innocent\nTo: alice.near\nAmount: 0.001 SOL";
+
+    #[test]
+    fn transfer_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
+    }
+
+    #[test]
+    fn transfer_notification_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Message").contains('\n'));
+    }
+
+    #[test]
+    fn token_diff_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"token_diff","diff":{{"nep141:wrap.near":"-1"}},"memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Memo").contains('\n'));
+    }
+
+    #[test]
+    fn ft_withdraw_memo_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","memo":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Memo").contains('\n'));
+    }
+
+    /// Covers every withdraw variant at once: `msg` renders through the shared
+    /// [`push_withdraw_call_details`].
+    #[test]
+    fn withdraw_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "Message").contains('\n'));
+    }
+
+    // `NftWithdraw::token_id` and `MtWithdraw::token_ids` are plain `String`s
+    // (`non_fungible_token::TokenId`, `defuse_nep245::TokenId`), unconstrained
+    // by any account-id charset -- so unlike `token`/`receiver_id`, they carry
+    // an attacker's bytes straight to the field text.
+    #[test]
+    fn nft_withdraw_token_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"nft_withdraw","token":"nft.near","receiver_id":"alice.near","token_id":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "NFT Token Id").contains('\n'));
+    }
+
+    #[test]
+    fn mt_withdraw_token_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["{SPOOF}"],"amounts":["5"]}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(!text_at(&fields, "MT Token").contains('\n'));
+    }
+
+    /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`
+    /// carries the same field and must not drop it.
+    #[test]
+    fn mt_withdraw_renders_its_memo() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["1"],"amounts":["5"],"memo":"for invoice 7"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(text_at(&fields, "Memo"), "for invoice 7");
     }
 }

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -144,11 +144,15 @@ fn token_amount_field(
     }
 }
 
-/// Charset-filter an optional field string, dropping it when nothing
-/// printable survives. Filtering before the emptiness test is what keeps an
-/// all-non-ASCII memo from rendering as a blank `Memo` line: it carries no
-/// information, and a labelled empty field reads as though the sender left it
-/// deliberately blank.
+/// Charset-filter an optional field string, dropping it only when the value
+/// itself is empty.
+///
+/// `charset_safe` marks what it cannot render rather than deleting it, so an
+/// all-non-ASCII memo renders as markers instead of vanishing. That is the
+/// intended reading: the sender attached text, and a signer who sees nothing
+/// cannot tell that from a memo that was never sent. The emptiness test still
+/// drops a genuinely empty string, which would otherwise render as a labelled
+/// blank line reading as a deliberately empty memo.
 fn nonempty_filtered(text: Option<&str>) -> Option<String> {
     text.map(charset_safe).filter(|t| !t.is_empty())
 }
@@ -1196,7 +1200,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Memo"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1208,7 +1212,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Message"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1220,7 +1224,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Memo"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1232,7 +1236,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Memo"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1246,7 +1250,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Message"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1262,7 +1266,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "NFT Token Id"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1274,7 +1278,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "MT Token"),
-            "innocentTo: alice.nearAmount: 0.001 SOL x5"
+            "innocent?To: alice.near?Amount: 0.001 SOL x5"
         );
     }
 
@@ -1286,7 +1290,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Message"),
-            "innocentTo: alice.nearAmount: 0.001 SOL"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 
@@ -1303,7 +1307,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "Amount"),
-            "1 (unresolved nep245:mt.near:xTo: attacker.nearAmount: 1000 USDC)"
+            "1 (unresolved nep245:mt.near:x?To: attacker.near?Amount: 1000 USDC)"
         );
     }
 
@@ -1349,7 +1353,7 @@ mod tests {
         // The non-`diagnostics` build prefixes the rule onto the same string,
         // so assert on the message's own content rather than the whole field.
         let message = message_of(&field);
-        assert!(message.contains("innocentTo: attacker.near"), "{message}");
+        assert!(message.contains("innocent?To: attacker.near"), "{message}");
     }
 
     /// The `extraction` rule quotes a `serde_json::Error`, which interpolates

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -26,13 +26,19 @@ type Fields = Vec<SignablePayloadField>;
 /// structured [`SignablePayloadField::Diagnostic`]; the default build carries
 /// the same information as a `Warning`-labelled text field, keeping the
 /// production payload shape unchanged.
+///
+/// `message` is charset-filtered here rather than at each call site. Every
+/// rule on this path quotes untrusted input -- an asset id, a decode error
+/// that echoes the offending value -- so filtering at this choke point is what
+/// makes a newly added rule safe by construction. `rule` is a literal at every
+/// call site and needs no filtering.
 #[cfg(feature = "diagnostics")]
 fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
     Ok(visualsign::field_builders::create_diagnostic_field(
         rule,
         "near-intents",
         visualsign::lint::Severity::Warn,
-        message,
+        &charset_safe(message),
         None,
     )
     .signable_payload_field)
@@ -41,7 +47,10 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// See the `diagnostics`-enabled twin above.
 #[cfg(not(feature = "diagnostics"))]
 fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
-    Ok(create_text_field("Warning", &format!("{rule}: {message}"))?.signable_payload_field)
+    Ok(
+        create_text_field("Warning", &format!("{rule}: {}", charset_safe(message)))?
+            .signable_payload_field,
+    )
 }
 
 /// Report each caller-supplied token-metadata entry the parser refused.
@@ -52,10 +61,10 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// supplied and thrown away. A rejection is a soft finding: the intents still
 /// render, since the refusal protects them rather than invalidating them.
 ///
-/// Both halves of the message are charset-filtered. `asset_id` is a
-/// caller-controlled map key and `reason` can quote it back (a JSON parse
-/// error, a length), so an embedded newline would otherwise render as extra
-/// apparent fields on the signing screen.
+/// `asset_id` is a caller-controlled map key and `reason` can quote it back (a
+/// JSON parse error, a length); [`diagnostic`] charset-filters the assembled
+/// message, so neither half can render as extra apparent fields on the signing
+/// screen.
 pub(crate) fn rejected_metadata_diagnostics(
     rejected: &[super::token_signature::RejectedTokenMetadata],
 ) -> Fields {
@@ -66,10 +75,10 @@ pub(crate) fn rejected_metadata_diagnostics(
     rejected
         .iter()
         .filter_map(|r| {
-            let message = charset_safe(&format!(
+            let message = format!(
                 "token metadata supplied for {} was rejected and not used: {}",
                 r.asset_id, r.reason
-            ));
+            );
             match diagnostic("rejected-token-metadata", &message) {
                 Ok(field) => Some(field),
                 Err(e) => {
@@ -89,13 +98,26 @@ pub(crate) fn rejected_metadata_diagnostics(
 /// Metadata resolved from an unsigned request entry (a gap-fill for an asset
 /// `SEEDS` doesn't cover) carries an extra diagnostic alongside the amount, so
 /// the signer sees the caveat rather than just an operator log.
+///
+/// A `TokenId` is only half account-typed: its `FromStr` parses the contract
+/// half as an `AccountId` and takes the remainder verbatim into a plain
+/// `String` (`Nep245TokenId::mt_token_id`, `Nep171TokenId::nft_token_id`), and
+/// `Display` round-trips it. So an asset id echoed into field text carries
+/// whatever bytes the sender chose and must be filtered.
+///
+/// The filtered form is for display only. Resolution runs against the raw id,
+/// because stripping first would let a crafted id collapse onto a seeded one
+/// (`nep141:wrap\u{7f}.near` -> `nep141:wrap.near`) and borrow that token's
+/// symbol and decimals.
 fn token_amount_field(
     label: &str,
     asset_id: &str,
     raw: u128,
     registry: &Reg,
 ) -> Result<Fields, VisualSignError> {
-    match tokens::resolve(asset_id, registry) {
+    let resolved = tokens::resolve(asset_id, registry);
+    let asset_id = charset_safe(asset_id);
+    match resolved {
         Some(meta) => {
             let mut fields = vec![
                 create_amount_field(
@@ -120,6 +142,15 @@ fn token_amount_field(
                 .signable_payload_field,
         ]),
     }
+}
+
+/// Charset-filter an optional field string, dropping it when nothing
+/// printable survives. Filtering before the emptiness test is what keeps an
+/// all-non-ASCII memo from rendering as a blank `Memo` line: it carries no
+/// information, and a labelled empty field reads as though the sender left it
+/// deliberately blank.
+fn nonempty_filtered(text: Option<&str>) -> Option<String> {
+    text.map(charset_safe).filter(|t| !t.is_empty())
 }
 
 /// Format a yoctoNEAR balance as a `<amount> NEAR` text field.
@@ -203,7 +234,7 @@ pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, V
         Intent::AuthCall(c) => {
             let mut fields = vec![
                 create_text_field("Contract", c.contract_id.as_str())?.signable_payload_field,
-                create_text_field("Message", &c.msg)?.signable_payload_field,
+                create_text_field("Message", &charset_safe(&c.msg))?.signable_payload_field,
                 near_amount_field("Attached Deposit", c.attached_deposit.as_yoctonear())?,
             ];
             if c.state_init.is_some() {
@@ -251,8 +282,8 @@ fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSig
             registry,
         )?);
     }
-    if let Some(memo) = &td.memo {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(td.memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
     // `referral` is an `AccountId`: its own charset rules already exclude
     // everything `charset_safe` would strip, so filtering it would be dead code.
@@ -272,8 +303,8 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
             registry,
         )?);
     }
-    if let Some(memo) = &t.memo {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(t.memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
     // A `Transfer`'s optional notification changes what the transfer does
     // beyond moving the named tokens: `msg` calls `mt_on_transfer` on
@@ -281,9 +312,9 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     // `_transfer_call` form), and `state_init` initializes the receiver's
     // contract in the same receipt.
     if let Some(notification) = &t.notification {
-        fields.push(
-            create_text_field("Message", &charset_safe(&notification.msg))?.signable_payload_field,
-        );
+        if let Some(msg) = nonempty_filtered(Some(notification.msg.as_str())) {
+            fields.push(create_text_field("Message", &msg)?.signable_payload_field);
+        }
         if notification.state_init.is_some() {
             fields.push(state_init_field()?);
         }
@@ -303,11 +334,11 @@ fn push_withdraw_call_details(
     msg: &Option<String>,
     storage_deposit: Option<near_sdk::NearToken>,
 ) -> Result<(), VisualSignError> {
-    if let Some(memo) = memo.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
-    if let Some(msg) = msg.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
+    if let Some(msg) = nonempty_filtered(msg.as_deref()) {
+        fields.push(create_text_field("Message", &msg)?.signable_payload_field);
     }
     if let Some(deposit) = storage_deposit {
         fields.push(near_amount_field(
@@ -1112,7 +1143,10 @@ mod tests {
             r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"msg":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Message").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1121,7 +1155,10 @@ mod tests {
             r#"{{"intent":"token_diff","diff":{{"nep141:wrap.near":"-1"}},"memo":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Memo").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1130,7 +1167,10 @@ mod tests {
             r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","memo":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Memo").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     /// Covers every withdraw variant at once: `msg` renders through the shared
@@ -1141,7 +1181,10 @@ mod tests {
             r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Message").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     // `NftWithdraw::token_id` and `MtWithdraw::token_ids` are plain `String`s
@@ -1154,7 +1197,10 @@ mod tests {
             r#"{{"intent":"nft_withdraw","token":"nft.near","receiver_id":"alice.near","token_id":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "NFT Token Id").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "NFT Token Id"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1163,7 +1209,102 @@ mod tests {
             r#"{{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["{SPOOF}"],"amounts":["5"]}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "MT Token").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "MT Token"),
+            "innocentTo: alice.nearAmount: 0.001 SOL x5"
+        );
+    }
+
+    #[test]
+    fn auth_call_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"auth_call","contract_id":"c.near","msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
+    }
+
+    // A `TokenId` is only half account-typed: `FromStr` splits on the first
+    // `:` and parses just the contract half as an `AccountId`, taking the
+    // remainder verbatim into a plain `String` (`Nep245TokenId::mt_token_id`,
+    // `Nep171TokenId::nft_token_id`). So an asset id echoed back into field
+    // text carries whatever bytes the sender chose.
+    #[test]
+    fn unresolved_asset_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep245:mt.near:x\nTo: attacker.near\nAmount: 1000 USDC":"1"}}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Amount"),
+            "1 (unresolved nep245:mt.near:xTo: attacker.nearAmount: 1000 USDC)"
+        );
+    }
+
+    /// Sanitizing the asset id must not feed the registry lookup: a crafted id
+    /// that *becomes* a seeded one once its non-printable bytes are stripped
+    /// would otherwise borrow that token's symbol and decimals.
+    #[test]
+    fn asset_id_resolves_on_its_raw_form_not_its_sanitized_form() {
+        let fields = token_amount_field(
+            "Amount",
+            "nep141:wrap\u{7f}.near",
+            1_000_000_000_000_000_000_000_000,
+            &empty_reg(),
+        )
+        .expect("render");
+        let text = text_at(&fields, "Amount");
+        assert!(
+            text.contains("unresolved"),
+            "must not resolve as wNEAR: {text}"
+        );
+    }
+
+    /// The message text of a soft finding, in whichever shape the build emits.
+    fn message_of(field: &SignablePayloadField) -> String {
+        #[cfg(feature = "diagnostics")]
+        match field {
+            SignablePayloadField::Diagnostic { diagnostic, .. } => diagnostic.message.clone(),
+            other => panic!("expected Diagnostic, got {other:?}"),
+        }
+        #[cfg(not(feature = "diagnostics"))]
+        match field {
+            SignablePayloadField::TextV2 { text_v2, .. } => text_v2.text.clone(),
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    /// Diagnostic messages quote untrusted input (an asset id, a decode
+    /// error), so the filter belongs inside the helper rather than at each
+    /// call site.
+    #[test]
+    fn diagnostic_messages_are_sanitized() {
+        let field = diagnostic("test-rule", "innocent\nTo: attacker.near").expect("diagnostic");
+        // The non-`diagnostics` build prefixes the rule onto the same string,
+        // so assert on the message's own content rather than the whole field.
+        let message = message_of(&field);
+        assert!(message.contains("innocentTo: attacker.near"), "{message}");
+    }
+
+    /// The `extraction` rule quotes a `serde_json::Error`, which interpolates
+    /// the offending value -- an attacker-chosen `intent` tag -- with `{}`, so
+    /// its newlines reach the message intact.
+    #[test]
+    fn extraction_diagnostic_sanitizes_the_decode_error() {
+        let mp: MultiPayload = serde_json::from_str(
+            r#"{"standard":"raw_ed25519","payload":"{\"signer_id\":\"alice.near\",\"verifying_contract\":\"intents.near\",\"deadline\":\"2999-01-01T00:00:00Z\",\"nonce\":\"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=\",\"intents\":[{\"intent\":\"innocent\\nTo: attacker.near\"}]}","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN","signature":"ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"}"#,
+        )
+        .expect("multi payload json");
+        let fields = section(1, 1, &mp, &empty_reg()).expect("render");
+        let extraction = fields
+            .iter()
+            .find(|f| super::super::test_support::is_warning_diagnostic(f, "extraction"))
+            .expect("extraction warning");
+        let message = message_of(extraction);
+        assert!(!message.contains('\n'), "{message}");
     }
 
     /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -144,17 +144,44 @@ fn token_amount_field(
     }
 }
 
-/// Charset-filter an optional field string, dropping it only when the value
-/// itself is empty.
+/// Stands in for a present value that renders as nothing, where the value
+/// being present is itself what the signer needs to see.
+const EMPTY_VALUE: &str = "(empty)";
+
+/// Charset-filter an optional field string, dropping it when the value is
+/// empty.
+///
+/// Only for fields whose presence carries no meaning of its own, so that a
+/// value rendering as nothing and a value never supplied are genuinely the
+/// same thing to the signer. A `memo` is such a field: it annotates the
+/// transfer and changes nothing the transfer does. Where presence does change
+/// what executes, use [`present_value`] instead -- dropping the field there
+/// hides the difference between the two on-chain behaviours.
 ///
 /// `charset_safe` marks what it cannot render rather than deleting it, so an
-/// all-non-ASCII memo renders as markers instead of vanishing. That is the
-/// intended reading: the sender attached text, and a signer who sees nothing
-/// cannot tell that from a memo that was never sent. The emptiness test still
-/// drops a genuinely empty string, which would otherwise render as a labelled
-/// blank line reading as a deliberately empty memo.
+/// all-non-ASCII memo renders as markers and reaches the signer; only a
+/// genuinely empty string is dropped, which would otherwise render as a
+/// labelled blank line reading as a deliberately empty memo.
 fn nonempty_filtered(text: Option<&str>) -> Option<String> {
     text.map(charset_safe).filter(|t| !t.is_empty())
+}
+
+/// Charset-filter a value whose presence changes what the transaction does,
+/// substituting [`EMPTY_VALUE`] when nothing renders.
+///
+/// An empty `msg` still selects a contract-calling form on-chain: a
+/// `NotifyOnTransfer` invokes `mt_on_transfer` on the receiver whatever its
+/// `msg` holds, and a withdraw's `Some("")` takes the `_transfer_call` branch
+/// rather than the plain one. Dropping the field for want of text would render
+/// those byte-identically to the transfer that calls nothing, so the signer
+/// would approve a receiver callback with nothing on screen distinguishing it.
+fn present_value(text: &str) -> String {
+    let filtered = charset_safe(text);
+    if filtered.is_empty() {
+        EMPTY_VALUE.to_string()
+    } else {
+        filtered
+    }
 }
 
 /// Format a yoctoNEAR balance as a `<amount> NEAR` text field.
@@ -335,9 +362,13 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     // `_transfer_call` form), and `state_init` initializes the receiver's
     // contract in the same receipt.
     if let Some(notification) = &t.notification {
-        if let Some(msg) = nonempty_filtered(Some(notification.msg.as_str())) {
-            fields.push(create_text_field("Message", &msg)?.signable_payload_field);
-        }
+        // Rendered on presence, not on content: `msg` is a required `String`
+        // here, and `notify_on_transfer` builds the `mt_on_transfer` promise
+        // whenever the notification exists, whatever it holds.
+        fields.push(
+            create_text_field("Message", &present_value(notification.msg.as_str()))?
+                .signable_payload_field,
+        );
         if notification.state_init.is_some() {
             fields.push(state_init_field()?);
         }
@@ -360,8 +391,11 @@ fn push_withdraw_call_details(
     if let Some(memo) = nonempty_filtered(memo.as_deref()) {
         fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
-    if let Some(msg) = nonempty_filtered(msg.as_deref()) {
-        fields.push(create_text_field("Message", &msg)?.signable_payload_field);
+    // `Some("")` is not the same withdraw as `None`: it selects the
+    // `_transfer_call` form, which invokes a callback on the receiver. The
+    // field renders on presence so the two cannot look alike.
+    if let Some(msg) = msg.as_deref() {
+        fields.push(create_text_field("Message", &present_value(msg))?.signable_payload_field);
     }
     if let Some(deposit) = storage_deposit {
         fields.push(near_amount_field(
@@ -1020,6 +1054,31 @@ mod tests {
         assert_eq!(labels, ["Contract", "For Account", "Amount"]);
     }
 
+    /// `Some("")` is a different withdraw from `None`: it takes the
+    /// `_transfer_call` branch, which invokes a callback on the receiver.
+    /// Rendering nothing for it would make the two indistinguishable.
+    #[test]
+    fn ft_withdraw_with_an_empty_message_still_renders_it() {
+        let with_msg = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":""}"#,
+        );
+        let fields = render_intent(&with_msg, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert!(labels.contains(&"Message"), "labels: {labels:?}");
+        assert_eq!(text_at(&fields, "Message"), "(empty)");
+
+        let without_msg = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1"}"#,
+        );
+        let plain = render_intent(&without_msg, &empty_reg()).expect("render");
+        let plain_labels: Vec<&str> = plain.iter().filter_map(label_of).collect();
+        assert!(
+            !plain_labels.contains(&"Message"),
+            "a withdraw with no msg calls nothing back and must render no Message: \
+             {plain_labels:?}"
+        );
+    }
+
     #[test]
     fn ft_withdraw_renders_token_receiver_amount() {
         let intent = intent_from(
@@ -1139,6 +1198,38 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert_eq!(labels, ["To", "Amount"]);
+    }
+
+    /// `notify_on_transfer` builds the `mt_on_transfer` promise whenever the
+    /// notification is present, whatever `msg` holds. An empty one that
+    /// rendered nothing would be byte-identical to the transfer that calls no
+    /// contract at all -- the signer would approve a receiver callback with
+    /// nothing on screen naming it.
+    #[test]
+    fn transfer_with_an_empty_notification_message_still_renders_it() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"attacker.near","tokens":{"nep141:wrap.near":"1"},"msg":""}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        assert_eq!(
+            labels,
+            ["To", "Amount", "Message"],
+            "an empty notification must not render as no notification"
+        );
+        assert_eq!(text_at(&fields, "Message"), "(empty)");
+    }
+
+    /// The other input that used to reach the same collapse. It no longer
+    /// sanitizes to nothing, so the field carries markers rather than needing
+    /// the placeholder.
+    #[test]
+    fn transfer_with_an_unrenderable_notification_message_renders_markers() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"attacker.near","tokens":{"nep141:wrap.near":"1"},"msg":"éé"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(text_at(&fields, "Message"), "??");
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -27,13 +27,19 @@ type Fields = Vec<SignablePayloadField>;
 /// structured [`SignablePayloadField::Diagnostic`]; the default build carries
 /// the same information as a `Warning`-labelled text field, keeping the
 /// production payload shape unchanged.
+///
+/// `message` is charset-filtered here rather than at each call site. Every
+/// rule on this path quotes untrusted input -- an asset id, a decode error
+/// that echoes the offending value -- so filtering at this choke point is what
+/// makes a newly added rule safe by construction. `rule` is a literal at every
+/// call site and needs no filtering.
 #[cfg(feature = "diagnostics")]
 fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
     Ok(visualsign::field_builders::create_diagnostic_field(
         rule,
         "near-intents",
         visualsign::lint::Severity::Warn,
-        message,
+        &charset_safe(message),
         None,
     )
     .signable_payload_field)
@@ -42,7 +48,10 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// See the `diagnostics`-enabled twin above.
 #[cfg(not(feature = "diagnostics"))]
 fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualSignError> {
-    Ok(create_text_field("Warning", &format!("{rule}: {message}"))?.signable_payload_field)
+    Ok(
+        create_text_field("Warning", &format!("{rule}: {}", charset_safe(message)))?
+            .signable_payload_field,
+    )
 }
 
 /// Report each caller-supplied token-metadata entry the parser refused.
@@ -53,10 +62,10 @@ fn diagnostic(rule: &str, message: &str) -> Result<SignablePayloadField, VisualS
 /// supplied and thrown away. A rejection is a soft finding: the intents still
 /// render, since the refusal protects them rather than invalidating them.
 ///
-/// Both halves of the message are charset-filtered. `asset_id` is a
-/// caller-controlled map key and `reason` can quote it back (a JSON parse
-/// error, a length), so an embedded newline would otherwise render as extra
-/// apparent fields on the signing screen.
+/// `asset_id` is a caller-controlled map key and `reason` can quote it back (a
+/// JSON parse error, a length); [`diagnostic`] charset-filters the assembled
+/// message, so neither half can render as extra apparent fields on the signing
+/// screen.
 pub(crate) fn rejected_metadata_diagnostics(
     rejected: &[super::token_signature::RejectedTokenMetadata],
 ) -> Fields {
@@ -67,10 +76,10 @@ pub(crate) fn rejected_metadata_diagnostics(
     rejected
         .iter()
         .filter_map(|r| {
-            let message = charset_safe(&format!(
+            let message = format!(
                 "token metadata supplied for {} was rejected and not used: {}",
                 r.asset_id, r.reason
-            ));
+            );
             match diagnostic("rejected-token-metadata", &message) {
                 Ok(field) => Some(field),
                 Err(e) => {
@@ -91,13 +100,26 @@ pub(crate) fn rejected_metadata_diagnostics(
 /// `SEEDS` doesn't cover, either unsigned or signed by a key this deployment has
 /// not enrolled) carries an extra diagnostic alongside the amount naming which,
 /// so the signer sees the caveat rather than just an operator log.
+///
+/// A `TokenId` is only half account-typed: its `FromStr` parses the contract
+/// half as an `AccountId` and takes the remainder verbatim into a plain
+/// `String` (`Nep245TokenId::mt_token_id`, `Nep171TokenId::nft_token_id`), and
+/// `Display` round-trips it. So an asset id echoed into field text carries
+/// whatever bytes the sender chose and must be filtered.
+///
+/// The filtered form is for display only. Resolution runs against the raw id,
+/// because stripping first would let a crafted id collapse onto a seeded one
+/// (`nep141:wrap\u{7f}.near` -> `nep141:wrap.near`) and borrow that token's
+/// symbol and decimals.
 fn token_amount_field(
     label: &str,
     asset_id: &str,
     raw: u128,
     registry: &Reg,
 ) -> Result<Fields, VisualSignError> {
-    match tokens::resolve(asset_id, registry) {
+    let resolved = tokens::resolve(asset_id, registry);
+    let asset_id = charset_safe(asset_id);
+    match resolved {
         Some(meta) => {
             let mut fields = vec![
                 create_amount_field(
@@ -120,6 +142,15 @@ fn token_amount_field(
                 .signable_payload_field,
         ]),
     }
+}
+
+/// Charset-filter an optional field string, dropping it when nothing
+/// printable survives. Filtering before the emptiness test is what keeps an
+/// all-non-ASCII memo from rendering as a blank `Memo` line: it carries no
+/// information, and a labelled empty field reads as though the sender left it
+/// deliberately blank.
+fn nonempty_filtered(text: Option<&str>) -> Option<String> {
+    text.map(charset_safe).filter(|t| !t.is_empty())
 }
 
 /// Format a yoctoNEAR balance as a `<amount> NEAR` text field.
@@ -204,7 +235,7 @@ pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, V
         Intent::AuthCall(c) => {
             let mut fields = vec![
                 create_text_field("Contract", c.contract_id.as_str())?.signable_payload_field,
-                create_text_field("Message", &c.msg)?.signable_payload_field,
+                create_text_field("Message", &charset_safe(&c.msg))?.signable_payload_field,
                 near_amount_field("Attached Deposit", c.attached_deposit.as_yoctonear())?,
             ];
             if c.state_init.is_some() {
@@ -270,8 +301,8 @@ fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSig
             registry,
         )?);
     }
-    if let Some(memo) = &td.memo {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(td.memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
     // `referral` is an `AccountId`: its own charset rules already exclude
     // everything `charset_safe` would strip, so filtering it would be dead code.
@@ -291,8 +322,8 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
             registry,
         )?);
     }
-    if let Some(memo) = &t.memo {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(t.memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
     // A `Transfer`'s optional notification changes what the transfer does
     // beyond moving the named tokens: `msg` calls `mt_on_transfer` on
@@ -300,9 +331,9 @@ fn render_transfer(t: &Transfer, registry: &Reg) -> Result<Fields, VisualSignErr
     // `_transfer_call` form), and `state_init` initializes the receiver's
     // contract in the same receipt.
     if let Some(notification) = &t.notification {
-        fields.push(
-            create_text_field("Message", &charset_safe(&notification.msg))?.signable_payload_field,
-        );
+        if let Some(msg) = nonempty_filtered(Some(notification.msg.as_str())) {
+            fields.push(create_text_field("Message", &msg)?.signable_payload_field);
+        }
         if notification.state_init.is_some() {
             fields.push(state_init_field()?);
         }
@@ -322,11 +353,11 @@ fn push_withdraw_call_details(
     msg: &Option<String>,
     storage_deposit: Option<near_sdk::NearToken>,
 ) -> Result<(), VisualSignError> {
-    if let Some(memo) = memo.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Memo", &charset_safe(memo))?.signable_payload_field);
+    if let Some(memo) = nonempty_filtered(memo.as_deref()) {
+        fields.push(create_text_field("Memo", &memo)?.signable_payload_field);
     }
-    if let Some(msg) = msg.as_deref().filter(|m| !m.is_empty()) {
-        fields.push(create_text_field("Message", &charset_safe(msg))?.signable_payload_field);
+    if let Some(msg) = nonempty_filtered(msg.as_deref()) {
+        fields.push(create_text_field("Message", &msg)?.signable_payload_field);
     }
     if let Some(deposit) = storage_deposit {
         fields.push(near_amount_field(
@@ -1175,7 +1206,10 @@ mod tests {
             r#"{{"intent":"transfer","receiver_id":"bob.near","tokens":{{"nep141:wrap.near":"1"}},"msg":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Message").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1184,7 +1218,10 @@ mod tests {
             r#"{{"intent":"token_diff","diff":{{"nep141:wrap.near":"-1"}},"memo":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Memo").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1193,7 +1230,10 @@ mod tests {
             r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","memo":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Memo").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Memo"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     /// Covers every withdraw variant at once: `msg` renders through the shared
@@ -1204,7 +1244,10 @@ mod tests {
             r#"{{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "Message").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     // `NftWithdraw::token_id` and `MtWithdraw::token_ids` are plain `String`s
@@ -1217,7 +1260,10 @@ mod tests {
             r#"{{"intent":"nft_withdraw","token":"nft.near","receiver_id":"alice.near","token_id":"{SPOOF}"}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "NFT Token Id").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "NFT Token Id"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
     }
 
     #[test]
@@ -1226,7 +1272,102 @@ mod tests {
             r#"{{"intent":"mt_withdraw","token":"mt.near","receiver_id":"alice.near","token_ids":["{SPOOF}"],"amounts":["5"]}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(!text_at(&fields, "MT Token").contains('\n'));
+        assert_eq!(
+            text_at(&fields, "MT Token"),
+            "innocentTo: alice.nearAmount: 0.001 SOL x5"
+        );
+    }
+
+    #[test]
+    fn auth_call_message_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(&format!(
+            r#"{{"intent":"auth_call","contract_id":"c.near","msg":"{SPOOF}"}}"#
+        ));
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Message"),
+            "innocentTo: alice.nearAmount: 0.001 SOL"
+        );
+    }
+
+    // A `TokenId` is only half account-typed: `FromStr` splits on the first
+    // `:` and parses just the contract half as an `AccountId`, taking the
+    // remainder verbatim into a plain `String` (`Nep245TokenId::mt_token_id`,
+    // `Nep171TokenId::nft_token_id`). So an asset id echoed back into field
+    // text carries whatever bytes the sender chose.
+    #[test]
+    fn unresolved_asset_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(
+            r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep245:mt.near:x\nTo: attacker.near\nAmount: 1000 USDC":"1"}}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert_eq!(
+            text_at(&fields, "Amount"),
+            "1 (unresolved nep245:mt.near:xTo: attacker.nearAmount: 1000 USDC)"
+        );
+    }
+
+    /// Sanitizing the asset id must not feed the registry lookup: a crafted id
+    /// that *becomes* a seeded one once its non-printable bytes are stripped
+    /// would otherwise borrow that token's symbol and decimals.
+    #[test]
+    fn asset_id_resolves_on_its_raw_form_not_its_sanitized_form() {
+        let fields = token_amount_field(
+            "Amount",
+            "nep141:wrap\u{7f}.near",
+            1_000_000_000_000_000_000_000_000,
+            &empty_reg(),
+        )
+        .expect("render");
+        let text = text_at(&fields, "Amount");
+        assert!(
+            text.contains("unresolved"),
+            "must not resolve as wNEAR: {text}"
+        );
+    }
+
+    /// The message text of a soft finding, in whichever shape the build emits.
+    fn message_of(field: &SignablePayloadField) -> String {
+        #[cfg(feature = "diagnostics")]
+        match field {
+            SignablePayloadField::Diagnostic { diagnostic, .. } => diagnostic.message.clone(),
+            other => panic!("expected Diagnostic, got {other:?}"),
+        }
+        #[cfg(not(feature = "diagnostics"))]
+        match field {
+            SignablePayloadField::TextV2 { text_v2, .. } => text_v2.text.clone(),
+            other => panic!("expected TextV2, got {other:?}"),
+        }
+    }
+
+    /// Diagnostic messages quote untrusted input (an asset id, a decode
+    /// error), so the filter belongs inside the helper rather than at each
+    /// call site.
+    #[test]
+    fn diagnostic_messages_are_sanitized() {
+        let field = diagnostic("test-rule", "innocent\nTo: attacker.near").expect("diagnostic");
+        // The non-`diagnostics` build prefixes the rule onto the same string,
+        // so assert on the message's own content rather than the whole field.
+        let message = message_of(&field);
+        assert!(message.contains("innocentTo: attacker.near"), "{message}");
+    }
+
+    /// The `extraction` rule quotes a `serde_json::Error`, which interpolates
+    /// the offending value -- an attacker-chosen `intent` tag -- with `{}`, so
+    /// its newlines reach the message intact.
+    #[test]
+    fn extraction_diagnostic_sanitizes_the_decode_error() {
+        let mp: MultiPayload = serde_json::from_str(
+            r#"{"standard":"raw_ed25519","payload":"{\"signer_id\":\"alice.near\",\"verifying_contract\":\"intents.near\",\"deadline\":\"2999-01-01T00:00:00Z\",\"nonce\":\"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=\",\"intents\":[{\"intent\":\"innocent\\nTo: attacker.near\"}]}","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN","signature":"ed25519:3vtbNQJHZfuV1s5DykzyjkbNLc583hnkrhTz57eDhd966iqzkor6Twgr4Loh2C195SCSEsiGfrd6KcxpjNq9ZbVj"}"#,
+        )
+        .expect("multi payload json");
+        let fields = section(1, 1, &mp, &empty_reg(), NearNetwork::Mainnet).expect("render");
+        let extraction = fields
+            .iter()
+            .find(|f| super::super::test_support::is_warning_diagnostic(f, "extraction"))
+            .expect("extraction warning");
+        let message = message_of(extraction);
+        assert!(!message.contains('\n'), "{message}");
     }
 
     /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -146,7 +146,12 @@ fn token_amount_field(
 
 /// Stands in for a present value that renders as nothing, where the value
 /// being present is itself what the signer needs to see.
-const EMPTY_VALUE: &str = "(empty)";
+///
+/// Ends in a literal backslash so no attacker-controlled string can ever
+/// equal it: [`charset_safe`] elides every backslash a caller's text
+/// contains, so this marker can be produced only here, never by a real `msg`
+/// that happens to spell out the same words.
+const EMPTY_VALUE: &str = "(empty)\\";
 
 /// Charset-filter an optional field string, dropping it when the value is
 /// empty.
@@ -321,7 +326,8 @@ fn render_token_diff(td: &TokenDiff, registry: &Reg) -> Result<Fields, VisualSig
     for (token_id, delta) in td.diff.iter() {
         if *delta == 0 {
             return Err(VisualSignError::ValidationError(format!(
-                "token_diff entry for {token_id} has a zero delta"
+                "token_diff entry for {} has a zero delta",
+                charset_safe(&token_id.to_string())
             )));
         }
         let label = if *delta < 0 { "Send" } else { "Receive" };
@@ -940,6 +946,24 @@ mod tests {
         assert!(message.contains("nep141:usdc.near"), "{message}");
     }
 
+    /// The zero-delta refusal echoes the offending asset id into its error
+    /// message; a crafted id with an embedded newline must reach it
+    /// sanitized, the same as every other echo of a `TokenId` in this file.
+    #[test]
+    fn token_diff_zero_delta_asset_id_with_embedded_newline_is_sanitized() {
+        let intent = intent_from(
+            r#"{"intent":"token_diff","diff":{"nep245:mt.near:x\nTo: attacker.near\nAmount: 1000 USDC":"0"}}"#,
+        );
+        let err = render_intent(&intent, &empty_reg()).expect_err("zero delta must be refused");
+        let message = err.to_string();
+        assert!(message.contains("zero delta"), "{message}");
+        assert!(
+            message.contains("nep245:mt.near:x?To: attacker.near?Amount: 1000 USDC"),
+            "{message}"
+        );
+        assert!(!message.contains('\n'), "{message}");
+    }
+
     #[test]
     fn token_diff_refuses_an_empty_diff() {
         let intent = intent_from(r#"{"intent":"token_diff","diff":{}}"#);
@@ -1065,7 +1089,7 @@ mod tests {
         let fields = render_intent(&with_msg, &empty_reg()).expect("render");
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(labels.contains(&"Message"), "labels: {labels:?}");
-        assert_eq!(text_at(&fields, "Message"), "(empty)");
+        assert_eq!(text_at(&fields, "Message"), "(empty)\\");
 
         let without_msg = intent_from(
             r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1"}"#,
@@ -1077,6 +1101,25 @@ mod tests {
             "a withdraw with no msg calls nothing back and must render no Message: \
              {plain_labels:?}"
         );
+    }
+
+    /// A `msg` that literally spells out the empty-value marker's words must
+    /// not render identically to a genuinely empty `msg` -- the two are
+    /// different on-chain payloads and the signer must be able to tell them
+    /// apart.
+    #[test]
+    fn ft_withdraw_message_spelling_the_empty_marker_is_distinct_from_empty() {
+        let literal = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":"(empty)"}"#,
+        );
+        let fields = render_intent(&literal, &empty_reg()).expect("render");
+        assert_eq!(text_at(&fields, "Message"), "(empty)");
+
+        let empty = intent_from(
+            r#"{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"alice.near","amount":"1","msg":""}"#,
+        );
+        let fields = render_intent(&empty, &empty_reg()).expect("render");
+        assert_eq!(text_at(&fields, "Message"), "(empty)\\");
     }
 
     #[test]
@@ -1217,7 +1260,7 @@ mod tests {
             ["To", "Amount", "Message"],
             "an empty notification must not render as no notification"
         );
-        assert_eq!(text_at(&fields, "Message"), "(empty)");
+        assert_eq!(text_at(&fields, "Message"), "(empty)\\");
     }
 
     /// The other input that used to reach the same collapse. It no longer


### PR DESCRIPTION
Stacked on #439.

Every caller-controlled string the intents renderer puts on the signing screen goes through `charset_safe`. The core charset validator permits `\n` as the wallet's documented multi-line separator (`validate_charset`, and its own comment says attacker-controlled strings must be sanitized at the insertion site), so an unfiltered `memo` or `msg` renders as extra apparent confirmed fields the parser never authored:

```
   ├─ To: 608fe1e7...
   ├─ Amount: 1 (unresolved nep141:sol.omft.near)
   └─ Message: innocent
To: alice.near
Amount: 0.001 SOL
```

The sibling borsh transaction path already filters at each insertion site. `charset_safe` moves to `fmt.rs` so both NEAR paths share one definition rather than the intents path reaching across into `actions.rs`.

## Sinks covered

| Field | Where |
|---|---|
| `memo` | `token_diff`, `transfer`, and all three withdraws |
| `msg` | `transfer`'s notification, the withdraws, `auth_call` |
| `token_id` | `nft_withdraw` (`non_fungible_token::TokenId` = `String`) |
| `token_ids` | `mt_withdraw` (`defuse_nep245::TokenId` = `String`) |
| asset id | the unresolved-amount fallback and the `unverified-token-metadata` diagnostic |
| every diagnostic message | filtered inside `diagnostic()` itself |

`referral` is exempt and stays unfiltered: it is an `AccountId`, whose own charset rules already exclude everything the filter strips, so filtering it would be dead code.

`TokenId` is **not** exempt despite its account-id-shaped prefix — its `FromStr` parses only the contract half as an `AccountId` and takes the remainder verbatim into a plain `String`, which `Display` round-trips. Verified against the pinned `defuse-core` rev `6dad94c`.

## Two details worth a reviewer's eye

**Resolution runs on the raw asset id; only the rendered form is filtered.** Filtering first would let a crafted id collapse onto a seeded one — `nep141:wrap\u{7f}.near` -> `nep141:wrap.near` — and borrow that token's symbol and decimals. Pinned by `asset_id_resolves_on_its_raw_form_not_its_sanitized_form`.

**Filtering inside `diagnostic()` rather than at each call site.** Every rule on this path quotes untrusted input — an asset id, a `serde_json::Error` that interpolates the offending value with `{}` — so the choke point is what makes a newly added rule safe by construction.

## Behavior changes

- `mt_withdraw` renders its `memo`. It carries the field and silently dropped it, while `ft_withdraw` and `nft_withdraw` both rendered theirs. Folding `memo` into `push_withdraw_call_details` alongside `msg` and `storage_deposit` closes it by construction.
- Filtering happens before the emptiness test, so an all-non-ASCII memo drops out instead of rendering as a blank `Memo` line. Applied at all three memo sites.
- Filtering strips rather than rejects: a legitimate memo with an accented character or emoji loses those characters instead of failing the whole parse. This matches the borsh path and keeps a non-ASCII memo from denying the signer their transaction.

## Testing

Tests assert exact output rather than the absence of a newline, so a filter that dropped only `\n` while passing `\t`, `\r`, control bytes or backslashes would still fail. `charset_safe` gains direct coverage in `fmt.rs` including the bidi-override and all-non-ASCII cases.

205 tests pass with default features, 189 with `--no-default-features` (the `Warning`-text build), clippy clean, full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
