### PR TITLE
fix(near): seed the omni-bridge assets, with origin-qualified symbols

### DIFF
--- a/scripts/gen_near_token_seeds.sh
+++ b/scripts/gen_near_token_seeds.sh
@@ -43,14 +43,39 @@ RPC_DELAY_SECONDS="${RPC_DELAY_SECONDS:-1}"
 # contract's `FromStr`/`Deserialize` impls accept), plus a separate list of
 # chains whose *native* asset (ETH, etc.) should be resolved via
 # `get_native_token_id` instead of `get_token_id`.
+#
+# This output is a starting point, not the authority. Two things must be
+# checked by hand before anything reaches the `SEEDS` table:
+#
+#   1. `get_native_token_id` does not always answer with the id real intents
+#      carry. It answers `Eth` with the legacy rainbow-bridge
+#      `eth.bridge.near`, and `Base`/`Arb`/`Pol` with `.omdep.near` deposit
+#      contracts, while observed traffic uses `<chain>.omft.near`. Cross-check
+#      every id against `ft_metadata` and against a real envelope.
+#
+#   2. The reported `symbol` is not unique across chains. Four assets report
+#      `ETH` and four report `USDC`. `SEEDS` requires origin-qualified symbols
+#      (`ETH.base`, `USDC.sol`) so two assets never render alike; see the
+#      table's own docs.
 
 FOREIGN_TOKENS=(
-    "eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"  # USDC on Ethereum
-    "eth:0xdac17f958d2ee523a2206206994597c13d831ec7"  # USDT on Ethereum
+    "eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"   # USDC on Ethereum
+    "eth:0xdac17f958d2ee523a2206206994597c13d831ec7"   # USDT on Ethereum
+    "sol:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" # USDC on Solana
+    "sol:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" # USDT on Solana
 )
+
+# Base and Arbitrum stablecoins are deliberately absent: `get_token_id`
+# returns nothing for them, so this script cannot source their ids, and the
+# `SEEDS` table leaves them out rather than seeding an unsourced id.
 
 NATIVE_CHAINS=(
     "Eth"
+    "Sol"
+    "Base"
+    "Arb"
+    "Pol"
+    "Btc"
 )
 
 # ── RPC helpers ─────────────────────────────────────────────────────────────

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -10,12 +10,56 @@ use super::{NearTokenRegistry, TokenMeta};
 /// before being added; a wrong `decimals` silently misrenders amounts, so
 /// anything not confidently verified is omitted and falls back to the raw
 /// asset id. `wrap.near` is the canonical wrapped-NEAR contract (24 decimals,
