### PR TITLE
fix(solana/arg_rendering): mark elided characters instead of deleting them

### DIFF
--- a/src/chain_parsers/visualsign-solana/src/core/arg_rendering.rs
+++ b/src/chain_parsers/visualsign-solana/src/core/arg_rendering.rs
@@ -22,9 +22,33 @@ pub fn format_arg_value(value: &serde_json::Value) -> String {
     }
 }
 
+/// Marker substituted for any character that cannot be rendered.
+///
+/// Substituting rather than deleting keeps distinct inputs distinct: silently
+/// dropping characters made `a"b` and `ab` render identically, so two different
+/// on-chain values could display as the same string. It also makes the loss
+/// visible to whoever reads the field, instead of silently presenting a
+/// truncated value as if it were complete.
+const ELIDED: char = '?';
+
+/// Render `text` as characters that are safe to place in a `SignablePayload`
+/// field, substituting [`ELIDED`] for anything else.
+///
+/// The payload-level charset gate (`SignablePayload::validate_charset`) rejects
+/// the entire payload on any non-ASCII byte, so non-ASCII must be handled here
+/// or a single accented token name fails the whole transaction. `"` and `\` are
+/// substituted too: `validate_charset` itself permits them, but this renderer
+/// emits its own `{key:value}` and `[a,b]` bracketing, and an unescaped quote
+/// inside a value would be indistinguishable from that structure.
 fn charset_safe(text: &str) -> String {
     text.chars()
-        .filter(|&c| c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\'))
+        .map(|c| {
+            if c == ' ' || (c.is_ascii_graphic() && c != '"' && c != '\\') {
+                c
+            } else {
+                ELIDED
+            }
+        })
         .collect()
 }
 
@@ -96,9 +120,30 @@ mod tests {
     }
 
     #[test]
-    fn test_string_with_forbidden_chars_is_stripped() {
-        assert_eq!(format_arg_value(&json!("a\"b\\c d")), "abc d");
-        assert_eq!(format_arg_value(&json!("a\tb\rc")), "abc");
+    fn test_forbidden_chars_are_marked_not_deleted() {
+        assert_eq!(format_arg_value(&json!("a\"b\\c d")), "a?b?c d");
+        assert_eq!(format_arg_value(&json!("a\tb\rc")), "a?b?c");
+    }
+
+    /// Deleting unsafe characters let distinct values collapse onto the same
+    /// rendering. Substituting a marker keeps them distinct.
+    #[test]
+    fn test_distinct_values_do_not_collapse() {
+        let quoted = format_arg_value(&json!("a\"b"));
+        let plain = format_arg_value(&json!("ab"));
+        assert_ne!(
+            quoted, plain,
+            "a value containing a quote must not render identically to one without"
+        );
+    }
+
+    /// Non-ASCII must not reach the payload -- `validate_charset` rejects the
+    /// whole payload on any non-ASCII byte -- but its loss should be visible
+    /// rather than silent.
+    #[test]
+    fn test_non_ascii_is_marked() {
+        assert_eq!(format_arg_value(&json!("Caf\u{e9}")), "Caf?");
+        assert!(format_arg_value(&json!("\u{4f60}\u{597d}")).is_ascii());
     }
 
     #[test]


### PR DESCRIPTION
Addresses the two review comments left on #375.

## Distinct values were collapsing onto the same rendering

`charset_safe` deleted every character it could not render, so `a"b` and `ab` both rendered as `ab`. Two different on-chain instruction arguments could be displayed to a signer identically — on a surface whose entire job is showing what is about to be signed.

It also presented truncated values as complete: an accented token name rendered `Caf`, with nothing indicating a character had been dropped.

This substitutes a marker (`?`) instead of deleting. Distinct inputs stay distinct, and the elision is visible.

```rust
format_arg_value(&json!("a\"b\\c d"))   // was "abc d",  now "a?b?c d"
format_arg_value(&json!("Café"))        // was "Caf",    now "Caf?"
```

## Why non-ASCII still cannot pass through

Worth stating explicitly, because it looks like over-caution and isn't: `SignablePayload::validate_charset` rejects the **entire payload** on any non-ASCII byte. Without substitution here, one accented token name fails the whole transaction rather than degrading one field. That behaviour is load-bearing, and the doc comment now says so rather than leaving the next reader to rediscover it.

## One thing I deliberately did not change

`"` and `\` are still substituted — but note that `validate_charset` **permits** both. The rationale in `visualsign/src/lib.rs` is explicit (PRS-572): they are allowed precisely so field text can carry real embedded JSON that a signer can copy out of the wallet UI and parse.

So there is an argument that this renderer should emit `{"key":"value"}` rather than `{key:value}` and stop stripping quotes entirely. I left that alone because:

1. It reverses a deliberate choice in #375, which added `test_object_renders_quote_free` and `test_nested_object_does_not_emit_quotes` on purpose.
2. This renderer emits its own `{key:value}` / `[a,b]` bracketing. An unescaped quote inside a *value* would be indistinguishable from that structure, so allowing quotes safely means quoting the structure properly — a real change, not a one-liner.

Flagging it rather than doing it. If the PRS-572 copy-paste-parseable goal is meant to extend to preset args, that is worth its own issue.

## Verification

`cargo test -p visualsign-solana`: **345 passed**. `cargo clippy --all-targets -D warnings`: clean.

Two existing tests changed, both of which pinned the deletion semantics (`test_string_with_forbidden_chars_is_stripped` → `test_forbidden_chars_are_marked_not_deleted`). Two added: one asserting distinct values do not collapse, one asserting non-ASCII is marked and the result stays ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
