### PR TITLE
feat(psc-3684): add SVM Governance visualizer preset for Solana

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/mod.rs
@@ -32,6 +32,8 @@ pub enum VisualizerKind {
     StakingPools(&'static str),
     /// Payment and simple transfer-related operations
     Payments(&'static str),
+    /// On-chain governance: proposals, voting, and protocol administration
+    Governance(&'static str),
 }
 
 /// Resolution of a compiled instruction's program_id_index.

--- a/src/chain_parsers/visualsign-solana/src/presets/svm_governance/config.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/svm_governance/config.rs
@@ -1,0 +1,22 @@
+use super::SVM_GOVERNANCE_PROGRAM_ID;
+use crate::core::{SolanaIntegrationConfig, SolanaIntegrationConfigData};
+use std::collections::BTreeMap;
+
+pub struct SvmGovernanceConfig;
+
+impl SolanaIntegrationConfig for SvmGovernanceConfig {
+    fn new() -> Self {
+        Self
+    }
+
+    fn data(&self) -> &SolanaIntegrationConfigData {
+        static DATA: std::sync::OnceLock<SolanaIntegrationConfigData> = std::sync::OnceLock::new();
+        DATA.get_or_init(|| {
+            let mut programs = BTreeMap::new();
+            let mut instructions = BTreeMap::new();
+            instructions.insert("*", vec!["*"]);
+            programs.insert(SVM_GOVERNANCE_PROGRAM_ID, instructions);
+            SolanaIntegrationConfigData { programs }
+        })
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
@@ -1,0 +1,652 @@
+//! SVM Governance preset implementation for Solana
+
+mod config;
+
+use crate::core::{
+    InstructionView, InstructionVisualizer, SolanaIntegrationConfig, VisualizerContext,
+    VisualizerKind,
+};
+use config::SvmGovernanceConfig;
+use solana_parser::{
+    Idl, SolanaParsedInstructionData, decode_idl_data, parse_instruction_with_idl,
+};
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+use visualsign::errors::VisualSignError;
+use visualsign::field_builders::{create_raw_data_field, create_text_field};
+use visualsign::{
+    AnnotatedPayloadField, SignablePayloadField, SignablePayloadFieldCommon,
+    SignablePayloadFieldListLayout, SignablePayloadFieldPreviewLayout, SignablePayloadFieldTextV2,
+};
+
+pub(crate) const SVM_GOVERNANCE_PROGRAM_ID: &str = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU";
+
+const SVM_GOVERNANCE_DISPLAY_NAME: &str = "SVM Governance";
+
+const SVM_GOVERNANCE_IDL_JSON: &str = include_str!("svm_governance.json");
+
+static SVM_GOVERNANCE_CONFIG: SvmGovernanceConfig = SvmGovernanceConfig;
+
+pub struct SvmGovernanceVisualizer;
+
+impl InstructionVisualizer for SvmGovernanceVisualizer {
+    fn visualize_tx_commands(
+        &self,
+        context: &VisualizerContext,
+    ) -> Result<AnnotatedPayloadField, VisualSignError> {
+        let view = InstructionView::from_context(context);
+        let data = context.data();
+
+        let instruction_data_hex = hex::encode(data);
+        let fallback_text = format!(
+            "Program ID: {}\nData: {instruction_data_hex}",
+            view.program_id
+        );
+
+        let parsed = parse_svm_governance_instruction(data, &view.accounts);
+
+        let (title, condensed_fields, mut expanded_fields) = match parsed {
+            Ok(parsed) => build_parsed_fields(&parsed, &view.program_id)?,
+            Err(e) => {
+                let index = context.instruction_index();
+                tracing::warn!(
+                    "Failed to parse SVM Governance instruction {index} with IDL: {e}"
+                );
+                build_fallback_fields(&view.program_id)?
+            }
+        };
+
+        let condensed = SignablePayloadFieldListLayout {
+            fields: condensed_fields,
+        };
+        expanded_fields.push(create_raw_data_field(data, Some(instruction_data_hex))?);
+        let expanded = SignablePayloadFieldListLayout {
+            fields: expanded_fields,
+        };
+
+        let preview_layout = SignablePayloadFieldPreviewLayout {
+            title: Some(SignablePayloadFieldTextV2 { text: title }),
+            subtitle: Some(SignablePayloadFieldTextV2 {
+                text: String::new(),
+            }),
+            condensed: Some(condensed),
+            expanded: Some(expanded),
+        };
+
+        let index = context.instruction_index() + 1;
+        Ok(AnnotatedPayloadField {
+            static_annotation: None,
+            dynamic_annotation: None,
+            signable_payload_field: SignablePayloadField::PreviewLayout {
+                common: SignablePayloadFieldCommon {
+                    label: format!("Instruction {index}"),
+                    fallback_text,
+                },
+                preview_layout,
+            },
+        })
+    }
+
+    fn get_config(&self) -> Option<&dyn SolanaIntegrationConfig> {
+        Some(&SVM_GOVERNANCE_CONFIG)
+    }
+
+    fn kind(&self) -> VisualizerKind {
+        VisualizerKind::Governance(SVM_GOVERNANCE_DISPLAY_NAME)
+    }
+}
+
+fn get_svm_governance_idl() -> Option<&'static Idl> {
+    static IDL: OnceLock<Option<Idl>> = OnceLock::new();
+    IDL.get_or_init(|| decode_idl_data(SVM_GOVERNANCE_IDL_JSON).ok())
+        .as_ref()
+}
+
+fn parse_svm_governance_instruction(
+    data: &[u8],
+    accounts: &[String],
+) -> Result<SvmGovernanceParsedInstruction, Box<dyn std::error::Error>> {
+    if data.len() < 8 {
+        return Err("Invalid instruction data length".into());
+    }
+
+    let idl = get_svm_governance_idl().ok_or("SVM Governance IDL not available")?;
+    let parsed = parse_instruction_with_idl(data, SVM_GOVERNANCE_PROGRAM_ID, idl)?;
+
+    let (named_accounts, extra_accounts) = build_named_accounts(data, idl, accounts);
+
+    Ok(SvmGovernanceParsedInstruction {
+        parsed,
+        named_accounts,
+        extra_accounts,
+    })
+}
+
+fn build_named_accounts(
+    data: &[u8],
+    idl: &Idl,
+    accounts: &[String],
+) -> (BTreeMap<String, String>, Vec<String>) {
+    let mut named_accounts = BTreeMap::new();
+    let mut extra_accounts = Vec::new();
+
+    let idl_instruction = idl.instructions.iter().find(|inst| {
+        inst.discriminator
+            .as_ref()
+            .is_some_and(|disc| data.get(..disc.len()) == Some(disc.as_slice()))
+    });
+
+    if let Some(idl_instruction) = idl_instruction {
+        for (index, account_str) in accounts.iter().enumerate() {
+            if let Some(idl_account) = idl_instruction.accounts.get(index) {
+                named_accounts.insert(idl_account.name.clone(), account_str.clone());
+            } else {
+                extra_accounts.push(account_str.clone());
+            }
+        }
+    }
+
+    (named_accounts, extra_accounts)
+}
+
+struct SvmGovernanceParsedInstruction {
+    parsed: SolanaParsedInstructionData,
+    named_accounts: BTreeMap<String, String>,
+    extra_accounts: Vec<String>,
+}
+
+fn build_parsed_fields(
+    instruction: &SvmGovernanceParsedInstruction,
+    program_id: &str,
+) -> Result<
+    (
+        String,
+        Vec<AnnotatedPayloadField>,
+        Vec<AnnotatedPayloadField>,
+    ),
+    VisualSignError,
+> {
+    let parsed = &instruction.parsed;
+    let instruction_name = &parsed.instruction_name;
+    let title = format!("{SVM_GOVERNANCE_DISPLAY_NAME}: {instruction_name}");
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    condensed_fields.push(create_text_field("Program", SVM_GOVERNANCE_DISPLAY_NAME)?);
+    condensed_fields.push(create_text_field("Instruction", instruction_name)?);
+    for (key, value) in &parsed.program_call_args {
+        condensed_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    expanded_fields.push(create_text_field("Program ID", program_id)?);
+    expanded_fields.push(create_text_field("Instruction", instruction_name)?);
+    expanded_fields.push(create_text_field("Discriminator", &parsed.discriminator)?);
+
+    for (account_name, account_address) in &instruction.named_accounts {
+        expanded_fields.push(create_text_field(account_name, account_address)?);
+    }
+
+    for (index, pubkey) in instruction.extra_accounts.iter().enumerate() {
+        expanded_fields.push(create_text_field(
+            &format!("Remaining Account {}", index + 1),
+            pubkey,
+        )?);
+    }
+
+    for (key, value) in &parsed.program_call_args {
+        expanded_fields.push(create_text_field(key, &format_arg_value(value))?);
+    }
+
+    Ok((title, condensed_fields, expanded_fields))
+}
+
+fn build_fallback_fields(
+    program_id: &str,
+) -> Result<
+    (
+        String,
+        Vec<AnnotatedPayloadField>,
+        Vec<AnnotatedPayloadField>,
+    ),
+    VisualSignError,
+> {
+    let title = format!("{SVM_GOVERNANCE_DISPLAY_NAME}: Unknown Instruction");
+
+    let mut condensed_fields = vec![];
+    let mut expanded_fields = vec![];
+
+    condensed_fields.push(create_text_field("Program", SVM_GOVERNANCE_DISPLAY_NAME)?);
+    condensed_fields.push(create_text_field("Status", "Unknown instruction type")?);
+
+    expanded_fields.push(create_text_field("Program ID", program_id)?);
+    expanded_fields.push(create_text_field("Status", "Unknown instruction type")?);
+
+    Ok((title, condensed_fields, expanded_fields))
+}
+
+/// Render a single program-call argument as one field value.
+///
+/// Each top-level argument becomes exactly ONE field. Objects and arrays render
+/// as a compact, JSON-like string WITHOUT the `"` quotes of real JSON. Two
+/// reasons, both of which this IDL exercises:
+///
+/// 1. **No field explosion.** `cast_vote_override.stake_merkle_proof` is a
+///    `Vec<[u8; 32]>`. Recursing into per-element fields would bury the vote
+///    weights (`for_votes_bp`, `against_votes_bp`, `abstain_votes_bp`) under
+///    hundreds of per-byte entries.
+/// 2. **Charset safety.** `create_proposal` takes attacker-controlled `title`
+///    and `description` strings straight from the transaction. Non-ASCII and
+///    control bytes there would fail `SignablePayload::validate_charset`, so
+///    every leaf string passes through `charset_safe`.
+///
+/// Arrays whose elements are all byte-sized integers (0..=255) render as a
+/// single `0x`-prefixed hex string. A `Vec<[u8; 32]>` therefore renders as a
+/// bracketed list of 32-byte hex strings, one per Merkle proof node.
+fn format_arg_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => charset_safe(s),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Array(items) => {
+            if let Some(hex) = bytes_as_hex(items) {
+                hex
+            } else {
+                let inner: Vec<String> = items.iter().map(format_arg_value).collect();
+                format!("[{}]", inner.join(","))
+            }
+        }
+        serde_json::Value::Object(map) => {
+            let inner: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{}:{}", charset_safe(k), format_arg_value(v)))
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        }
+    }
+}
+
+/// Keep printable ASCII and spaces; drop everything else. `"` and `\` go
+/// because a leaf string carrying them would reintroduce the JSON quoting that
+/// `format_arg_value` renders without. Tabs, carriage returns, other control
+/// bytes, and non-ASCII go because `SignablePayload::validate_charset` rejects
+/// them.
+///
+/// Load-bearing for this program, not defensive: `create_proposal` carries a
+/// free-form `title` and `description` supplied by the proposer.
+fn charset_safe(text: &str) -> String {
+    text.chars()
+        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\'))
+        .collect()
+}
+
+/// If every element is an integer in `0..=255`, render the array as a single
+/// `0x`-prefixed hex string. Returns `None` for empty or non-byte arrays so the
+/// caller falls back to a bracketed list.
+fn bytes_as_hex(items: &[serde_json::Value]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(items.len());
+    for item in items {
+        let byte = item.as_u64().filter(|n| *n <= u8::MAX as u64)? as u8;
+        bytes.push(byte);
+    }
+    Some(format!("0x{}", hex::encode(bytes)))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use crate::{SolanaTransactionWrapper, SolanaVisualSignConverter};
+    use serde_json::json;
+    use solana_parser::solana::structs::SolanaAccount;
+    use solana_sdk::instruction::{AccountMeta, CompiledInstruction, Instruction};
+    use solana_sdk::message::Message;
+    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::transaction::Transaction;
+    use std::str::FromStr;
+    use visualsign::vsptrait::{
+        Transaction as _, VisualSignConverter as _, VisualSignOptions,
+    };
+
+    fn field_label_value(field: &AnnotatedPayloadField) -> (String, String) {
+        match &field.signable_payload_field {
+            SignablePayloadField::TextV2 { common, text_v2 } => {
+                (common.label.clone(), text_v2.text.clone())
+            }
+            other => panic!("expected TextV2 field, got {other:?}"),
+        }
+    }
+
+    /// Look the discriminator up from the bundled IDL instead of hard-coding
+    /// the bytes, so the tests stay correct across IDL regenerations.
+    fn discriminator_for(instruction_name: &str) -> Vec<u8> {
+        let idl = get_svm_governance_idl().unwrap();
+        idl.instructions
+            .iter()
+            .find(|ix| ix.name == instruction_name)
+            .unwrap_or_else(|| panic!("{instruction_name} exists in the bundled IDL"))
+            .discriminator
+            .as_ref()
+            .expect("instruction has a computed discriminator")
+            .clone()
+    }
+
+    fn borsh_string(text: &str) -> Vec<u8> {
+        let mut out = (text.len() as u32).to_le_bytes().to_vec();
+        out.extend_from_slice(text.as_bytes());
+        out
+    }
+
+    #[test]
+    fn test_svm_governance_idl_loads() {
+        let idl = get_svm_governance_idl();
+        assert!(idl.is_some(), "SVM Governance IDL should load successfully");
+        let idl = idl.unwrap();
+        assert!(!idl.instructions.is_empty(), "IDL should have instructions");
+    }
+
+    #[test]
+    fn test_svm_governance_idl_has_discriminators() {
+        let idl = get_svm_governance_idl().unwrap();
+        for instruction in &idl.instructions {
+            assert!(
+                instruction.discriminator.is_some(),
+                "Instruction '{}' should have a computed discriminator",
+                instruction.name
+            );
+            let disc = instruction.discriminator.as_ref().unwrap();
+            assert_eq!(
+                disc.len(),
+                8,
+                "Discriminator for '{}' should be 8 bytes",
+                instruction.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_discriminator_returns_error() {
+        let garbage_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        let accounts = vec![];
+        let result = parse_svm_governance_instruction(&garbage_data, &accounts);
+        assert!(result.is_err(), "Unknown discriminator should return error");
+    }
+
+    #[test]
+    fn test_short_data_returns_error() {
+        let short_data = [0x01, 0x02, 0x03];
+        let accounts = vec![];
+        let result = parse_svm_governance_instruction(&short_data, &accounts);
+        assert!(result.is_err(), "Short data should return error");
+    }
+
+    #[test]
+    fn test_cast_vote_renders_vote_weights_and_named_accounts() {
+        // cast_vote takes three u64 basis-point weights. Its IDL account list is
+        // signer, proposal, vote, ... -- so a caller-supplied account list maps
+        // positionally onto those names.
+        let mut data = discriminator_for("cast_vote");
+        data.extend_from_slice(&6_000u64.to_le_bytes());
+        data.extend_from_slice(&3_000u64.to_le_bytes());
+        data.extend_from_slice(&1_000u64.to_le_bytes());
+
+        let pubkeys: Vec<String> = (0..3).map(|_| Pubkey::new_unique().to_string()).collect();
+        let parsed = parse_svm_governance_instruction(&data, &pubkeys)
+            .expect("cast_vote should decode against the bundled IDL");
+
+        assert_eq!(parsed.parsed.instruction_name, "cast_vote");
+        assert_eq!(
+            parsed.named_accounts.get("signer"),
+            Some(&pubkeys[0]),
+            "first account should be named 'signer'"
+        );
+        assert_eq!(
+            parsed.named_accounts.get("proposal"),
+            Some(&pubkeys[1]),
+            "second account should be named 'proposal'"
+        );
+
+        let (title, condensed, _expanded) =
+            build_parsed_fields(&parsed, SVM_GOVERNANCE_PROGRAM_ID).unwrap();
+        assert_eq!(title, "SVM Governance: cast_vote");
+
+        let entries: Vec<(String, String)> = condensed.iter().map(field_label_value).collect();
+        for (label, expected) in [
+            ("for_votes_bp", "6000"),
+            ("against_votes_bp", "3000"),
+            ("abstain_votes_bp", "1000"),
+        ] {
+            assert!(
+                entries
+                    .iter()
+                    .any(|(l, v)| l == label && v == expected),
+                "condensed view should show {label}={expected}, got: {entries:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_create_proposal_strings_are_charset_safe() {
+        // title and description come straight from the proposer, so they are the
+        // one place in this program where a transaction can carry arbitrary
+        // UTF-8 into a field value. validate_charset forbids non-ASCII, so
+        // charset_safe must strip it before the field is built.
+        let mut data = discriminator_for("create_proposal");
+        data.extend_from_slice(&7u64.to_le_bytes());
+        data.extend_from_slice(&borsh_string("Raise the \"fee\" cap \u{2192} 5%\u{1f600}"));
+        data.extend_from_slice(&borsh_string("Body\twith\ncontrol bytes"));
+
+        let parsed = parse_svm_governance_instruction(&data, &[])
+            .expect("create_proposal should decode against the bundled IDL");
+
+        let (_title, _condensed, expanded) =
+            build_parsed_fields(&parsed, SVM_GOVERNANCE_PROGRAM_ID).unwrap();
+        let entries: Vec<(String, String)> = expanded
+            .iter()
+            .map(field_label_value)
+            .filter(|(label, _)| label == "title" || label == "description")
+            .collect();
+        assert_eq!(entries.len(), 2, "both strings should render as fields");
+
+        for (label, value) in &entries {
+            assert!(
+                value.is_ascii()
+                    && !value.contains('"')
+                    && !value.contains('\\')
+                    && !value.chars().any(|c| c.is_ascii_control()),
+                "{label} must be charset-safe, got: {value}"
+            );
+        }
+        let title_value = entries
+            .iter()
+            .find(|(label, _)| label == "title")
+            .map(|(_, value)| value.clone())
+            .unwrap();
+        assert!(
+            title_value.contains("Raise the fee cap") && title_value.contains("5%"),
+            "printable ASCII should survive sanitization, got: {title_value}"
+        );
+    }
+
+    #[test]
+    fn test_merkle_proof_renders_as_hex_list_not_per_byte_fields() {
+        // stake_merkle_proof is a Vec<[u8; 32]>. Each node renders as one 0x-hex
+        // string and the whole proof stays inside a single field, so the vote
+        // weights next to it remain legible.
+        let node_a: Vec<u8> = (0u8..32).collect();
+        let node_b: Vec<u8> = (32u8..64).collect();
+        let rendered = format_arg_value(&json!([node_a, node_b]));
+
+        assert_eq!(
+            rendered,
+            "[0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f,\
+             0x202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f]"
+        );
+        assert!(
+            !rendered.contains("[0,1,2"),
+            "proof nodes must not render as per-byte number lists: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_format_arg_value_renders_scalars_and_objects_quote_free() {
+        assert_eq!(format_arg_value(&json!(42)), "42");
+        assert_eq!(format_arg_value(&json!(true)), "true");
+        assert_eq!(format_arg_value(&serde_json::Value::Null), "null");
+        // StakeMerkleLeaf is a struct: one field, rendered quote-free.
+        let leaf = format_arg_value(&json!({"active_stake": 100, "stake_account": "Stake111"}));
+        assert!(
+            !leaf.contains('"') && !leaf.contains('\\'),
+            "struct args must render quote-free: {leaf}"
+        );
+        assert!(
+            leaf.contains("active_stake:100") && leaf.contains("stake_account:Stake111"),
+            "struct fields should stay legible inline: {leaf}"
+        );
+    }
+
+    /// End-to-end proof of the two things the unit tests above cannot reach:
+    /// that `build.rs` registration actually routes this program to this preset
+    /// instead of the `unknown_program` catch-all, and that a hostile proposal
+    /// title survives `validate_charset` on the real payload.
+    #[test]
+    fn test_end_to_end_transaction_routes_here_and_passes_charset() {
+        let payer = Pubkey::new_unique();
+        let mut data = discriminator_for("create_proposal");
+        data.extend_from_slice(&1u64.to_le_bytes());
+        data.extend_from_slice(&borsh_string("Fee cap \u{2192} 5% \u{1f600}"));
+        data.extend_from_slice(&borsh_string("Body"));
+
+        let instruction = Instruction {
+            program_id: Pubkey::from_str(SVM_GOVERNANCE_PROGRAM_ID).unwrap(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(Pubkey::new_unique(), false),
+                AccountMeta::new(Pubkey::new_unique(), false),
+            ],
+            data,
+        };
+        let message = Message::new(&[instruction], Some(&payer));
+        let transaction = Transaction::new_unsigned(message);
+        let encoded = BASE64.encode(bincode::serialize(&transaction).unwrap());
+
+        let wrapper = SolanaTransactionWrapper::from_string(&encoded).unwrap();
+        let payload = SolanaVisualSignConverter
+            .to_visual_sign_payload(
+                wrapper,
+                VisualSignOptions {
+                    include_intermediate_output: false,
+                    metadata: None,
+                    decode_transfers: true,
+                    transaction_name: Some("svm governance create_proposal".to_string()),
+                    developer_config: None,
+                },
+            )
+            .unwrap()
+            .payload;
+
+        payload
+            .validate_anchorage_wallet_renderable()
+            .expect("every field this preset emits must be renderable by the wallet");
+        let json = payload
+            .to_validated_json()
+            .expect("payload must pass charset validation with a non-ASCII proposal title");
+        assert!(
+            json.contains("SVM Governance: create_proposal"),
+            "the SVM Governance preset should handle this program, not the catch-all: {json}"
+        );
+    }
+
+    /// Build a context for one instruction to this program, with `count`
+    /// accounts. Mirrors how the converter compiles a transaction: the program
+    /// sits at account_keys[0] and the instruction's accounts follow.
+    fn context_fixture(data: &[u8], count: u8) -> (CompiledInstruction, Vec<Pubkey>) {
+        let mut account_keys = vec![Pubkey::from_str(SVM_GOVERNANCE_PROGRAM_ID).unwrap()];
+        account_keys.extend((0..count).map(|_| Pubkey::new_unique()));
+        let compiled = CompiledInstruction {
+            program_id_index: 0,
+            accounts: (1..=count).collect(),
+            data: data.to_vec(),
+        };
+        (compiled, account_keys)
+    }
+
+    /// Pins the failure-mode contract this preset takes on by claiming the
+    /// program away from the `unknown_program` catch-all: an instruction it
+    /// cannot decode still renders, carrying the program id and the raw data.
+    /// It must never turn an input that previously rendered into an error.
+    #[test]
+    fn test_undecodable_instruction_renders_fallback_instead_of_erroring() {
+        let garbage = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03, 0x04];
+        let (compiled, account_keys) = context_fixture(&garbage, 2);
+        let sender = SolanaAccount {
+            account_key: account_keys[1].to_string(),
+            signer: true,
+            writable: true,
+        };
+        let idl_registry = crate::idl::IdlRegistry::new();
+        let context = VisualizerContext::new(&sender, &compiled, &account_keys, &idl_registry, 0);
+
+        let field = SvmGovernanceVisualizer
+            .visualize_tx_commands(&context)
+            .expect("an undecodable instruction must still render");
+
+        let SignablePayloadField::PreviewLayout {
+            ref preview_layout, ..
+        } = field.signable_payload_field
+        else {
+            panic!("expected a PreviewLayout field");
+        };
+        assert_eq!(
+            preview_layout.title.as_ref().map(|t| t.text.as_str()),
+            Some("SVM Governance: Unknown Instruction")
+        );
+        let expanded = preview_layout.expanded.as_ref().unwrap();
+        let entries: Vec<(String, String)> =
+            expanded.fields.iter().map(field_label_value).collect();
+        assert!(
+            entries
+                .iter()
+                .any(|(label, value)| label == "Raw Data" && value == &hex::encode(garbage)),
+            "the raw bytes must survive so the signer sees something: {entries:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_named_accounts_surfaces_extra_accounts() {
+        // accept_admin has 2 named accounts; provide 4 entries so the last 2
+        // land in extra_accounts.
+        let idl = get_svm_governance_idl().unwrap();
+        let disc = discriminator_for("accept_admin");
+        let pubkeys: Vec<String> = (0..4).map(|_| Pubkey::new_unique().to_string()).collect();
+
+        let (named, extra) = build_named_accounts(&disc, idl, &pubkeys);
+
+        assert_eq!(named.len(), 2, "first 2 accounts should be named");
+        assert_eq!(extra, vec![pubkeys[2].clone(), pubkeys[3].clone()]);
+    }
+
+    #[test]
+    fn test_unknown_instruction_falls_back_without_erroring() {
+        let (title, condensed, expanded) = build_fallback_fields(SVM_GOVERNANCE_PROGRAM_ID).unwrap();
+        assert_eq!(title, "SVM Governance: Unknown Instruction");
+        assert!(
+            condensed
+                .iter()
+                .map(field_label_value)
+                .any(|(label, value)| label == "Program" && value == "SVM Governance")
+        );
+        assert!(
+            expanded
+                .iter()
+                .map(field_label_value)
+                .any(|(label, value)| label == "Program ID" && value == SVM_GOVERNANCE_PROGRAM_ID)
+        );
+    }
+}

--- a/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
@@ -431,6 +431,61 @@ mod tests {
         }
     }
 
+    /// PSC-3684 names vote *and* vote-override operations as the operations
+    /// that must be human-readable. Override is the harder of the two: it
+    /// carries a `Vec<[u8; 32]>` Merkle proof and a `StakeMerkleLeaf` struct
+    /// alongside the weights. Decode a full override payload and assert all
+    /// three survive as legible fields.
+    #[test]
+    fn test_cast_vote_override_renders_weights_proof_and_leaf() {
+        let voting_wallet = Pubkey::new_unique();
+        let stake_account = Pubkey::new_unique();
+        let proof_nodes: Vec<[u8; 32]> = vec![[0xaa; 32], [0xbb; 32]];
+
+        let mut data = discriminator_for("cast_vote_override");
+        data.extend_from_slice(&10_000u64.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        data.extend_from_slice(&0u64.to_le_bytes());
+        data.extend_from_slice(&(proof_nodes.len() as u32).to_le_bytes());
+        for node in &proof_nodes {
+            data.extend_from_slice(node);
+        }
+        data.extend_from_slice(voting_wallet.as_ref());
+        data.extend_from_slice(stake_account.as_ref());
+        data.extend_from_slice(&42_000_000_000u64.to_le_bytes());
+
+        let parsed = parse_svm_governance_instruction(&data, &[])
+            .expect("cast_vote_override should decode against the bundled IDL");
+        assert_eq!(parsed.parsed.instruction_name, "cast_vote_override");
+
+        let (title, _condensed, expanded) =
+            build_parsed_fields(&parsed, SVM_GOVERNANCE_PROGRAM_ID).unwrap();
+        assert_eq!(title, "SVM Governance: cast_vote_override");
+        let entries: Vec<(String, String)> = expanded.iter().map(field_label_value).collect();
+        let value_of = |label: &str| {
+            entries
+                .iter()
+                .find(|(l, _)| l == label)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| panic!("missing field {label} in {entries:?}"))
+        };
+
+        assert_eq!(value_of("for_votes_bp"), "10000");
+        assert_eq!(
+            value_of("stake_merkle_proof"),
+            format!("[0x{},0x{}]", "aa".repeat(32), "bb".repeat(32))
+        );
+        // The leaf renders as one quote-free field carrying all three members,
+        // so a signer can see whose stake the override is claiming.
+        let leaf = value_of("stake_merkle_leaf");
+        assert!(
+            leaf.contains(&format!("voting_wallet:{voting_wallet}"))
+                && leaf.contains(&format!("stake_account:{stake_account}"))
+                && leaf.contains("active_stake:42000000000"),
+            "leaf must name the wallet, the stake account, and the stake: {leaf}"
+        );
+    }
+
     #[test]
     fn test_create_proposal_strings_are_charset_safe() {
         // title and description come straight from the proposer, so they are the

--- a/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/svm_governance/mod.rs
@@ -267,11 +267,11 @@ fn format_arg_value(value: &serde_json::Value) -> String {
     }
 }
 
-/// Keep printable ASCII and spaces; drop everything else. `"` and `\` go
-/// because a leaf string carrying them would reintroduce the JSON quoting that
-/// `format_arg_value` renders without. Tabs, carriage returns, other control
-/// bytes, and non-ASCII go because `SignablePayload::validate_charset` rejects
-/// them.
+/// Keep printable ASCII and spaces, excluding `"` and `\`. `"` and `\` are
+/// stripped because a leaf string carrying them would reintroduce the JSON
+/// quoting that `format_arg_value` renders without. Tabs, carriage returns,
+/// other control bytes, and non-ASCII are stripped because
+/// `SignablePayload::validate_charset` rejects them.
 ///
 /// Load-bearing for this program, not defensive: `create_proposal` carries a
 /// free-form `title` and `description` supplied by the proposer.

--- a/src/chain_parsers/visualsign-solana/src/presets/svm_governance/svm_governance.json
+++ b/src/chain_parsers/visualsign-solana/src/presets/svm_governance/svm_governance.json
@@ -1,0 +1,2806 @@
+{
+  "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU",
+  "metadata": {
+    "name": "svmgov_program",
+    "version": "0.5.0-40200",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "accept_admin",
+      "docs": [
+        "Step 2 of the two-step admin transfer: the nominated admin accepts and becomes",
+        "the active admin."
+      ],
+      "discriminator": [
+        112,
+        42,
+        45,
+        90,
+        116,
+        181,
+        13,
+        170
+      ],
+      "accounts": [
+        {
+          "name": "new_admin",
+          "signer": true
+        },
+        {
+          "name": "global_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cast_vote",
+      "discriminator": [
+        20,
+        212,
+        15,
+        189,
+        69,
+        180,
+        69,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here. The signer-to-vote-account binding is proved in the handler",
+            "via the meta merkle proof: voting_wallet == signer AND vote_account ==",
+            "spl_vote_account, both anchored to proposal.consensus_result."
+          ]
+        },
+        {
+          "name": "vote_override_cache",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  95,
+                  111,
+                  118,
+                  101,
+                  114,
+                  114,
+                  105,
+                  100,
+                  101,
+                  95,
+                  99,
+                  97,
+                  99,
+                  104,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "vote"
+              }
+            ]
+          }
+        },
+        {
+          "name": "snapshot_program"
+        },
+        {
+          "name": "consensus_result"
+        },
+        {
+          "name": "meta_merkle_proof"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "for_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "against_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "abstain_votes_bp",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "cast_vote_override",
+      "discriminator": [
+        225,
+        8,
+        137,
+        98,
+        214,
+        156,
+        183,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "validator_vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here. The signer here is the delegator (not the validator); the",
+            "handler proves stake_merkle_leaf.voting_wallet == signer and binds the",
+            "stake leaf to this vote account via the two-tier merkle proof",
+            "(stake_merkle_root nested inside meta_merkle_leaf)."
+          ]
+        },
+        {
+          "name": "vote_override",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  95,
+                  111,
+                  118,
+                  101,
+                  114,
+                  114,
+                  105,
+                  100,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_stake_account"
+              },
+              {
+                "kind": "account",
+                "path": "validator_vote"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vote_override_cache",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  95,
+                  111,
+                  118,
+                  101,
+                  114,
+                  114,
+                  105,
+                  100,
+                  101,
+                  95,
+                  99,
+                  97,
+                  99,
+                  104,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "validator_vote"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_stake_account"
+        },
+        {
+          "name": "snapshot_program"
+        },
+        {
+          "name": "consensus_result"
+        },
+        {
+          "name": "meta_merkle_proof"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "for_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "against_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "abstain_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "stake_merkle_proof",
+          "type": {
+            "vec": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        },
+        {
+          "name": "stake_merkle_leaf",
+          "type": {
+            "defined": {
+              "name": "StakeMerkleLeaf"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_proposal",
+      "discriminator": [
+        132,
+        116,
+        68,
+        174,
+        216,
+        160,
+        198,
+        22
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "seed"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "proposal_index",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  100,
+                  101,
+                  120
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here; the handler then deserializes VoteStateVersions and requires",
+            "node_pubkey == signer, proving the signer operates this vote account."
+          ]
+        },
+        {
+          "name": "global_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "seed",
+          "type": "u64"
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "description",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "finalize_proposal",
+      "discriminator": [
+        23,
+        68,
+        51,
+        167,
+        109,
+        173,
+        187,
+        164
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "flush_merkle_root",
+      "discriminator": [
+        10,
+        71,
+        17,
+        246,
+        162,
+        57,
+        144,
+        87
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "to the proposal by the init_ballot_box CPI's PDA seed check, which re-derives",
+            "[b\"proposal\", proposal_seed, spl_vote_account] against the signing proposal",
+            "PDA. A mismatched vote account is therefore rejected regardless of who signs",
+            "this instruction (the signer is the admin, not necessarily the author)."
+          ]
+        },
+        {
+          "name": "ballot_box"
+        },
+        {
+          "name": "ballot_program"
+        },
+        {
+          "name": "program_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  114,
+                  111,
+                  103,
+                  114,
+                  97,
+                  109,
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "ballot_program"
+            }
+          }
+        },
+        {
+          "name": "global_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_config",
+      "discriminator": [
+        208,
+        127,
+        21,
+        1,
+        194,
+        190,
+        196,
+        70
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "global_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "program",
+          "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+        },
+        {
+          "name": "program_data"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_title_length",
+          "type": "u16"
+        },
+        {
+          "name": "max_description_length",
+          "type": "u16"
+        },
+        {
+          "name": "max_support_epochs",
+          "type": "u64"
+        },
+        {
+          "name": "min_proposal_stake_lamports",
+          "type": "u64"
+        },
+        {
+          "name": "cluster_support_pct_min_bps",
+          "type": "u64"
+        },
+        {
+          "name": "discussion_epochs",
+          "type": "u64"
+        },
+        {
+          "name": "voting_epochs",
+          "type": "u64"
+        },
+        {
+          "name": "snapshot_epoch_extension",
+          "type": "u64"
+        },
+        {
+          "name": "snapshot_slot_offset",
+          "type": "i64"
+        },
+        {
+          "name": "max_supporters",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_index",
+      "discriminator": [
+        204,
+        67,
+        3,
+        74,
+        139,
+        139,
+        233,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal_index",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  100,
+                  101,
+                  120
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "modify_vote",
+      "discriminator": [
+        116,
+        52,
+        102,
+        0,
+        121,
+        145,
+        27,
+        139
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here. The signer-to-vote-account binding is proved in the handler",
+            "via the meta merkle proof: voting_wallet == signer AND vote_account ==",
+            "spl_vote_account, both anchored to proposal.consensus_result."
+          ]
+        },
+        {
+          "name": "snapshot_program"
+        },
+        {
+          "name": "consensus_result"
+        },
+        {
+          "name": "meta_merkle_proof"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "for_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "against_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "abstain_votes_bp",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "modify_vote_override",
+      "discriminator": [
+        42,
+        54,
+        123,
+        87,
+        239,
+        152,
+        22,
+        186
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "validator_vote",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here. The signer here is the delegator (not the validator); the",
+            "handler proves stake_merkle_leaf.voting_wallet == signer and binds the",
+            "stake leaf to this vote account via the two-tier merkle proof",
+            "(stake_merkle_root nested inside meta_merkle_leaf)."
+          ]
+        },
+        {
+          "name": "vote_override",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  95,
+                  111,
+                  118,
+                  101,
+                  114,
+                  114,
+                  105,
+                  100,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_stake_account"
+              },
+              {
+                "kind": "account",
+                "path": "validator_vote"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vote_override_cache",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101,
+                  95,
+                  111,
+                  118,
+                  101,
+                  114,
+                  114,
+                  105,
+                  100,
+                  101,
+                  95,
+                  99,
+                  97,
+                  99,
+                  104,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "validator_vote"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_stake_account"
+        },
+        {
+          "name": "snapshot_program"
+        },
+        {
+          "name": "consensus_result"
+        },
+        {
+          "name": "meta_merkle_proof"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "for_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "against_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "abstain_votes_bp",
+          "type": "u64"
+        },
+        {
+          "name": "stake_merkle_proof",
+          "type": {
+            "vec": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        },
+        {
+          "name": "stake_merkle_leaf",
+          "type": {
+            "defined": {
+              "name": "StakeMerkleLeaf"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "nominate_admin",
+      "docs": [
+        "Step 1 of the two-step admin transfer: the current admin nominates a new admin.",
+        "The transfer only completes once the nominee calls `accept_admin`."
+      ],
+      "discriminator": [
+        134,
+        11,
+        31,
+        244,
+        20,
+        77,
+        138,
+        121
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "signer": true
+        },
+        {
+          "name": "global_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "proposed_admin",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "retally_support",
+      "docs": [
+        "Permissionless re-tally of a proposal's support at the current epoch.",
+        "Activates voting if the re-measured support now meets the threshold."
+      ],
+      "discriminator": [
+        132,
+        55,
+        145,
+        255,
+        12,
+        163,
+        151,
+        141
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "docs": [
+            "Any caller. Pays only the tx fee — plus the ballot-box rent iff this",
+            "retally activates voting and the ballot box does not exist yet."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "ballot_box",
+          "writable": true
+        },
+        {
+          "name": "ballot_program"
+        },
+        {
+          "name": "program_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  114,
+                  111,
+                  103,
+                  114,
+                  97,
+                  109,
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "ballot_program"
+            }
+          }
+        },
+        {
+          "name": "global_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "support_proposal",
+      "discriminator": [
+        95,
+        239,
+        233,
+        199,
+        201,
+        62,
+        90,
+        27
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "proposal",
+          "writable": true
+        },
+        {
+          "name": "support",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  117,
+                  112,
+                  112,
+                  111,
+                  114,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "spl_vote_account"
+              }
+            ]
+          }
+        },
+        {
+          "name": "spl_vote_account",
+          "docs": [
+            "enforced here; the handler then deserializes VoteStateVersions and requires",
+            "node_pubkey == signer, so a supporter can only pledge stake from a vote",
+            "account they operate."
+          ]
+        },
+        {
+          "name": "ballot_box",
+          "writable": true
+        },
+        {
+          "name": "ballot_program"
+        },
+        {
+          "name": "program_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  80,
+                  114,
+                  111,
+                  103,
+                  114,
+                  97,
+                  109,
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "ballot_program"
+            }
+          }
+        },
+        {
+          "name": "global_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_config",
+      "discriminator": [
+        29,
+        158,
+        252,
+        191,
+        10,
+        83,
+        219,
+        99
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "global_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_title_length",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "max_description_length",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "max_support_epochs",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "min_proposal_stake_lamports",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "cluster_support_pct_min_bps",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "discussion_epochs",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "voting_epochs",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "snapshot_epoch_extension",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "snapshot_slot_offset",
+          "type": {
+            "option": "i64"
+          }
+        },
+        {
+          "name": "max_supporters",
+          "type": {
+            "option": "u32"
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "GlobalConfig",
+      "discriminator": [
+        149,
+        8,
+        156,
+        202,
+        160,
+        252,
+        176,
+        217
+      ]
+    },
+    {
+      "name": "Proposal",
+      "discriminator": [
+        26,
+        94,
+        189,
+        187,
+        116,
+        136,
+        53,
+        33
+      ]
+    },
+    {
+      "name": "ProposalIndex",
+      "discriminator": [
+        83,
+        97,
+        143,
+        58,
+        176,
+        46,
+        177,
+        195
+      ]
+    },
+    {
+      "name": "Support",
+      "discriminator": [
+        247,
+        108,
+        3,
+        111,
+        84,
+        51,
+        217,
+        107
+      ]
+    },
+    {
+      "name": "Vote",
+      "discriminator": [
+        96,
+        91,
+        104,
+        57,
+        145,
+        35,
+        172,
+        155
+      ]
+    },
+    {
+      "name": "VoteOverride",
+      "discriminator": [
+        130,
+        93,
+        172,
+        50,
+        168,
+        151,
+        176,
+        188
+      ]
+    },
+    {
+      "name": "VoteOverrideCache",
+      "discriminator": [
+        195,
+        82,
+        50,
+        219,
+        140,
+        34,
+        108,
+        57
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "AdminNominated",
+      "discriminator": [
+        22,
+        247,
+        53,
+        33,
+        59,
+        59,
+        68,
+        112
+      ]
+    },
+    {
+      "name": "AdminTransferred",
+      "discriminator": [
+        255,
+        147,
+        182,
+        5,
+        199,
+        217,
+        38,
+        179
+      ]
+    },
+    {
+      "name": "MerkleRootFlushed",
+      "discriminator": [
+        120,
+        37,
+        53,
+        216,
+        119,
+        172,
+        17,
+        144
+      ]
+    },
+    {
+      "name": "ProposalCreated",
+      "discriminator": [
+        186,
+        8,
+        160,
+        108,
+        81,
+        13,
+        51,
+        206
+      ]
+    },
+    {
+      "name": "ProposalFinalized",
+      "discriminator": [
+        159,
+        104,
+        210,
+        220,
+        86,
+        209,
+        61,
+        51
+      ]
+    },
+    {
+      "name": "ProposalRetallied",
+      "discriminator": [
+        50,
+        227,
+        187,
+        86,
+        132,
+        93,
+        57,
+        3
+      ]
+    },
+    {
+      "name": "ProposalSupported",
+      "discriminator": [
+        248,
+        220,
+        71,
+        30,
+        127,
+        209,
+        67,
+        231
+      ]
+    },
+    {
+      "name": "VoteCast",
+      "discriminator": [
+        39,
+        53,
+        195,
+        104,
+        188,
+        17,
+        225,
+        213
+      ]
+    },
+    {
+      "name": "VoteModified",
+      "discriminator": [
+        192,
+        64,
+        130,
+        9,
+        210,
+        47,
+        57,
+        175
+      ]
+    },
+    {
+      "name": "VoteOverrideCast",
+      "discriminator": [
+        111,
+        204,
+        225,
+        252,
+        254,
+        218,
+        120,
+        236
+      ]
+    },
+    {
+      "name": "VoteOverrideModified",
+      "discriminator": [
+        235,
+        74,
+        153,
+        225,
+        242,
+        72,
+        228,
+        9
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "NotEnoughStake",
+      "msg": "Insufficient stake to perform this action"
+    },
+    {
+      "code": 6001,
+      "name": "TitleEmpty",
+      "msg": "The title of the proposal cannot be empty"
+    },
+    {
+      "code": 6002,
+      "name": "TitleTooLong",
+      "msg": "The title of the proposal is too long, max 200 bytes"
+    },
+    {
+      "code": 6003,
+      "name": "DescriptionEmpty",
+      "msg": "The description of the proposal cannot be empty"
+    },
+    {
+      "code": 6004,
+      "name": "DescriptionTooLong",
+      "msg": "The description of the proposal is too long, max 500 bytes"
+    },
+    {
+      "code": 6005,
+      "name": "DescriptionInvalid",
+      "msg": "The description of the proposal must point to a github link"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidProposalId",
+      "msg": "Invalid proposal ID"
+    },
+    {
+      "code": 6007,
+      "name": "VotingNotStarted",
+      "msg": "Voting on proposal not yet started"
+    },
+    {
+      "code": 6008,
+      "name": "ProposalClosed",
+      "msg": "Proposal voting period has ended"
+    },
+    {
+      "code": 6009,
+      "name": "ProposalFinalized",
+      "msg": "Proposal has already been finalized"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidVoteDistribution",
+      "msg": "Vote distribution must add up to 100% in Basis Points"
+    },
+    {
+      "code": 6011,
+      "name": "VotingPeriodNotEnded",
+      "msg": "Voting period not yet ended"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidVoteAccount",
+      "msg": "Invalid vote account"
+    },
+    {
+      "code": 6013,
+      "name": "FailedDeserializeNodePubkey",
+      "msg": "Failed to deserialize node_pubkey from Vote account"
+    },
+    {
+      "code": 6014,
+      "name": "VoteNodePubkeyMismatch",
+      "msg": "Deserialized node_pubkey from Vote accounts does not match"
+    },
+    {
+      "code": 6015,
+      "name": "NotEnoughAccounts",
+      "msg": "Not enough accounts for tally"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidClusterStake",
+      "msg": "Cluster stake cannot be zero"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidStartEpoch",
+      "msg": "Start epoch must be current or future epoch"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidVotingLength",
+      "msg": "Voting length must be bigger than 0"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidVoteAccountVersion",
+      "msg": "Invalid Vote account version"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidVoteAccountSize",
+      "msg": "Invalid Vote account size"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidStakeAccount",
+      "msg": "Invalid stake account"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidStakeState",
+      "msg": "Invalid stake account state"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidStakeAccountSize",
+      "msg": "Invalid Stake account size"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidSnapshotProgram",
+      "msg": "Invalid Snapshot program: provided program ID does not match the expected Merkle Verifier Service program"
+    },
+    {
+      "code": 6025,
+      "name": "UnauthorizedMerkleRootUpdate",
+      "msg": "Only the original proposal author can add the merkle root hash"
+    },
+    {
+      "code": 6026,
+      "name": "MerkleRootAlreadySet",
+      "msg": "Merkle root hash is already set for this proposal"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidMerkleRoot",
+      "msg": "Merkle root hash cannot be all zeros"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidSnapshotSlot",
+      "msg": "Invalid snapshot slot: snapshot slot must be past or current slot"
+    },
+    {
+      "code": 6029,
+      "name": "MustBeOwnedBySnapshotProgram",
+      "msg": "Account must be owned by Snapshot program"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidConsensusResultPDA",
+      "msg": "Invalid consensus result PDA"
+    },
+    {
+      "code": 6031,
+      "name": "CannotDeserializeMetaMerkleProofPDA",
+      "msg": "Cannot deserialize MetaMerkleProof PDA"
+    },
+    {
+      "code": 6032,
+      "name": "CannotDeserializeConsensusResult",
+      "msg": "Cannot deserialize ConsensusResult"
+    },
+    {
+      "code": 6033,
+      "name": "CannotModifyAfterStart",
+      "msg": "Cannot modify proposal after voting has started"
+    },
+    {
+      "code": 6034,
+      "name": "VotingLengthTooLong",
+      "msg": "Voting length exceeds maximum allowed epochs"
+    },
+    {
+      "code": 6035,
+      "name": "ArithmeticOverflow",
+      "msg": "Arithmetic overflow occurred"
+    },
+    {
+      "code": 6036,
+      "name": "SnapshotProgramUpgraded",
+      "msg": "Snapshot program has been upgraded, update protection triggered"
+    },
+    {
+      "code": 6037,
+      "name": "MerkleRootNotSet",
+      "msg": "Merkle root hash has not been set for this proposal"
+    },
+    {
+      "code": 6038,
+      "name": "SupportPeriodExpired",
+      "msg": "Support period has expired for this proposal"
+    },
+    {
+      "code": 6039,
+      "name": "NotInSupportPeriod",
+      "msg": "Not within the support period"
+    },
+    {
+      "code": 6040,
+      "name": "ConsensusResultNotSet",
+      "msg": "Consensus result has not been set for this proposal"
+    },
+    {
+      "code": 6041,
+      "name": "Unauthorized",
+      "msg": "Unauthorized: caller is not authorized to perform this action"
+    },
+    {
+      "code": 6042,
+      "name": "ProposalNotInVotingPhase",
+      "msg": "Proposal is not in voting phase"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidVoteOverrideCache",
+      "msg": "Invalid vote override cache"
+    },
+    {
+      "code": 6044,
+      "name": "StakeAccountOwnerMismatch",
+      "msg": "Stake account owner mismatch"
+    },
+    {
+      "code": 6045,
+      "name": "UnauthorizedAdmin",
+      "msg": "Unauthorized: only the admin can perform this action"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidProgram",
+      "msg": "Invalid program"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidClusterSupportPctMin",
+      "msg": "Invalid cluster support percentage minimum in basis points (must be between 0 and 10,000)"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidMaxTitleLength",
+      "msg": "Invalid max title length (must be greater than 0 and less than or equal to 200)"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidMaxDescriptionLength",
+      "msg": "Invalid max description length (must be greater than 0 and less than or equal to 500)"
+    },
+    {
+      "code": 6050,
+      "name": "InvalidAdmin",
+      "msg": "Admin cannot be the default (all-zero) pubkey"
+    },
+    {
+      "code": 6051,
+      "name": "NoPendingAdmin",
+      "msg": "No pending admin nomination exists to accept"
+    },
+    {
+      "code": 6052,
+      "name": "NotPendingAdmin",
+      "msg": "Signer is not the pending admin nominee"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidBallotBox",
+      "msg": "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
+    },
+    {
+      "code": 6054,
+      "name": "SnapshotSlotNotInFuture",
+      "msg": "Snapshot slot must be in the future (greater than the current slot)"
+    },
+    {
+      "code": 6055,
+      "name": "NoSupporters",
+      "msg": "Proposal has no supporters to retally"
+    },
+    {
+      "code": 6056,
+      "name": "SupporterLimitReached",
+      "msg": "Proposal has reached the maximum number of supporters"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidMaxSupporters",
+      "msg": "Invalid max supporters (must be greater than 0 and less than or equal to the supporter limit)"
+    },
+    {
+      "code": 6058,
+      "name": "SupportAlreadyActivated",
+      "msg": "Support is closed: this proposal already reached its support threshold and voting has been scheduled"
+    }
+  ],
+  "types": [
+    {
+      "name": "AdminNominated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_admin",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AdminTransferred",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "previous_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "docs": [
+              "The admin pubkey who can update this config"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_admin",
+            "docs": [
+              "A pending admin nominated by the current admin. The transfer only completes",
+              "once this key signs `accept_admin`. `None` when no transfer is in progress."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "max_title_length",
+            "docs": [
+              "Maximum length for proposal titles"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_description_length",
+            "docs": [
+              "Maximum length for proposal descriptions"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_support_epochs",
+            "docs": [
+              "Maximum epochs allowed for support phase (0 means same epoch as creation)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_proposal_stake_lamports",
+            "docs": [
+              "Minimum stake in lamports required to create a proposal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cluster_support_pct_min_bps",
+            "docs": [
+              "Minimum cluster support percentage in BASIS POINTS (1 bp = 0.01%)",
+              "e.g., 1000 = 10%, 50 = 0.5%"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "discussion_epochs",
+            "docs": [
+              "Number of full epochs reserved for discussion"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "voting_epochs",
+            "docs": [
+              "Number of epochs for voting period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "snapshot_epoch_extension",
+            "docs": [
+              "Epochs of extension for snapshot"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "snapshot_slot_offset",
+            "docs": [
+              "Slot offset from epoch start for snapshot computation (can be negative)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "max_supporters",
+            "docs": [
+              "Maximum number of validators that may support a single proposal. Bounds",
+              "the per-transaction cost of re-tallying the `supporters` list so a",
+              "proposal can always be processed within Solana's heap/compute limits.",
+              "Must be in `1..=MAX_SUPPORTERS_LIMIT`."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MerkleRootFlushed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_snapshot_slot",
+            "type": "u64"
+          },
+          {
+            "name": "flush_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Proposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "author",
+            "docs": [
+              "The public key of the validator who created this proposal"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "title",
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "name": "creation_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "start_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "end_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "proposer_stake_weight_bp",
+            "type": "u64"
+          },
+          {
+            "name": "cluster_support_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "docs": [
+              "Total lamports voted in favor of this proposal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "docs": [
+              "Total lamports voted against this proposal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "docs": [
+              "Total lamports that abstained from voting on this proposal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "voting",
+            "type": "bool"
+          },
+          {
+            "name": "finalized",
+            "type": "bool"
+          },
+          {
+            "name": "proposal_bump",
+            "type": "u8"
+          },
+          {
+            "name": "creation_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "vote_count",
+            "type": "u32"
+          },
+          {
+            "name": "index",
+            "type": "u32"
+          },
+          {
+            "name": "consensus_result",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "snapshot_slot",
+            "docs": [
+              "Slot number when the validator stake snapshot was taken"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "proposal_seed",
+            "type": "u64"
+          },
+          {
+            "name": "vote_account_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "num_supporters",
+            "docs": [
+              "Number of supporter entries stored in the account data at the fixed",
+              "offset [`Proposal::SUPPORTERS_OFFSET`].",
+              "",
+              "The supporter vote-account pubkeys are intentionally NOT a field of",
+              "this struct: they live past the struct's Borsh capacity boundary",
+              "(`discriminator + INIT_SPACE`), so Anchor only (de)serializes this",
+              "4-byte count. The entries are read zero-copy via",
+              "[`Proposal::supporters`] and written by [`Proposal::append_supporter`]."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "title",
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "name": "creation_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalFinalized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "finalizer",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_for_votes",
+            "type": "u64"
+          },
+          {
+            "name": "total_against_votes",
+            "type": "u64"
+          },
+          {
+            "name": "total_abstain_votes",
+            "type": "u64"
+          },
+          {
+            "name": "total_votes_count",
+            "type": "u32"
+          },
+          {
+            "name": "finalization_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalIndex",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_index",
+            "type": "u32"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalRetallied",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "caller",
+            "type": "pubkey"
+          },
+          {
+            "name": "cluster_support_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "voting_activated",
+            "type": "bool"
+          },
+          {
+            "name": "snapshot_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalSupported",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "supporter",
+            "type": "pubkey"
+          },
+          {
+            "name": "cluster_support_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "voting_activated",
+            "type": "bool"
+          },
+          {
+            "name": "snapshot_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakeMerkleLeaf",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "voting_wallet",
+            "docs": [
+              "Wallet designated for governance voting for the stake account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_account",
+            "docs": [
+              "The stake account address."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "active_stake",
+            "docs": [
+              "Active delegated stake amount."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Support",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Vote",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "stake",
+            "type": "u64"
+          },
+          {
+            "name": "override_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "vote_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteCast",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "vote_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "vote_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteModified",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "vote_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "old_against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "old_abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "modification_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteOverride",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegator",
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "vote_account_validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
+            "name": "vote_override_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteOverrideCache",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "vote_account_validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "total_stake",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteOverrideCast",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegator",
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
+            "name": "vote_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VoteOverrideModified",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegator",
+            "type": "pubkey"
+          },
+          {
+            "name": "stake_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "validator",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "old_against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "old_abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_for_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_against_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "new_abstain_votes_bp",
+            "type": "u64"
+          },
+          {
+            "name": "for_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "against_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "abstain_votes_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
+            "name": "modification_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 1. Why this PR exists

https://linear.app/anchorlabs/issue/PSC-3684

Transactions to the Solana Foundation governance program (`govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU`) now render as named governance actions — `SVM Governance: cast_vote` with the three vote weights and the named `signer` / `proposal` / `vote` accounts. Today they fall through to the `unknown_program` catch-all, which shows a program id and a hex blob.

PSC-3684 asks for the governance program to be added "so governance vote and vote-override operations are human-readable", from exactly the IDL file this PR bundles. A signer approving a governance vote cannot tell from the catch-all rendering which proposal they are voting on or how their stake is being split. Vote override is the sharper case: it claims a specific stake account's weight through a Merkle proof, and none of that is visible today.

The preset is IDL-driven and follows the existing `dflow_aggregator` shape, so the decode path is the one already exercised by 17 other presets. 11 new tests cover it, including an end-to-end test that drives a real bincode-encoded transaction through the converter and asserts both that dispatch lands on this preset and that the payload passes charset validation.

## 2. What changed

- **New preset** `chain_parsers/visualsign-solana/src/presets/svm_governance/` — bundled IDL (14 instructions), a config claiming the program with a `*`/`*` instruction match, and the renderer. `build.rs` discovers `SvmGovernanceVisualizer` from the directory name; there is no registry file to edit.
- **`VisualizerKind::Governance`** added to `solana/src/core/mod.rs`. Rejected alternatives: `Payments`, the bucket holding System / Squads / Swig, which mislabels governance in metadata that ships with the payload; and `StakingPools`, closer in spirit since votes are stake-weighted, but no instruction here stakes or unstakes. `kind()` is descriptive metadata — the one match on it (`swig_wallet`) has a `_` arm, so the variant is purely additive.
- **Renderer decisions.** One field per top-level IDL argument: `stake_merkle_proof` is a `Vec<[u8; 32]>`, so recursing into elements would bury the vote weights under per-byte fields. Byte arrays render as `0x`-hex. Every leaf string passes through `charset_safe`, because `create_proposal` carries a free-form `title` and `description` supplied by the proposer — the one place this program lets a transaction push arbitrary UTF-8 into a field value.
- **Uses `InstructionView::from_context`, not `resolve_accounts()?`.** The fallible accessors abort a v0 transaction whose accounts come from an address lookup table, since those never resolve against the static key slice. `InstructionView` renders `unresolved(N)` instead. This matches every other IDL preset.
- **Failure-mode shape change**: dispatch in `visualize_with_any` for program `govYkyQ...` — *`unknown_program` catch-all -> `SvmGovernanceVisualizer`*; affects the rendering of every instruction to this program and nothing else, since `can_handle` matches on the exact program id; mitigation: an undecodable instruction (unknown discriminator, truncated data) degrades to a labeled `SVM Governance: Unknown Instruction` fallback carrying the program id and the raw data, so no input that rendered before can now fail.
- **Carried review finding (P2).** `format_arg_value`, `charset_safe`, and `bytes_as_hex` are byte-identical copies of `dflow_aggregator`'s. Not extracted here, for two reasons. Three different `format_arg_value` implementations already exist across the 19 presets, so there is no canonical helper to reuse — choosing one is a design call over 19 files, not a mechanical extraction. And `dflow_aggregator`'s copy documents itself as a stopgap awaiting a DFlow-aware renderer, so extracting a shared helper now would fork again shortly. Filed as https://linear.app/anchorlabs/issue/PRS-632 rather than silently adding the copy.
- Nothing removed.

## 3. Test plan

**Agent-verified (automated)**

- `make -C src test` — exit 0, 39 test binaries, 1636 tests pass.
- `cargo clippy -p visualsign-solana --all-targets -- -D warnings` — clean both with and without `diagnostics`. Both configurations matter: `parser_app` builds without the feature, `parser_cli` with it.
- `cargo fmt --all -- --check` — clean.
- 13 new tests: the IDL loads and every instruction carries an 8-byte discriminator; an unknown discriminator and 3-byte data both error; `cast_vote` renders its three weights and names `signer` / `proposal`; `create_proposal` strips a non-ASCII title and description while keeping the printable ASCII; a `Vec<[u8; 32]>` Merkle proof renders as two `0x`-hex nodes rather than 64 per-byte fields; surplus accounts surface as `Remaining Account N`; and the unknown-instruction fallback renders.
- `test_cast_vote_override_renders_weights_proof_and_leaf` pins the ticket's own acceptance criterion for the harder of the two named operations: a full `cast_vote_override` payload decodes, and the weights, the two Merkle proof nodes, and the leaf's voting wallet, stake account, and stake amount all render as legible fields.
- Two more pin the contracts this PR takes on rather than the code's own shape. `test_undecodable_instruction_renders_fallback_instead_of_erroring` drives `visualize_tx_commands` with garbage and asserts it still returns a rendered field carrying the raw bytes — that is the failure-mode contract named in section 2, and it fails if the fallback branch ever becomes an error. `test_end_to_end_transaction_routes_here_and_passes_charset` builds a real bincode + base64 transaction with an emoji in the proposal title, then asserts dispatch reaches this preset, `validate_anchorage_wallet_renderable()` is clean, and `to_validated_json()` succeeds.
- Discriminators are looked up from the bundled IDL rather than hardcoded, so an IDL regeneration cannot leave the tests asserting stale bytes.
- The bundled IDL is byte-identical to the upstream file at `solana-foundation/solana-governance@main:svmgov/cli/idls/svmgov_program.json`.
- Review: `review-changes` (adversarial 4-lens) run on this HEAD. Two findings fixed — the missing failure-mode test above, and a decode-failure warning that did not name the instruction index. One finding carried, see below.

**Human QA (manual checklist)**

- [x] No UI surface — the deliverable is a decode path. The end-to-end test covers what a manual CLI decode would have covered, driving the full `SolanaVisualSignConverter` path rather than the visualizer in isolation.
- [ ] Not done: decode of a real mainnet transaction. Every test payload is synthetic, built from the bundled IDL's own discriminators. Real Cast Vote and Modify Vote samples are being gathered from the validator governance portal on the ticket's own Slack thread; when they land, they should become a `tests/fixtures/` snapshot like `orca_whirlpool`'s. That fixture is the one gap these tests leave open.

## 4. How this is maintainable by Claude

A fresh agent can work on this without broad exploration. The preset is one self-contained directory of ~530 lines plus the IDL JSON, which no agent needs to read in full. It is a near-copy of `dflow_aggregator`, so reading any one IDL preset transfers directly.

`CLAUDE.md` guards the parts easy to get wrong: field builders instead of hand-built structs, ASCII-only user-visible strings, no `unwrap` / `expect` / `panic` outside tests, `BTreeMap` for deterministic ordering. The tests catch the two regressions this file shape invites — field explosion on a nested argument, and non-ASCII reaching `validate_charset`.

One trap worth naming: the directory name is load-bearing. `build.rs` derives `SvmGovernanceVisualizer` from `svm_governance` by PascalCase, so renaming the directory without renaming the struct breaks the build.

## Manual steps needed (by human)

None — fully automated by CI. No feature flag, no migration, no backfill. Rollback is a revert of a single commit.

One product-visible note, **low** risk: the display name `SVM Governance` and the new `Governance` kind reach wallet-facing metadata. Worth a glance if that string has a convention I missed.
