### PR TITLE
feat(near): name every intent, and flag the ones that hand over authority

### DIFF
--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -98,7 +98,7 @@ cargo run --bin parser_cli -- decode \
 Output:
 
 ```
-┌─ Transaction: NEAR Intent
+┌─ Transaction: NEAR Intent: FT Withdraw
 │  Version: 0
 │  Type: NearTx
 │
@@ -107,6 +107,7 @@ Output:
    ├─ Verifying Contract: intents.near
    ├─ Deadline: 2100-01-01T00:00:00+00:00
    ├─ Nonce: 0x5d5a0a7e649c6f71be5ea1fd91efdf4a527fdf13b9f6c3610b18691bcdb5047f
+   ├─ Intent: FT Withdraw
    ├─ Token: wrap.near
    ├─ To: bob.near
    └─ Amount: 1 wNEAR

--- a/docs/chains/near.mdx
+++ b/docs/chains/near.mdx
@@ -98,7 +98,7 @@ cargo run --bin parser_cli -- decode \
 Output:
 
 ```
-┌─ Transaction: NEAR Intent
+┌─ Transaction: NEAR Intent: FT Withdraw
 │  Version: 0
 │  Type: NearTx
 │
@@ -108,6 +108,7 @@ Output:
    ├─ Verifying Contract: intents.near
    ├─ Deadline: 2100-01-01T00:00:00+00:00
    ├─ Nonce: 0x5d5a0a7e649c6f71be5ea1fd91efdf4a527fdf13b9f6c3610b18691bcdb5047f
+   ├─ Intent: FT Withdraw
    ├─ Token: wrap.near
    ├─ To: bob.near
    └─ Amount: 1 wNEAR

--- a/docs/wallet-integration/dapps/near-intents.mdx
+++ b/docs/wallet-integration/dapps/near-intents.mdx
@@ -123,6 +123,12 @@ cargo run --bin parser_cli -- decode --chain near --output json \
       "Type": "text_v2"
     },
     {
+      "FallbackText": "FT Withdraw",
+      "Label": "Intent",
+      "TextV2": { "Text": "FT Withdraw" },
+      "Type": "text_v2"
+    },
+    {
       "FallbackText": "wrap.near",
       "Label": "Token",
       "TextV2": { "Text": "wrap.near" },
@@ -142,12 +148,14 @@ cargo run --bin parser_cli -- decode --chain near --output json \
     }
   ],
   "PayloadType": "NearTx",
