### PR TITLE
fix(cli): render every field variant instead of "Field: Unknown"

### DIFF
--- a/src/parser/cli-core/src/output.rs
+++ b/src/parser/cli-core/src/output.rs
@@ -138,8 +138,17 @@ impl<'a> HumanReadableFormatter<'a> {
                     prefix, common.label, address_v2.address
                 )?;
             }
+            // Every remaining variant renders from the accessors, which are
+            // exhaustive over the enum. A variant added later prints its
+            // label and value rather than silently reading as "Unknown".
             _ => {
-                writeln!(writer, "{} Field: {}", prefix, common_label(field))?;
+                writeln!(
+                    writer,
+                    "{} {}: {}",
+                    prefix,
+                    field.label(),
+                    field.fallback_text()
+                )?;
             }
         }
         Ok(())
@@ -170,17 +179,6 @@ impl std::fmt::Display for HumanReadableFormatter<'_> {
         }
 
         Ok(())
-    }
-}
-
-/// Extracts the common label from any field type.
-fn common_label(field: &SignablePayloadField) -> String {
-    match field {
-        SignablePayloadField::TextV2 { common, .. }
-        | SignablePayloadField::PreviewLayout { common, .. }
-        | SignablePayloadField::AmountV2 { common, .. }
-        | SignablePayloadField::AddressV2 { common, .. } => common.label.clone(),
-        _ => "Unknown".to_string(),
     }
 }
 
@@ -235,4 +233,70 @@ pub fn parse_and_display(
         eprintln!("{}", hex::encode(bytes));
     }
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use visualsign::field_builders::{
+        create_amount_field, create_number_field, create_preview_layout, create_text_field,
+    };
+
+    fn payload_of(fields: Vec<SignablePayloadField>) -> SignablePayload {
+        SignablePayload::new(0, "Test".to_string(), None, fields, "TestTx".to_string())
+    }
+
+    fn render(fields: Vec<SignablePayloadField>) -> String {
+        HumanReadableFormatter::new(&payload_of(fields), false).to_string()
+    }
+
+    // `Number` is emitted for the amount of every NEAR fungible-token
+    // transfer. Falling through to the catch-all arm hid the amount behind
+    // "Field: Unknown" while the recipient, memo and gas all rendered.
+    #[test]
+    fn a_number_field_renders_its_label_and_value() {
+        let field = create_number_field("Amount", "1000000", "raw token units")
+            .unwrap()
+            .signable_payload_field;
+        let out = render(vec![field]);
+        assert!(out.contains("Amount: 1000000 raw token units"), "{out}");
+        assert!(!out.contains("Unknown"), "{out}");
+    }
+
+    /// Every variant must render its label and value. The catch-all arm reads
+    /// from `label()`/`fallback_text()`, which are exhaustive over the enum,
+    /// so a variant added later cannot silently print as "Unknown".
+    #[test]
+    fn no_field_variant_renders_as_unknown() {
+        let fields = vec![
+            create_text_field("Note", "hello")
+                .unwrap()
+                .signable_payload_field,
+            create_amount_field("Total", "1.5", "ETH")
+                .unwrap()
+                .signable_payload_field,
+            create_number_field("Count", "7", "items")
+                .unwrap()
+                .signable_payload_field,
+        ];
+        let out = render(fields);
+        assert!(!out.contains("Unknown"), "{out}");
+        for expected in ["Note: hello", "Total: 1.5 ETH", "Count: 7 items"] {
+            assert!(out.contains(expected), "missing {expected} in:\n{out}");
+        }
+    }
+
+    // The Solana presets that emit `Number` -- jupiter_swap's slippage and
+    // platform fee, compute_budget's limits, system's account space -- put it
+    // inside a `PreviewLayout`'s expanded list, so the nested render path is
+    // the one that actually hid them.
+    #[test]
+    fn a_number_nested_in_a_preview_layout_renders_its_label_and_value() {
+        let nested = create_number_field("Slippage", "50", "bps").unwrap();
+        let layout = create_preview_layout("Swap", "via Jupiter".to_string(), vec![nested]);
+        let out = render(vec![layout.signable_payload_field]);
+        assert!(out.contains("Slippage: 50 bps"), "{out}");
+        assert!(!out.contains("Unknown"), "{out}");
+    }
 }


### PR DESCRIPTION
`format_field` handles `TextV2`, `PreviewLayout`, `AmountV2` and `AddressV2`. Every other `SignablePayloadField` variant — seven of the eleven in a default build, eight of twelve with the `diagnostics` feature — fell through to a catch-all printing `Field: Unknown`, and `common_label` mirrored the gap by returning `"Unknown"`, losing the label too.

## What this hides today

`Number` is the variant that matters in practice, and it is not rare. `visualsign-solana` emits it for:

- `jupiter_swap` — slippage and platform fee
- `compute_budget` — all four limits
- `system` — account space

All already on main. Those sit inside a `PreviewLayout`'s expanded list, and the nested render path goes through the same catch-all, so it hid them too. Someone triaging a swap saw every routing detail except the slippage they were agreeing to.

## The fix

The catch-all reads `label()` and `fallback_text()`, which are exhaustive over the enum. This closes the class rather than the one variant, including any variant added later. `common_label` had exactly one caller and is removed.

Display only — the wire payload was always correct. `Number`'s custom `Serialize` maps it to `amount_v2`, recovering the unit from `fallback_text`, so backends and wallets were unaffected. It still matters because the CLI is the tool reached for to triage a production payload.

## Testing

`output.rs` had no test module at all, which is why this went unnoticed — the Jupiter tests assert on decoded values, never on rendered output. This adds one covering `Number` at the top level, `Number` nested inside a `PreviewLayout` (the path the Solana fields actually take), and an assertion that no variant renders as `Unknown`. All three were verified to fail without the fix.

## Coordination

#439 modifies the same match block, adding a `Diagnostic` arm above the catch-all plus its own `mod tests` at the end of this file. When that stack rebases onto a main containing this PR, expect:

- a conflict in the `_` arm — keep this PR's accessor version, keep #439's `Diagnostic` arm above it
- #439's test module is renamed to `diagnostic_tests` so the two modules coexist; without that rename, keeping both hunks is `E0428`
- #439's arm comment ("a diagnostic printed as `Field: Unknown` tells the reader nothing") needs rewording, since diagnostics no longer print that way

🤖 Generated with [Claude Code](https://claude.com/claude-code)