-/// matching native NEAR). The bridged entries below resolve through
-/// `omni.bridge.near`'s own `get_token_id`/`get_native_token_id` registry via
-/// `scripts/gen_near_token_seeds.sh`, not a hand-typed guess at the
-/// `<chain>-<address>.omft.near` naming convention.
+/// matching native NEAR).
+///
+/// # Symbols are origin-qualified, and unique
+///
+/// The on-chain `ft_metadata` symbol is not usable verbatim. Four distinct
+/// assets report `{"symbol":"ETH","decimals":18}` -- Ethereum's ether via the
+/// omni bridge and via the legacy rainbow bridge, plus ether bridged from Base
+/// and from Arbitrum -- and four report `{"symbol":"USDC","decimals":6}`.
+/// `SignablePayloadFieldAmountV2` carries only an amount and an abbreviation,
+/// so seeding the raw symbol would render Base ether identically to mainnet
+/// ether, and a swap of one for the other identically to its mirror.
+///
+/// So the bare symbol belongs to the asset native to its own chain, and
+/// anything bridged from elsewhere carries an origin suffix (`ETH.base`,
+/// `USDC.sol`). `.e` marks the legacy rainbow-bridge entries, the convention
+/// the first stablecoin seeds already used. `every_seeded_symbol_is_unique`
+/// enforces this: a new entry that collides fails the test rather than
+/// silently making two assets look alike.
+///
+/// # Sourcing
+///
+/// `scripts/gen_near_token_seeds.sh` resolves ids through `omni.bridge.near`'s
+/// own registry, rather than hand-typing the `<chain>-<address>.omft.near`
+/// convention. Its output is a starting point, not the authority. Both of its
+/// lookups answer with ids that real intents do not carry:
+/// `get_native_token_id` gives `Eth` the legacy `eth.bridge.near` and
+/// `Base`/`Arb`/`Pol` their `.omdep.near` deposit contracts, and
+/// `get_token_id` gives Ethereum USDC/USDT their legacy `factory.bridge.near`
+/// ids while returning nothing at all for Base or Arbitrum.
+///
+/// So every entry's `symbol`/`decimals` is confirmed against the token
+/// contract's own `ft_metadata`, and its id rests on one of these:
+///
+/// - **observed traffic** -- `eth.omft.near` and `sol.omft.near` appear in
+///   captured production envelopes, which is also what establishes
+///   `<chain>.omft.near` as the intents-facing form for the entries beside
+///   them;
+/// - **the bridge registry** -- `get_token_id` maps the canonical Solana USDC
+///   and USDT mints onto the two `sol-*` ids, and `get_native_token_id` names
+///   `nbtc.bridge.near` for `Btc`;
+/// - **a self-describing id** -- the two `eth-0x…` ids embed the source-chain
+///   contract address, so it can be checked against Ethereum directly.
+///
+/// Assets whose id has none of these -- notably the per-token Base and
+/// Arbitrum stablecoins, which the bridge does not index at all -- are left
+/// out. They render as raw base units against their asset id, which is honest
+/// about what the parser knows.
 const SEEDS: &[(&str, &str, u8)] = &[
     ("nep141:wrap.near", "wNEAR", 24),
+    // Legacy rainbow bridge.
     (
         "nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near",
         "USDC.e",
@@ -26,7 +70,37 @@ const SEEDS: &[(&str, &str, u8)] = &[
         "USDT.e",
         6,
     ),
-    ("nep141:eth.bridge.near", "ETH", 18),
+    ("nep141:eth.bridge.near", "ETH.e", 18),
+    // Omni bridge, chain-native assets. `eth`/`sol` are the two ids carried by
+    // observed intent traffic.
+    ("nep141:eth.omft.near", "ETH", 18),
+    ("nep141:sol.omft.near", "SOL", 9),
+    ("nep141:btc.omft.near", "BTC", 8),
+    ("nep141:nbtc.bridge.near", "NBTC", 8),
+    ("nep141:pol.omft.near", "POL", 18),
+    ("nep141:base.omft.near", "ETH.base", 18),
+    ("nep141:arb.omft.near", "ETH.arb", 18),
+    // Omni bridge, per-token assets.
+    (
+        "nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+        "USDC",
+        6,
+    ),
+    (
+        "nep141:sol-5ce3bf3a31af18be40ba30f721101b4341690186.omft.near",
+        "USDC.sol",
+        6,
+    ),
+    (
+        "nep141:sol-c800a4bd850783ccb82c2b2c7e84175443606352.omft.near",
+        "USDT.sol",
+        6,
+    ),
+    (
+        "nep141:eth-0xdac17f958d2ee523a2206206994597c13d831ec7.omft.near",
+        "USDT",
+        6,
+    ),
 ];
 
 /// Largest `decimals` [`format_units`] can scale by: `10^39` exceeds `u128`.
@@ -155,6 +229,59 @@ mod tests {
         assert_eq!(meta.decimals, MAX_DECIMALS);
         // The bound is exactly what `format_units` can scale by.
         assert_eq!(format_units(0, MAX_DECIMALS), "0");
+    }
+
+    /// The two assets carried by real intent traffic. Both were rendering as
+    /// raw base units against an unresolved asset id, so nothing on screen
+    /// distinguished 1 ETH from 1 gwei.
+    #[test]
+    fn the_omni_bridge_native_assets_resolve() {
+        let eth = resolve("nep141:eth.omft.near", &empty()).expect("seeded");
+        assert_eq!((eth.symbol.as_str(), eth.decimals), ("ETH", 18));
+        let sol = resolve("nep141:sol.omft.near", &empty()).expect("seeded");
+        assert_eq!((sol.symbol.as_str(), sol.decimals), ("SOL", 9));
+    }
+
+    /// `omni.bridge.near::get_native_token_id("Eth")` returns the legacy
+    /// rainbow-bridge id, which is how the wrong entry reached the table. Both
+    /// ids are real and both are ETH, so they have to stay distinguishable.
+    #[test]
+    fn the_legacy_and_omni_ether_ids_do_not_render_alike() {
+        let legacy = resolve("nep141:eth.bridge.near", &empty()).expect("seeded");
+        let omni = resolve("nep141:eth.omft.near", &empty()).expect("seeded");
+        assert_ne!(legacy.symbol, omni.symbol);
+    }
+
+    /// Four distinct assets report `{"symbol":"ETH","decimals":18}` on-chain
+    /// and four report `{"symbol":"USDC","decimals":6}`. `AmountV2` carries
+    /// only an amount and an abbreviation, so an unqualified symbol would let
+    /// Base ETH render identically to mainnet ETH -- and a swap of one for the
+    /// other render identically to its mirror.
+    #[test]
+    fn every_seeded_symbol_is_unique() {
+        let mut seen = std::collections::BTreeMap::new();
+        for (asset_id, symbol, _) in SEEDS {
+            if let Some(previous) = seen.insert(*symbol, *asset_id) {
+                panic!("symbol {symbol} is shared by {previous} and {asset_id}");
+            }
+        }
+    }
+
+    /// The same token bridged from a different chain carries an origin
+    /// qualifier; the asset native to its own chain carries the bare symbol.
+    #[test]
+    fn same_token_from_different_chains_is_origin_qualified() {
+        for (asset_id, expected) in [
+            ("nep141:base.omft.near", "ETH.base"),
+            ("nep141:arb.omft.near", "ETH.arb"),
+            (
+                "nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+                "USDC",
+            ),
+        ] {
+            let meta = resolve(asset_id, &empty()).expect(asset_id);
+            assert_eq!(meta.symbol, expected, "for {asset_id}");
+        }
     }
 
     #[test]

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -50,7 +50,7 @@ use super::{NearTokenRegistry, TokenMeta};
 /// - **the bridge registry** -- `get_token_id` maps the canonical Solana USDC
 ///   and USDT mints onto the two `sol-*` ids, and `get_native_token_id` names
 ///   `nbtc.bridge.near` for `Btc`;
-/// - **a self-describing id** -- the two `eth-0x…` ids embed the source-chain
+/// - **a self-describing id** -- the two `eth-0x...` ids embed the source-chain
 ///   contract address, so it can be checked against Ethereum directly.
 ///
 /// Assets whose id has none of these -- notably the per-token Base and

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -10,12 +10,56 @@ use super::{NearTokenRegistry, TokenMeta};
 /// before being added; a wrong `decimals` silently misrenders amounts, so
 /// anything not confidently verified is omitted and falls back to the raw
 /// asset id. `wrap.near` is the canonical wrapped-NEAR contract (24 decimals,
-/// matching native NEAR). The bridged entries below resolve through
-/// `omni.bridge.near`'s own `get_token_id`/`get_native_token_id` registry via
-/// `scripts/gen_near_token_seeds.sh`, not a hand-typed guess at the
-/// `<chain>-<address>.omft.near` naming convention.
+/// matching native NEAR).
+///
+/// # Symbols are origin-qualified, and unique
+///
+/// The on-chain `ft_metadata` symbol is not usable verbatim. Four distinct
+/// assets report `{"symbol":"ETH","decimals":18}` -- Ethereum's ether via the
+/// omni bridge and via the legacy rainbow bridge, plus ether bridged from Base
+/// and from Arbitrum -- and four report `{"symbol":"USDC","decimals":6}`.
+/// `SignablePayloadFieldAmountV2` carries only an amount and an abbreviation,
+/// so seeding the raw symbol would render Base ether identically to mainnet
+/// ether, and a swap of one for the other identically to its mirror.
+///
+/// So the bare symbol belongs to the asset native to its own chain, and
+/// anything bridged from elsewhere carries an origin suffix (`ETH.base`,
+/// `USDC.sol`). `.e` marks the legacy rainbow-bridge entries, the convention
+/// the first stablecoin seeds already used. `every_seeded_symbol_is_unique`
+/// enforces this: a new entry that collides fails the test rather than
+/// silently making two assets look alike.
+///
+/// # Sourcing
+///
+/// `scripts/gen_near_token_seeds.sh` resolves ids through `omni.bridge.near`'s
+/// own registry, rather than hand-typing the `<chain>-<address>.omft.near`
+/// convention. Its output is a starting point, not the authority. Both of its
+/// lookups answer with ids that real intents do not carry:
+/// `get_native_token_id` gives `Eth` the legacy `eth.bridge.near` and
+/// `Base`/`Arb`/`Pol` their `.omdep.near` deposit contracts, and
+/// `get_token_id` gives Ethereum USDC/USDT their legacy `factory.bridge.near`
+/// ids while returning nothing at all for Base or Arbitrum.
+///
+/// So every entry's `symbol`/`decimals` is confirmed against the token
+/// contract's own `ft_metadata`, and its id rests on one of these:
+///
+/// - **observed traffic** -- `eth.omft.near` and `sol.omft.near` appear in
+///   captured production envelopes, which is also what establishes
+///   `<chain>.omft.near` as the intents-facing form for the entries beside
+///   them;
+/// - **the bridge registry** -- `get_token_id` maps the canonical Solana USDC
+///   and USDT mints onto the two `sol-*` ids, and `get_native_token_id` names
+///   `nbtc.bridge.near` for `Btc`;
+/// - **a self-describing id** -- the two `eth-0x…` ids embed the source-chain
+///   contract address, so it can be checked against Ethereum directly.
+///
+/// Assets whose id has none of these -- notably the per-token Base and
+/// Arbitrum stablecoins, which the bridge does not index at all -- are left
+/// out. They render as raw base units against their asset id, which is honest
+/// about what the parser knows.
 const SEEDS: &[(&str, &str, u8)] = &[
     ("nep141:wrap.near", "wNEAR", 24),
+    // Legacy rainbow bridge.
     (
         "nep141:a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near",
         "USDC.e",
@@ -26,7 +70,37 @@ const SEEDS: &[(&str, &str, u8)] = &[
         "USDT.e",
         6,
     ),
-    ("nep141:eth.bridge.near", "ETH", 18),
+    ("nep141:eth.bridge.near", "ETH.e", 18),
+    // Omni bridge, chain-native assets. `eth`/`sol` are the two ids carried by
+    // observed intent traffic.
+    ("nep141:eth.omft.near", "ETH", 18),
+    ("nep141:sol.omft.near", "SOL", 9),
+    ("nep141:btc.omft.near", "BTC", 8),
+    ("nep141:nbtc.bridge.near", "NBTC", 8),
+    ("nep141:pol.omft.near", "POL", 18),
+    ("nep141:base.omft.near", "ETH.base", 18),
+    ("nep141:arb.omft.near", "ETH.arb", 18),
+    // Omni bridge, per-token assets.
+    (
+        "nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+        "USDC",
+        6,
+    ),
+    (
+        "nep141:sol-5ce3bf3a31af18be40ba30f721101b4341690186.omft.near",
+        "USDC.sol",
+        6,
+    ),
+    (
+        "nep141:sol-c800a4bd850783ccb82c2b2c7e84175443606352.omft.near",
+        "USDT.sol",
+        6,
+    ),
+    (
+        "nep141:eth-0xdac17f958d2ee523a2206206994597c13d831ec7.omft.near",
+        "USDT",
+        6,
+    ),
 ];
 
 /// Largest `decimals` [`format_units`] can scale by: `10^39` exceeds `u128`.
@@ -156,6 +230,59 @@ mod tests {
         assert_eq!(meta.decimals, MAX_DECIMALS);
         // The bound is exactly what `format_units` can scale by.
         assert_eq!(format_units(0, MAX_DECIMALS), "0");
+    }
+
+    /// The two assets carried by real intent traffic. Both were rendering as
+    /// raw base units against an unresolved asset id, so nothing on screen
+    /// distinguished 1 ETH from 1 gwei.
+    #[test]
+    fn the_omni_bridge_native_assets_resolve() {
+        let eth = resolve("nep141:eth.omft.near", &empty()).expect("seeded");
+        assert_eq!((eth.symbol.as_str(), eth.decimals), ("ETH", 18));
+        let sol = resolve("nep141:sol.omft.near", &empty()).expect("seeded");
+        assert_eq!((sol.symbol.as_str(), sol.decimals), ("SOL", 9));
+    }
+
+    /// `omni.bridge.near::get_native_token_id("Eth")` returns the legacy
+    /// rainbow-bridge id, which is how the wrong entry reached the table. Both
+    /// ids are real and both are ETH, so they have to stay distinguishable.
+    #[test]
+    fn the_legacy_and_omni_ether_ids_do_not_render_alike() {
+        let legacy = resolve("nep141:eth.bridge.near", &empty()).expect("seeded");
+        let omni = resolve("nep141:eth.omft.near", &empty()).expect("seeded");
+        assert_ne!(legacy.symbol, omni.symbol);
+    }
+
+    /// Four distinct assets report `{"symbol":"ETH","decimals":18}` on-chain
+    /// and four report `{"symbol":"USDC","decimals":6}`. `AmountV2` carries
+    /// only an amount and an abbreviation, so an unqualified symbol would let
+    /// Base ETH render identically to mainnet ETH -- and a swap of one for the
+    /// other render identically to its mirror.
+    #[test]
+    fn every_seeded_symbol_is_unique() {
+        let mut seen = std::collections::BTreeMap::new();
+        for (asset_id, symbol, _) in SEEDS {
+            if let Some(previous) = seen.insert(*symbol, *asset_id) {
+                panic!("symbol {symbol} is shared by {previous} and {asset_id}");
+            }
+        }
+    }
+
+    /// The same token bridged from a different chain carries an origin
+    /// qualifier; the asset native to its own chain carries the bare symbol.
+    #[test]
+    fn same_token_from_different_chains_is_origin_qualified() {
+        for (asset_id, expected) in [
+            ("nep141:base.omft.near", "ETH.base"),
+            ("nep141:arb.omft.near", "ETH.arb"),
+            (
+                "nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+                "USDC",
+            ),
+        ] {
+            let meta = resolve(asset_id, &empty()).expect(asset_id);
+            assert_eq!(meta.symbol, expected, "for {asset_id}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #432, which adds the seed table and the gap-fill rule this PR's entries interact with.

`SEEDS` covered no omni-bridge asset, so both ids carried by observed intent traffic fell to the unresolved arm:

```
Amount: 1000000000000 (unresolved nep141:eth.omft.near)
Amount: 2596756 (unresolved nep141:sol.omft.near)
```

Nothing on screen distinguished 1 ETH from 1 gwei. The three captured production payloads now read `0.000001 ETH`, `0.000099 ETH`, `0.002596756 SOL`.

## ⚠️ Behavior change for integrators

**Seeding an asset takes it out of reach of unattributable caller-supplied metadata.** `try_extract_from_chain_metadata` accepts an entry it cannot attribute to a curator only as a gap-fill for an asset `SEEDS` does not cover. A wallet currently supplying `token_mappings` for any asset added here — unsigned, or signed by a key this deployment has not enrolled — will now have it **refused** instead of applied, by the gap-fill rule in `try_extract_from_chain_metadata`. The refusal is logged for the operator; #439, higher in the stack, also reports it to the signer as a `rejected-token-metadata` diagnostic.

This is the intended posture — a curated seed should beat data the parser cannot attribute, and such callers already get an `unverified-token-metadata` warning on every render — but it is visible to anyone integrating today. A signature from an enrolled curator still overrides normally.

## Why the generator could not produce this

Neither bridge lookup is trustworthy on its own:

| Lookup | Asks | Answers | Real intents carry |
|---|---|---|---|
| `get_native_token_id` | `Eth` | `eth.bridge.near` (legacy rainbow) | `eth.omft.near` |
| `get_native_token_id` | `Base`/`Arb`/`Pol` | `*.omdep.near` (deposit contracts) | `*.omft.near` |
| `get_token_id` | Ethereum USDC/USDT | `*.factory.bridge.near` (legacy) | `eth-0x….omft.near` |
| `get_token_id` | Base/Arbitrum USDC/USDT | *nothing* | — |

The first row is how the wrong id reached the table originally.

So every entry's symbol and decimals is confirmed against the token contract's own `ft_metadata`, and every id rests on one of: **observed traffic** (`eth.omft`, `sol.omft`), **a bridge-registry mapping** (`get_token_id` resolves the canonical Solana USDC/USDT mints onto the two `sol-*` ids; `get_native_token_id` names `nbtc.bridge.near` for `Btc`), or **a self-describing id** embedding a source-chain address checkable directly.

Assets with none of those — the per-token Base and Arbitrum stablecoins — are deliberately left out rather than seeded from an unsourced id. They keep rendering as raw base units, which is honest about what the parser knows. The generator's input list matches, and says why.

## Symbols are origin-qualified

`ft_metadata` symbols are not usable verbatim. **Four distinct assets report `{"symbol":"ETH","decimals":18}`** — ether via the omni bridge and via the legacy rainbow bridge, plus ether bridged from Base and Arbitrum — and **four report `{"symbol":"USDC","decimals":6}`**. `AmountV2` carries only an amount and an abbreviation, so raw symbols would render Base ether identically to mainnet ether, and this swap identically to its mirror:

```
Send:    100 USDC.base        Send:    100 USDC.arb
Receive: 99.7 USDC.arb        Receive: 99.7 USDC.base
```

The bare symbol belongs to the asset native to its own chain; anything bridged from elsewhere carries an origin suffix. This extends the `.e` convention the first stablecoin seeds already used, and moves the legacy `eth.bridge.near` entry from `ETH` to `ETH.e`. `every_seeded_symbol_is_unique` enforces it, so a colliding entry fails the test rather than silently making two assets look alike.

This is the cheapest mitigation for the "asset id disappears once a token resolves" problem that lives entirely in the seed table — it does not need a schema change.

## Notes

- BNB is omitted: `bnb.omft.near` serves no `ft_metadata`, and the deposit contract the bridge names instead is not an id intents carry.
- The ERC-191 fixture at `verify.rs:213` uses `base-0x8335….omft.near`, one of the deliberately unseeded ids, so it still renders unresolved.
- All 15 entries were machine-checked against `ft_metadata` on mainnet: every `decimals` matches, every symbol matches or is the deliberate qualified form, and all ids are unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