-  "Title": "NEAR Intent",
+  "Title": "NEAR Intent: FT Withdraw",
   "Version": "0"
 }
 ```
 
 (The example above uses a `ft_withdraw` intent for brevity; a `token_diff` swap renders one `Send`/`Receive` amount field per token in the diff, plus the same `Signer`/`Verifying Contract`/`Deadline`/`Nonce` envelope fields.)
+
+Each intent is preceded by an `Intent` field naming its type, and a single-intent envelope carries that type in its `Title`. An envelope holding more than one numbers them (`1 of 2: Transfer`), so a batch's fields cannot be read as belonging to the wrong intent. Intents that hand over account authority rather than moving a named amount -- `add_public_key`, `remove_public_key`, `set_auth_by_predecessor_id`, `auth_call` -- each carry a warning naming the consequence.
 
 Send this same input under `chain: CHAIN_NEAR` — the parser identifies it as an envelope, not a transaction, because the input is JSON rather than borsh (see [format discrimination](/chains/near#two-input-formats-one-chain-identity)). No signature exists yet at this stage, so nothing renders for it.
 

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -410,18 +410,17 @@ fn render_intent_envelope(
     let mut fields =
         vec![create_text_field("Network", network.display_name())?.signable_payload_field];
     fields.extend(tokens.diagnostics);
-    fields.extend(
-        crate::presets::intents::try_render_single_intent(
-            json.as_bytes(),
-            &tokens.registry,
-            options,
-            network,
-        )
-        .map_err(intents_error)?,
-    );
+    let rendered = crate::presets::intents::try_render_single_intent(
+        json.as_bytes(),
+        &tokens.registry,
+        options,
+        network,
+    )
+    .map_err(intents_error)?;
+    fields.extend(rendered.fields);
     Ok(ConversionResult::new(SignablePayload::new(
         PAYLOAD_VERSION,
-        "NEAR Intent".to_string(),
+        rendered.title,
         None,
         fields,
         PAYLOAD_TYPE.to_string(),

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -243,13 +243,13 @@ fn render_intent_envelope(
 ) -> Result<ConversionResult, VisualSignError> {
     let (registry, rejection_diagnostics) = token_registry_for(options, trust_policy);
     let mut fields = rejection_diagnostics;
-    fields.extend(
+    let rendered =
         crate::presets::intents::try_render_single_intent(json.as_bytes(), &registry, options)
-            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?,
-    );
+            .map_err(|e| VisualSignError::ConversionError(e.to_string()))?;
+    fields.extend(rendered.fields);
     Ok(ConversionResult::new(SignablePayload::new(
         PAYLOAD_VERSION,
-        "NEAR Intent".to_string(),
+        rendered.title,
         None,
         fields,
         PAYLOAD_TYPE.to_string(),

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -183,6 +183,15 @@ pub fn single_intent_consumes_token_registry(payload_json: &[u8]) -> bool {
     })
 }
 
+/// A rendered pre-signature envelope: the fields, plus the title naming what
+/// the envelope does.
+pub struct RenderedEnvelope {
+    /// Payload title. A lone intent names its type; a batch stays generic.
+    pub title: String,
+    /// Envelope + per-intent fields.
+    pub fields: Vec<visualsign::SignablePayloadField>,
+}
+
 /// Render the single intent a user is about to sign, from the JSON of its
 /// `DefusePayload` message (the inner message that gets signed, independent of
 /// which signature standard later wraps it).
@@ -194,11 +203,15 @@ pub fn try_render_single_intent(
     token_registry: &visualsign::registry::LayeredRegistry<NearTokenRegistry>,
     _options: &visualsign::vsptrait::VisualSignOptions,
     network: crate::networks::NearNetwork,
-) -> Result<Vec<visualsign::SignablePayloadField>, NearIntentsError> {
+) -> Result<RenderedEnvelope, NearIntentsError> {
     let payload: defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents> =
         serde_json::from_slice(payload_json)
             .map_err(|e| NearIntentsError::InputNotJson(e.to_string()))?;
-    render::render_single(&payload, token_registry, network).map_err(render_error)
+    let fields = render::render_single(&payload, token_registry, network).map_err(render_error)?;
+    Ok(RenderedEnvelope {
+        title: render::title_for_intents(&payload.intents),
+        fields,
+    })
 }
 
 /// Test-only matcher shared across this module's test submodules.
@@ -304,14 +317,19 @@ mod tests {
         let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
         let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
 
-        let fields = try_render_single_intent(
+        let rendered = try_render_single_intent(
             inner.as_bytes(),
             &reg,
             &VisualSignOptions::default(),
             crate::networks::NearNetwork::Mainnet,
         )
         .unwrap();
+        let fields = rendered.fields;
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+
+        // A lone intent names its type in both the title and the Intent field.
+        assert_eq!(rendered.title, "NEAR Intent: FT Withdraw");
+        assert!(labels.contains(&"Intent"), "missing the intent type field");
 
         for expected in [
             "Signer",
@@ -353,7 +371,8 @@ mod tests {
             &VisualSignOptions::default(),
             crate::networks::NearNetwork::Mainnet,
         )
-        .expect_err("malformed JSON should error");
+        .err()
+        .expect("malformed JSON should error");
         assert!(matches!(err, NearIntentsError::InputNotJson(_)));
     }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/mod.rs
@@ -80,6 +80,15 @@ pub fn try_decode_execute_intents(
     Ok(fields)
 }
 
+/// A rendered pre-signature envelope: the fields, plus the title naming what
+/// the envelope does.
+pub struct RenderedEnvelope {
+    /// Payload title. A lone intent names its type; a batch stays generic.
+    pub title: String,
+    /// Envelope + per-intent fields.
+    pub fields: Vec<visualsign::SignablePayloadField>,
+}
+
 /// Render the single intent a user is about to sign, from the JSON of its
 /// `DefusePayload` message (the inner message that gets signed, independent of
 /// which signature standard later wraps it).
@@ -90,12 +99,16 @@ pub fn try_render_single_intent(
     payload_json: &[u8],
     token_registry: &visualsign::registry::LayeredRegistry<NearTokenRegistry>,
     _options: &visualsign::vsptrait::VisualSignOptions,
-) -> Result<Vec<visualsign::SignablePayloadField>, NearIntentsError> {
+) -> Result<RenderedEnvelope, NearIntentsError> {
     let payload: defuse_core::payload::DefusePayload<defuse_core::intents::DefuseIntents> =
         serde_json::from_slice(payload_json)
             .map_err(|e| NearIntentsError::InputNotJson(e.to_string()))?;
-    render::render_single(&payload, token_registry)
-        .map_err(|e| NearIntentsError::Render(e.to_string()))
+    let fields = render::render_single(&payload, token_registry)
+        .map_err(|e| NearIntentsError::Render(e.to_string()))?;
+    Ok(RenderedEnvelope {
+        title: render::title_for_intents(&payload.intents),
+        fields,
+    })
 }
 
 /// Test-only matcher shared across this module's test submodules.
@@ -196,10 +209,15 @@ mod tests {
         let inner = r#"{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":[{"intent":"ft_withdraw","token":"wrap.near","receiver_id":"bob.near","amount":"1000000000000000000000000"}]}"#;
         let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
 
-        let fields =
+        let rendered =
             try_render_single_intent(inner.as_bytes(), &reg, &VisualSignOptions::default())
                 .unwrap();
+        let fields = rendered.fields;
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+
+        // A lone intent names its type in both the title and the Intent field.
+        assert_eq!(rendered.title, "NEAR Intent: FT Withdraw");
+        assert!(labels.contains(&"Intent"), "missing the intent type field");
 
         for expected in [
             "Signer",
@@ -236,7 +254,8 @@ mod tests {
     fn single_intent_rejects_malformed_json() {
         let reg = LayeredRegistry::new(Arc::new(NearTokenRegistry::default()));
         let err = try_render_single_intent(b"not json", &reg, &VisualSignOptions::default())
-            .expect_err("malformed JSON should error");
+            .err()
+            .expect("malformed JSON should error");
         assert!(matches!(err, NearIntentsError::InputNotJson(_)));
     }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -251,7 +251,7 @@ pub(crate) fn intent_label(intent: &Intent) -> &'static str {
         Intent::NativeWithdraw(_) => "Native Withdraw",
         Intent::AddPublicKey(_) => "Add Public Key",
         Intent::RemovePublicKey(_) => "Remove Public Key",
-        Intent::SetAuthByPredecessorId(_) => "Set Auth By Predecessor",
+        Intent::SetAuthByPredecessorId(_) => "Set Auth By Predecessor Id",
         Intent::StorageDeposit(_) => "Storage Deposit",
         Intent::AuthCall(_) => "Auth Call",
     }
@@ -1743,6 +1743,16 @@ mod tests {
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
             "expected an account-control warning, got {fields:?}"
         );
+    }
+
+    /// The on-screen label names the variant precisely: dropping "Id" would
+    /// make it read as though the intent were something else the account
+    /// authorizes by predecessor generally, rather than this one specific
+    /// mechanism.
+    #[test]
+    fn set_auth_by_predecessor_id_label_names_the_variant_precisely() {
+        let intent = intent_from(r#"{"intent":"set_auth_by_predecessor_id","enabled":true}"#);
+        assert_eq!(intent_label(&intent), "Set Auth By Predecessor Id");
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -202,8 +202,100 @@ pub(crate) fn section(
     Ok(fields)
 }
 
+/// Human-readable name for an intent variant, mirroring `actions::action_label`
+/// on the transaction path.
+pub(crate) fn intent_label(intent: &Intent) -> &'static str {
+    match intent {
+        Intent::TokenDiff(_) => "Token Diff",
+        Intent::Transfer(_) => "Transfer",
+        Intent::FtWithdraw(_) => "FT Withdraw",
+        Intent::NftWithdraw(_) => "NFT Withdraw",
+        Intent::MtWithdraw(_) => "MT Withdraw",
+        Intent::NativeWithdraw(_) => "Native Withdraw",
+        Intent::AddPublicKey(_) => "Add Public Key",
+        Intent::RemovePublicKey(_) => "Remove Public Key",
+        Intent::SetAuthByPredecessorId(_) => "Set Auth By Predecessor",
+        Intent::StorageDeposit(_) => "Storage Deposit",
+        Intent::AuthCall(_) => "Auth Call",
+    }
+}
+
+/// Title for a pre-signature envelope, mirroring `convert::title_for` on the
+/// transaction path: a lone intent names its type, a batch stays generic
+/// because no single name describes it.
+pub(crate) fn title_for_intents(intents: &[Intent]) -> String {
+    match intents {
+        [single] => format!("NEAR Intent: {}", intent_label(single)),
+        _ => "NEAR Intent".to_string(),
+    }
+}
+
+/// The `"Intent"` field naming what the following fields belong to.
+///
+/// Unlike `actions::action_boundary_field`, which a single-action transaction
+/// omits because the title already names it, this renders for a lone intent
+/// too: a signed batch nests intents inside per-payload sections, so a section
+/// carrying one intent has nothing else to name its type. The index is added
+/// only when there is more than one, where it is what separates them.
+///
+/// The type is otherwise absent from the render entirely -- serde consumes the
+/// `intent` tag to select the variant, so it is known and dropped. Without it
+/// `transfer` and `ft_withdraw` differ only by the presence of one `Token`
+/// field.
+fn intent_boundary_field(
+    intent: &Intent,
+    index: usize,
+    total: usize,
+) -> Result<SignablePayloadField, VisualSignError> {
+    let label = intent_label(intent);
+    let text = if total > 1 {
+        format!("{} of {total}: {label}", index + 1)
+    } else {
+        label.to_string()
+    };
+    Ok(create_text_field("Intent", &text)?.signable_payload_field)
+}
+
+/// Warns that an intent hands over authority rather than moving a named
+/// amount. These render as one unremarkable line each, and appended to a
+/// legitimate swap they read as part of it -- but an added key holds
+/// permanent authority over the account's entire intents balance, and
+/// `auth_call` invokes a contract with the signer's own authority. The
+/// transaction path gives the equivalent `AddKey` action the same treatment,
+/// breaking its permission out field by field because "their absent forms
+/// widen the grant".
+fn account_control_warning(
+    intent: &Intent,
+) -> Result<Option<SignablePayloadField>, VisualSignError> {
+    let consequence = match intent {
+        Intent::AddPublicKey(_) => {
+            "this key gains permanent authority over the account's entire intents balance, until it is explicitly removed"
+        }
+        Intent::RemovePublicKey(_) => {
+            "removing a key revokes its authority over the account; removing the only remaining key can lock the account out"
+        }
+        Intent::SetAuthByPredecessorId(_) => {
+            "this changes which callers the account authorizes, independently of its keys"
+        }
+        Intent::AuthCall(_) => {
+            "this calls the named contract with the signer's own authority, and the attached deposit is not refunded on failure"
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(diagnostic("account-control", consequence)?))
+}
+
 /// Render the fields intrinsic to a single intent.
 pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, VisualSignError> {
+    let mut fields = render_intent_body(intent, registry)?;
+    if let Some(warning) = account_control_warning(intent)? {
+        fields.push(warning);
+    }
+    Ok(fields)
+}
+
+/// The intent's own fields, without the boundary or any warning.
+fn render_intent_body(intent: &Intent, registry: &Reg) -> Result<Fields, VisualSignError> {
     match intent {
         Intent::TokenDiff(td) => render_token_diff(td, registry),
         Intent::Transfer(t) => render_transfer(t, registry),
@@ -525,10 +617,44 @@ pub(crate) fn render_single(
             "deadline has passed; the intents would be rejected",
         )?);
     }
-    for intent in &payload.intents {
+    // An empty list is valid and does nothing, but still consumes the nonce
+    // for this signer -- so it renders as an envelope with no body, and a
+    // signer has nothing on screen telling them that is all it does.
+    if payload.intents.is_empty() {
+        fields.push(diagnostic(
+            "empty-intents",
+            "this envelope carries no intents; signing it moves nothing but spends the nonce",
+        )?);
+    }
+    let total = payload.intents.len();
+    for (index, intent) in payload.intents.iter().enumerate() {
+        fields.push(intent_boundary_field(intent, index, total)?);
         fields.extend(render_intent(intent, registry)?);
+        if let Some(warning) = self_transfer_warning(payload, intent)? {
+            fields.push(warning);
+        }
     }
     Ok(fields)
+}
+
+/// Warns that a transfer to the signer's own account cannot execute:
+/// `Transfer::execute_intent` returns `InvalidIntent` on
+/// `sender_id == receiver_id`. Renders clean otherwise, the same way an
+/// expired deadline would without the check beside this one.
+fn self_transfer_warning(
+    payload: &DefusePayload<DefuseIntents>,
+    intent: &Intent,
+) -> Result<Option<SignablePayloadField>, VisualSignError> {
+    let Intent::Transfer(t) = intent else {
+        return Ok(None);
+    };
+    if t.receiver_id != payload.signer_id {
+        return Ok(None);
+    }
+    Ok(Some(diagnostic(
+        "self-transfer",
+        "the recipient is the signer's own account; the contract rejects a transfer to self",
+    )?))
 }
 
 #[cfg(test)]
@@ -545,6 +671,17 @@ mod tests {
             | SignablePayloadField::AddressV2 { common, .. } => Some(common.label.as_str()),
             _ => None,
         }
+    }
+
+    /// Field labels excluding soft findings. The non-`diagnostics` build
+    /// surfaces those as a `Warning`-labelled text field, so a test about
+    /// which value fields render must not count them.
+    fn value_labels(fields: &Fields) -> Vec<&str> {
+        fields
+            .iter()
+            .filter_map(label_of)
+            .filter(|l| *l != "Warning")
+            .collect()
     }
 
     fn empty_reg() -> Reg {
@@ -1080,9 +1217,8 @@ mod tests {
             r#"{{"intent":"auth_call","contract_id":"evil.near","msg":"{{}}","state_init":{STATE_INIT}}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert_eq!(
-            labels,
+            value_labels(&fields),
             ["Contract", "Message", "Attached Deposit", "State Init"]
         );
     }
@@ -1092,8 +1228,10 @@ mod tests {
         let intent =
             intent_from(r#"{"intent":"auth_call","contract_id":"callee.near","msg":"{}"}"#);
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
-        assert_eq!(labels, ["Contract", "Message", "Attached Deposit"]);
+        assert_eq!(
+            value_labels(&fields),
+            ["Contract", "Message", "Attached Deposit"]
+        );
     }
 
     #[test]
@@ -1305,6 +1443,179 @@ mod tests {
             .expect("extraction warning");
         let message = message_of(extraction);
         assert!(!message.contains('\n'), "{message}");
+    }
+
+    /// Builds a payload carrying `intents` verbatim.
+    fn payload_with(intents: &str) -> DefusePayload<DefuseIntents> {
+        let json = format!(
+            r#"{{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":{intents}}}"#
+        );
+        serde_json::from_str(&json).expect("payload json")
+    }
+
+    const A_TRANSFER: &str =
+        r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep141:wrap.near":"1"}}"#;
+    const AN_ADD_KEY: &str = r#"{"intent":"add_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#;
+
+    /// Every `Intent` field text, in order.
+    fn intent_lines(fields: &Fields) -> Vec<String> {
+        fields
+            .iter()
+            .filter_map(|f| match f {
+                SignablePayloadField::TextV2 { common, text_v2 } if common.label == "Intent" => {
+                    Some(text_v2.text.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Without a type line, `transfer` and `ft_withdraw` differ only by the
+    // presence of one `Token` field, so an instant irreversible internal
+    // transfer reads like a withdraw. serde consumes the `intent` tag to
+    // select the variant, so the value is known and was simply dropped.
+    #[test]
+    fn a_single_intent_names_its_type() {
+        let fields =
+            render_single(&payload_with(&format!("[{A_TRANSFER}]")), &empty_reg()).expect("render");
+        assert_eq!(intent_lines(&fields), ["Transfer"]);
+    }
+
+    #[test]
+    fn each_intent_in_a_batch_is_numbered_and_named() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER},{AN_ADD_KEY}]")),
+            &empty_reg(),
+        )
+        .expect("render");
+        assert_eq!(
+            intent_lines(&fields),
+            ["1 of 2: Transfer", "2 of 2: Add Public Key"]
+        );
+    }
+
+    /// The boundary has to precede its own intent's fields, or it labels the
+    /// wrong ones.
+    #[test]
+    fn the_type_line_precedes_the_fields_it_describes() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER},{AN_ADD_KEY}]")),
+            &empty_reg(),
+        )
+        .expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        let first = labels.iter().position(|l| *l == "Intent").expect("first");
+        let to = labels.iter().position(|l| *l == "To").expect("To");
+        assert!(first < to, "{labels:?}");
+    }
+
+    // Account-control intents hand over authority rather than moving a named
+    // amount, and render as a single unremarkable line. Appended to a
+    // legitimate swap, an added key gains permanent authority over the
+    // account's whole intents balance.
+    #[test]
+    fn add_public_key_warns_that_it_grants_account_authority() {
+        let fields = render_intent(&intent_from(AN_ADD_KEY), &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn remove_public_key_warns_that_it_changes_account_authority() {
+        let intent = intent_from(
+            r#"{"intent":"remove_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn set_auth_by_predecessor_warns_that_it_changes_account_authority() {
+        let intent = intent_from(r#"{"intent":"set_auth_by_predecessor_id","enabled":true}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn auth_call_warns_that_it_calls_a_contract_as_the_signer() {
+        let intent =
+            intent_from(r#"{"intent":"auth_call","contract_id":"callee.near","msg":"{}"}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn a_value_moving_intent_carries_no_account_control_warning() {
+        let fields = render_intent(&intent_from(A_TRANSFER), &empty_reg()).expect("render");
+        assert!(
+            !fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "unexpected account-control warning: {fields:?}"
+        );
+    }
+
+    /// `DefuseIntents` documents an empty list as valid: it does nothing, but
+    /// still invalidates the nonce for the signer. So it is a real no-op nonce
+    /// burn a user can be tricked into signing.
+    #[test]
+    fn an_empty_intent_list_warns_that_it_only_burns_the_nonce() {
+        let fields = render_single(&payload_with("[]"), &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "empty-intents")),
+            "expected an empty-intents warning, got {fields:?}"
+        );
+    }
+
+    /// `Transfer::execute_intent` returns `InvalidIntent` when
+    /// `sender_id == receiver_id`, so this can never execute -- the same class
+    /// as the expired-deadline check next to it.
+    #[test]
+    fn a_self_transfer_warns_that_the_contract_refuses_it() {
+        let intents = format!(
+            r#"[{}]"#,
+            r#"{"intent":"transfer","receiver_id":"alice.near","tokens":{"nep141:wrap.near":"1"}}"#
+        );
+        let fields = render_single(&payload_with(&intents), &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
+            "expected a self-transfer warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn a_transfer_to_another_account_carries_no_self_transfer_warning() {
+        let fields =
+            render_single(&payload_with(&format!("[{A_TRANSFER}]")), &empty_reg()).expect("render");
+        assert!(
+            !fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
+            "unexpected self-transfer warning: {fields:?}"
+        );
     }
 
     /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -239,8 +239,100 @@ pub(crate) fn section(
     Ok(fields)
 }
 
+/// Human-readable name for an intent variant, mirroring `actions::action_label`
+/// on the transaction path.
+pub(crate) fn intent_label(intent: &Intent) -> &'static str {
+    match intent {
+        Intent::TokenDiff(_) => "Token Diff",
+        Intent::Transfer(_) => "Transfer",
+        Intent::FtWithdraw(_) => "FT Withdraw",
+        Intent::NftWithdraw(_) => "NFT Withdraw",
+        Intent::MtWithdraw(_) => "MT Withdraw",
+        Intent::NativeWithdraw(_) => "Native Withdraw",
+        Intent::AddPublicKey(_) => "Add Public Key",
+        Intent::RemovePublicKey(_) => "Remove Public Key",
+        Intent::SetAuthByPredecessorId(_) => "Set Auth By Predecessor",
+        Intent::StorageDeposit(_) => "Storage Deposit",
+        Intent::AuthCall(_) => "Auth Call",
+    }
+}
+
+/// Title for a pre-signature envelope, mirroring `convert::title_for` on the
+/// transaction path: a lone intent names its type, a batch stays generic
+/// because no single name describes it.
+pub(crate) fn title_for_intents(intents: &[Intent]) -> String {
+    match intents {
+        [single] => format!("NEAR Intent: {}", intent_label(single)),
+        _ => "NEAR Intent".to_string(),
+    }
+}
+
+/// The `"Intent"` field naming what the following fields belong to.
+///
+/// Unlike `actions::action_boundary_field`, which a single-action transaction
+/// omits because the title already names it, this renders for a lone intent
+/// too: a signed batch nests intents inside per-payload sections, so a section
+/// carrying one intent has nothing else to name its type. The index is added
+/// only when there is more than one, where it is what separates them.
+///
+/// The type is otherwise absent from the render entirely -- serde consumes the
+/// `intent` tag to select the variant, so it is known and dropped. Without it
+/// `transfer` and `ft_withdraw` differ only by the presence of one `Token`
+/// field.
+fn intent_boundary_field(
+    intent: &Intent,
+    index: usize,
+    total: usize,
+) -> Result<SignablePayloadField, VisualSignError> {
+    let label = intent_label(intent);
+    let text = if total > 1 {
+        format!("{} of {total}: {label}", index + 1)
+    } else {
+        label.to_string()
+    };
+    Ok(create_text_field("Intent", &text)?.signable_payload_field)
+}
+
+/// Warns that an intent hands over authority rather than moving a named
+/// amount. These render as one unremarkable line each, and appended to a
+/// legitimate swap they read as part of it -- but an added key holds
+/// permanent authority over the account's entire intents balance, and
+/// `auth_call` invokes a contract with the signer's own authority. The
+/// transaction path gives the equivalent `AddKey` action the same treatment,
+/// breaking its permission out field by field because "their absent forms
+/// widen the grant".
+fn account_control_warning(
+    intent: &Intent,
+) -> Result<Option<SignablePayloadField>, VisualSignError> {
+    let consequence = match intent {
+        Intent::AddPublicKey(_) => {
+            "this key gains permanent authority over the account's entire intents balance, until it is explicitly removed"
+        }
+        Intent::RemovePublicKey(_) => {
+            "removing a key revokes its authority over the account; removing the only remaining key can lock the account out"
+        }
+        Intent::SetAuthByPredecessorId(_) => {
+            "this changes which callers the account authorizes, independently of its keys"
+        }
+        Intent::AuthCall(_) => {
+            "this calls the named contract with the signer's own authority, and the attached deposit is not refunded on failure"
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(diagnostic("account-control", consequence)?))
+}
+
 /// Render the fields intrinsic to a single intent.
 pub(crate) fn render_intent(intent: &Intent, registry: &Reg) -> Result<Fields, VisualSignError> {
+    let mut fields = render_intent_body(intent, registry)?;
+    if let Some(warning) = account_control_warning(intent)? {
+        fields.push(warning);
+    }
+    Ok(fields)
+}
+
+/// The intent's own fields, without the boundary or any warning.
+fn render_intent_body(intent: &Intent, registry: &Reg) -> Result<Fields, VisualSignError> {
     match intent {
         Intent::TokenDiff(td) => render_token_diff(td, registry),
         Intent::Transfer(t) => render_transfer(t, registry),
@@ -608,10 +700,44 @@ pub(crate) fn render_single(
             "deadline has passed; the intents would be rejected",
         )?);
     }
-    for intent in &payload.intents {
+    // An empty list is valid and does nothing, but still consumes the nonce
+    // for this signer -- so it renders as an envelope with no body, and a
+    // signer has nothing on screen telling them that is all it does.
+    if payload.intents.is_empty() {
+        fields.push(diagnostic(
+            "empty-intents",
+            "this envelope carries no intents; signing it moves nothing but spends the nonce",
+        )?);
+    }
+    let total = payload.intents.len();
+    for (index, intent) in payload.intents.iter().enumerate() {
+        fields.push(intent_boundary_field(intent, index, total)?);
         fields.extend(render_intent(intent, registry)?);
+        if let Some(warning) = self_transfer_warning(payload, intent)? {
+            fields.push(warning);
+        }
     }
     Ok(fields)
+}
+
+/// Warns that a transfer to the signer's own account cannot execute:
+/// `Transfer::execute_intent` returns `InvalidIntent` on
+/// `sender_id == receiver_id`. Renders clean otherwise, the same way an
+/// expired deadline would without the check beside this one.
+fn self_transfer_warning(
+    payload: &DefusePayload<DefuseIntents>,
+    intent: &Intent,
+) -> Result<Option<SignablePayloadField>, VisualSignError> {
+    let Intent::Transfer(t) = intent else {
+        return Ok(None);
+    };
+    if t.receiver_id != payload.signer_id {
+        return Ok(None);
+    }
+    Ok(Some(diagnostic(
+        "self-transfer",
+        "the recipient is the signer's own account; the contract rejects a transfer to self",
+    )?))
 }
 
 #[cfg(test)]
@@ -628,6 +754,17 @@ mod tests {
             | SignablePayloadField::AddressV2 { common, .. } => Some(common.label.as_str()),
             _ => None,
         }
+    }
+
+    /// Field labels excluding soft findings. The non-`diagnostics` build
+    /// surfaces those as a `Warning`-labelled text field, so a test about
+    /// which value fields render must not count them.
+    fn value_labels(fields: &Fields) -> Vec<&str> {
+        fields
+            .iter()
+            .filter_map(label_of)
+            .filter(|l| *l != "Warning")
+            .collect()
     }
 
     fn empty_reg() -> Reg {
@@ -1281,9 +1418,8 @@ mod tests {
             r#"{{"intent":"auth_call","contract_id":"evil.near","msg":"{{}}","state_init":{STATE_INIT}}}"#
         ));
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert_eq!(
-            labels,
+            value_labels(&fields),
             ["Contract", "Message", "Attached Deposit", "State Init"]
         );
     }
@@ -1293,8 +1429,10 @@ mod tests {
         let intent =
             intent_from(r#"{"intent":"auth_call","contract_id":"callee.near","msg":"{}"}"#);
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
-        assert_eq!(labels, ["Contract", "Message", "Attached Deposit"]);
+        assert_eq!(
+            value_labels(&fields),
+            ["Contract", "Message", "Attached Deposit"]
+        );
     }
 
     #[test]
@@ -1506,6 +1644,191 @@ mod tests {
             .expect("extraction warning");
         let message = message_of(extraction);
         assert!(!message.contains('\n'), "{message}");
+    }
+
+    /// Builds a payload carrying `intents` verbatim.
+    fn payload_with(intents: &str) -> DefusePayload<DefuseIntents> {
+        let json = format!(
+            r#"{{"signer_id":"alice.near","verifying_contract":"intents.near","deadline":"2999-01-01T00:00:00Z","nonce":"XVoKfmScb3G+XqH9ke/fSlJ/3xO59sNhCxhpG821BH8=","intents":{intents}}}"#
+        );
+        serde_json::from_str(&json).expect("payload json")
+    }
+
+    const A_TRANSFER: &str =
+        r#"{"intent":"transfer","receiver_id":"bob.near","tokens":{"nep141:wrap.near":"1"}}"#;
+    const AN_ADD_KEY: &str = r#"{"intent":"add_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#;
+
+    /// Every `Intent` field text, in order.
+    fn intent_lines(fields: &Fields) -> Vec<String> {
+        fields
+            .iter()
+            .filter_map(|f| match f {
+                SignablePayloadField::TextV2 { common, text_v2 } if common.label == "Intent" => {
+                    Some(text_v2.text.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Without a type line, `transfer` and `ft_withdraw` differ only by the
+    // presence of one `Token` field, so an instant irreversible internal
+    // transfer reads like a withdraw. serde consumes the `intent` tag to
+    // select the variant, so the value is known and was simply dropped.
+    #[test]
+    fn a_single_intent_names_its_type() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER}]")),
+            &empty_reg(),
+            NearNetwork::Mainnet,
+        )
+        .expect("render");
+        assert_eq!(intent_lines(&fields), ["Transfer"]);
+    }
+
+    #[test]
+    fn each_intent_in_a_batch_is_numbered_and_named() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER},{AN_ADD_KEY}]")),
+            &empty_reg(),
+            NearNetwork::Mainnet,
+        )
+        .expect("render");
+        assert_eq!(
+            intent_lines(&fields),
+            ["1 of 2: Transfer", "2 of 2: Add Public Key"]
+        );
+    }
+
+    /// The boundary has to precede its own intent's fields, or it labels the
+    /// wrong ones.
+    #[test]
+    fn the_type_line_precedes_the_fields_it_describes() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER},{AN_ADD_KEY}]")),
+            &empty_reg(),
+            NearNetwork::Mainnet,
+        )
+        .expect("render");
+        let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
+        let first = labels.iter().position(|l| *l == "Intent").expect("first");
+        let to = labels.iter().position(|l| *l == "To").expect("To");
+        assert!(first < to, "{labels:?}");
+    }
+
+    // Account-control intents hand over authority rather than moving a named
+    // amount, and render as a single unremarkable line. Appended to a
+    // legitimate swap, an added key gains permanent authority over the
+    // account's whole intents balance.
+    #[test]
+    fn add_public_key_warns_that_it_grants_account_authority() {
+        let fields = render_intent(&intent_from(AN_ADD_KEY), &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn remove_public_key_warns_that_it_changes_account_authority() {
+        let intent = intent_from(
+            r#"{"intent":"remove_public_key","public_key":"ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn set_auth_by_predecessor_warns_that_it_changes_account_authority() {
+        let intent = intent_from(r#"{"intent":"set_auth_by_predecessor_id","enabled":true}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn auth_call_warns_that_it_calls_a_contract_as_the_signer() {
+        let intent =
+            intent_from(r#"{"intent":"auth_call","contract_id":"callee.near","msg":"{}"}"#);
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "expected an account-control warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn a_value_moving_intent_carries_no_account_control_warning() {
+        let fields = render_intent(&intent_from(A_TRANSFER), &empty_reg()).expect("render");
+        assert!(
+            !fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
+            "unexpected account-control warning: {fields:?}"
+        );
+    }
+
+    /// `DefuseIntents` documents an empty list as valid: it does nothing, but
+    /// still invalidates the nonce for the signer. So it is a real no-op nonce
+    /// burn a user can be tricked into signing.
+    #[test]
+    fn an_empty_intent_list_warns_that_it_only_burns_the_nonce() {
+        let fields =
+            render_single(&payload_with("[]"), &empty_reg(), NearNetwork::Mainnet).expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "empty-intents")),
+            "expected an empty-intents warning, got {fields:?}"
+        );
+    }
+
+    /// `Transfer::execute_intent` returns `InvalidIntent` when
+    /// `sender_id == receiver_id`, so this can never execute -- the same class
+    /// as the expired-deadline check next to it.
+    #[test]
+    fn a_self_transfer_warns_that_the_contract_refuses_it() {
+        let intents = format!(
+            r#"[{}]"#,
+            r#"{"intent":"transfer","receiver_id":"alice.near","tokens":{"nep141:wrap.near":"1"}}"#
+        );
+        let fields = render_single(&payload_with(&intents), &empty_reg(), NearNetwork::Mainnet)
+            .expect("render");
+        assert!(
+            fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
+            "expected a self-transfer warning, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn a_transfer_to_another_account_carries_no_self_transfer_warning() {
+        let fields = render_single(
+            &payload_with(&format!("[{A_TRANSFER}]")),
+            &empty_reg(),
+            NearNetwork::Mainnet,
+        )
+        .expect("render");
+        assert!(
+            !fields
+                .iter()
+                .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
+            "unexpected self-transfer warning: {fields:?}"
+        );
     }
 
     /// `ft_withdraw` and `nft_withdraw` both render their memo; `mt_withdraw`

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -1016,10 +1016,7 @@ mod tests {
         let has_extraction_warning = fields
             .iter()
             .any(|f| super::super::test_support::is_warning_diagnostic(f, "extraction"));
-        assert!(
-            has_extraction_warning,
-            "expected an extraction warning, got {fields:?}"
-        );
+        assert!(has_extraction_warning, "expected an extraction warning");
         let labels: Vec<&str> = fields.iter().filter_map(label_of).collect();
         assert!(
             !labels.contains(&"Signer"),
@@ -1188,7 +1185,7 @@ mod tests {
                     "ed25519:8rVvtHWFr8hasdQGGD5WiQBTyr4iH2ruEPPVfj491RPN"
                 );
             }
-            other => panic!("expected TextV2, got {other:?}"),
+            _ => panic!("expected TextV2 field"),
         }
     }
 
@@ -1201,7 +1198,7 @@ mod tests {
                 assert_eq!(common.label, "Auth By Predecessor");
                 assert_eq!(text_v2.text, "enabled");
             }
-            other => panic!("expected TextV2, got {other:?}"),
+            _ => panic!("expected TextV2 field"),
         }
     }
 
@@ -1456,7 +1453,7 @@ mod tests {
                 }
                 _ => None,
             })
-            .unwrap_or_else(|| panic!("no TextV2 field labelled {label}: {fields:?}"))
+            .unwrap_or_else(|| panic!("no TextV2 field labelled {label}"))
     }
 
     /// An intent-carried string an attacker controls, shaped to read as two
@@ -1727,7 +1724,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
-            "expected an account-control warning, got {fields:?}"
+            "expected an account-control warning"
         );
     }
 
@@ -1741,7 +1738,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
-            "expected an account-control warning, got {fields:?}"
+            "expected an account-control warning"
         );
     }
 
@@ -1763,7 +1760,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
-            "expected an account-control warning, got {fields:?}"
+            "expected an account-control warning"
         );
     }
 
@@ -1776,7 +1773,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
-            "expected an account-control warning, got {fields:?}"
+            "expected an account-control warning"
         );
     }
 
@@ -1787,7 +1784,7 @@ mod tests {
             !fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "account-control")),
-            "unexpected account-control warning: {fields:?}"
+            "unexpected account-control warning"
         );
     }
 
@@ -1802,7 +1799,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "empty-intents")),
-            "expected an empty-intents warning, got {fields:?}"
+            "expected an empty-intents warning"
         );
     }
 
@@ -1821,7 +1818,7 @@ mod tests {
             fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
-            "expected a self-transfer warning, got {fields:?}"
+            "expected a self-transfer warning"
         );
     }
 
@@ -1837,7 +1834,7 @@ mod tests {
             !fields
                 .iter()
                 .any(|f| super::super::test_support::is_warning_diagnostic(f, "self-transfer")),
-            "unexpected self-transfer warning: {fields:?}"
+            "unexpected self-transfer warning"
         );
     }
 

--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -954,6 +954,12 @@ async fn parser_near_intent_envelope_e2e() {
                     "Type": "text_v2"
                 },
                 {
+                    "FallbackText": "FT Withdraw",
+                    "Label": "Intent",
+                    "TextV2": { "Text": "FT Withdraw" },
+                    "Type": "text_v2"
+                },
+                {
                     "FallbackText": "wrap.near",
                     "Label": "Token",
                     "TextV2": { "Text": "wrap.near" },
@@ -973,7 +979,7 @@ async fn parser_near_intent_envelope_e2e() {
                 }
             ],
             "PayloadType": "NearTx",
-            "Title": "NEAR Intent",
+            "Title": "NEAR Intent: FT Withdraw",
             "Version": "0"
         });
 

--- a/src/integration/tests/parser.rs
+++ b/src/integration/tests/parser.rs
@@ -974,6 +974,12 @@ async fn parser_near_intent_envelope_e2e() {
                     "Type": "text_v2"
                 },
                 {
+                    "FallbackText": "FT Withdraw",
+                    "Label": "Intent",
+                    "TextV2": { "Text": "FT Withdraw" },
+                    "Type": "text_v2"
+                },
+                {
                     "FallbackText": "wrap.near",
                     "Label": "Token",
                     "TextV2": { "Text": "wrap.near" },
@@ -993,7 +999,7 @@ async fn parser_near_intent_envelope_e2e() {
                 }
             ],
             "PayloadType": "NearTx",
-            "Title": "NEAR Intent",
+            "Title": "NEAR Intent: FT Withdraw",
             "Version": "0"
         });
 

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -711,5 +711,5 @@ fn test_cli_near_token_metadata_invalid_file_still_parses() {
     );
     let json: serde_json::Value =
         serde_json::from_str(&stdout).expect("CLI output should be valid JSON");
-    assert_eq!(json["Title"], "NEAR Intent");
+    assert_eq!(json["Title"], "NEAR Intent: FT Withdraw");
 }

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -733,5 +733,5 @@ fn test_cli_near_token_metadata_invalid_file_still_parses() {
     );
     let json: serde_json::Value =
         serde_json::from_str(&stdout).expect("CLI output should be valid JSON");
-    assert_eq!(json["Title"], "NEAR Intent");
+    assert_eq!(json["Title"], "NEAR Intent: FT Withdraw");
 }

--- a/src/parser/cli/tests/fixtures/near-json.display.expected
+++ b/src/parser/cli/tests/fixtures/near-json.display.expected
@@ -33,6 +33,14 @@
       "Type": "text_v2"
     },
     {
+      "FallbackText": "FT Withdraw",
+      "Label": "Intent",
+      "TextV2": {
+        "Text": "FT Withdraw"
+      },
+      "Type": "text_v2"
+    },
+    {
       "FallbackText": "wrap.near",
       "Label": "Token",
       "TextV2": {
@@ -59,6 +67,6 @@
     }
   ],
   "PayloadType": "NearTx",
-  "Title": "NEAR Intent",
+  "Title": "NEAR Intent: FT Withdraw",
   "Version": "0"
 }

--- a/src/parser/cli/tests/fixtures/near-json.display.expected
+++ b/src/parser/cli/tests/fixtures/near-json.display.expected
@@ -41,6 +41,14 @@
       "Type": "text_v2"
     },
     {
+      "FallbackText": "FT Withdraw",
+      "Label": "Intent",
+      "TextV2": {
+        "Text": "FT Withdraw"
+      },
+      "Type": "text_v2"
+    },
+    {
       "FallbackText": "wrap.near",
       "Label": "Token",
       "TextV2": {
@@ -67,6 +75,6 @@
     }
   ],
   "PayloadType": "NearTx",
-  "Title": "NEAR Intent",
+  "Title": "NEAR Intent: FT Withdraw",
   "Version": "0"
 }


### PR DESCRIPTION
Stacked on #459.

## The intent type reaches the screen

serde consumes the `intent` tag to select the variant, so the type is known and was dropped. Without it, `transfer` and `ft_withdraw` differ only by the presence of one `Token` field under an identical title — an instant, irreversible internal transfer reads like a withdraw. A batch had no boundary either, so a second intent's fields ran on from the first's.

```
   ├─ Intent: 1 of 2: Transfer
   ├─ To: bob.near
   ├─ Amount: 1 wNEAR
   ├─ Intent: 2 of 2: Add Public Key
   ├─ Add Public Key: ed25519:8rVv...
   └─ [warn] account-control: this key gains permanent authority over the
      account's entire intents balance, until it is explicitly removed
