### PR TITLE
fix(images): compile NEAR into the parser_app enclave binary

### DIFF
--- a/images/parser_app/Containerfile
+++ b/images/parser_app/Containerfile
@@ -16,7 +16,7 @@ ENV VERSION=$VERSION
 # passes --no-default-features, so chains not listed here are NOT linked into
 # the binary, shrinking both the image and the attestation surface. Default
 # mirrors parser_app/Cargo.toml's `default` feature set.
-ARG CHAIN_FEATURES="ethereum solana sui tron unspecified"
+ARG CHAIN_FEATURES="ethereum near solana sui tron unspecified"
 ENV CHAIN_FEATURES=$CHAIN_FEATURES
 
 # Load Rust sources


### PR DESCRIPTION
Follow-up to #430, per prasanna's approval note.

`images/parser_app/Containerfile:19` lists the chain visualizers compiled into the enclave image:

```
ARG CHAIN_FEATURES="ethereum solana sui tron unspecified"
```

`CARGOFLAGS` (line 5) passes `--no-default-features`, so this list is authoritative — a chain absent from it is not linked into the binary. `parser_app`'s `default` feature set is `["ethereum", "near", "solana", "sui", "tron", "unspecified"]`, so the image shipped without NEAR support even though #430 makes NEAR reachable over gRPC. This adds `near`, restoring the mirror the surrounding comment describes.

## Why this fails at runtime rather than at build time

- `src/parser/app/src/chain_conversion.rs:12` maps `ProtoChain::Near => RegistryChain::Near` with no `#[cfg]` gate.
- `src/parser/app/src/registry.rs:37` gates the converter registration behind `#[cfg(feature = "near")]`.

Without the feature the image builds clean, deploys clean and passes CI. A `CHAIN_NEAR` request then resolves its chain successfully, finds no registered converter, and fails — only in production, only once a real NEAR transaction arrives.

## Notes

`CHAIN_FEATURES` appears in this one file and nowhere else — no Makefile override and no check comparing it against the crate's `default` set, so nothing would have caught the drift. A guard test is deliberately left out here to keep the fix to the one line; worth raising separately if the drift recurs.

Also flagged as MEDIUM by @pepe-anchor on #430 (2026-08-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)