### PR TITLE
style(solana/marginfi): rustfmt the preset merged in #375

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/presets/marginfi/mod.rs
+++ b/src/chain_parsers/visualsign-solana/src/presets/marginfi/mod.rs
@@ -38,8 +38,10 @@ impl InstructionVisualizer for MarginfiVisualizer {
         let data = context.data();
 
         let instruction_data_hex = hex::encode(data);
-        let fallback_text =
-            format!("Program ID: {}\nData: {instruction_data_hex}", view.program_id);
+        let fallback_text = format!(
+            "Program ID: {}\nData: {instruction_data_hex}",
+            view.program_id
+        );
 
         let parsed = parse_marginfi_instruction(data, &view.accounts);
 
@@ -246,7 +248,10 @@ mod tests {
     fn test_marginfi_idl_loads() {
         let idl = get_marginfi_idl();
         assert!(idl.is_some(), "Marginfi IDL should load successfully");
-        assert!(!idl.unwrap().instructions.is_empty(), "IDL should have instructions");
+        assert!(
+            !idl.unwrap().instructions.is_empty(),
+            "IDL should have instructions"
+        );
     }
 
     #[test]
@@ -254,7 +259,11 @@ mod tests {
         let idl = get_marginfi_idl().unwrap();
         for ix in &idl.instructions {
             let len = ix.discriminator.as_ref().map(Vec::len).unwrap_or(0);
-            assert_eq!(len, 8, "instruction {} missing 8-byte discriminator", ix.name);
+            assert_eq!(
+                len, 8,
+                "instruction {} missing 8-byte discriminator",
+                ix.name
+            );
         }
     }
 
@@ -278,15 +287,26 @@ mod tests {
     fn test_build_named_accounts_surfaces_extra_accounts() {
         let idl = get_marginfi_idl().unwrap();
         // Pick any IDL instruction with at least one named account
-        let ix = idl.instructions.first().expect("IDL has at least one instruction");
-        let disc = ix.discriminator.as_ref().expect("instruction has a discriminator").clone();
+        let ix = idl
+            .instructions
+            .first()
+            .expect("IDL has at least one instruction");
+        let disc = ix
+            .discriminator
+            .as_ref()
+            .expect("instruction has a discriminator")
+            .clone();
         let n_named = ix.accounts.len();
 
         // Provide n_named + 2 accounts to get 2 extras
         let accounts = dummy_account_strings(n_named + 2);
         let (named, extra) = build_named_accounts(&disc, idl, &accounts);
 
-        assert_eq!(named.len(), n_named, "first {n_named} accounts should be named");
+        assert_eq!(
+            named.len(),
+            n_named,
+            "first {n_named} accounts should be named"
+        );
         assert_eq!(extra.len(), 2, "remaining 2 accounts should be extras");
         assert_eq!(extra[0], accounts[n_named]);
         assert_eq!(extra[1], accounts[n_named + 1]);


### PR DESCRIPTION
## Fixes red `main`

The `Continuous Integration` workflow's **"Ensure working tree is clean"** step is failing on `main` ([run 33450315764](https://github.com/anchorageoss/visualsign-parser/actions/runs/33450315764)). `src/chain_parsers/visualsign-solana/src/presets/marginfi/mod.rs` is not rustfmt-clean.

## Why CI passed on #375 and still broke `main`

A semantic merge conflict, not a skipped check.

`cargo fmt` cannot reach the Solana preset sources: `build.rs` generates their module declarations, so they never appear in the module graph rustfmt walks. #436 added an explicit second pass to `make fmt` to cover them:

```make
	@rustfmt $(SOLANA_PRESET_SOURCES)
```

#375 branched before #436 landed, so its own CI ran **without** that pass and went green. Once both were on `main` together, the preset tree came into scope and the gap surfaced. Neither PR was individually wrong.

## Change

`make -C src fmt`, committed. Formatting only — line wrapping in `fallback_text` and four test assertions. No behavioural change; `git diff --stat` is one file, +27/−7.

## Worth considering separately

This class of break is invisible to PR CI by construction, so it will recur whenever a preset-touching PR branches from before #436. Two options:

1. Require branches to be up to date with `main` before merge (branch protection), which turns this into a pre-merge failure rather than a post-merge one.
2. Have the preset-tree `rustfmt` pass run as its own CI step regardless of branch age, so a stale branch still gets checked against current `main`'s fmt scope.

Not doing either here — this PR just unblocks `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