```

A single-intent envelope titles after its type: `NEAR Intent: FT Withdraw`.

This mirrors `action_boundary_field` and `title_for` on the transaction path, with **one deliberate difference**: the `Intent` field renders for a lone intent too, where `action_boundary_field` omits itself because the title covers it. A signed batch nests intents inside per-payload sections, so a section holding one intent has nothing else naming its type — its title comes from the enclosing borsh transaction.

## Intents that hand over authority

`add_public_key`, `remove_public_key`, `set_auth_by_predecessor_id` and `auth_call` each rendered as one unremarkable line while granting authority rather than moving a named amount. Appended to a legitimate swap they read as part of it. Each now carries a warning naming the consequence — the treatment `actions.rs` already gives the `AddKey` action, which it breaks out field by field because "their absent forms widen the grant".

## Two intents that cannot execute

Both rendered clean, the same way an expired deadline would without the check beside them:

- An empty `intents` list does nothing but still spends the signer's nonce — a real no-op nonce burn a user can be tricked into signing.
- A transfer to the signer's own account is refused by `Transfer::execute_intent` with `InvalidIntent`.

## API

`try_render_single_intent` returns a `RenderedEnvelope` carrying the title alongside the fields, rather than making the caller re-parse the envelope to derive it.

## Payload shape

This changes the emitted payload, so wallet renderers and any downstream snapshots need to expect:

- one extra `TextV2` labelled `Intent` per intent
- a different `Title` for single-intent envelopes

Updated here: the e2e expected payload, the CLI display fixture, a CLI title assertion, and the two docs pages showing rendered output.

## Scope

Purely additive to the field list. P9 — the `Network` field and network cross-check on the intents path — is deliberately **not** here, since it needs wallet-side coordination on a different axis; it follows as its own PR.

## Testing

203 tests pass with default features, 187 with `--no-default-features`, clippy clean, full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)