### PR TITLE
fix(near): reject a token-metadata entry the CLI failed to sign

### DIFF
--- a/src/chain_parsers/visualsign-near/src/cli_plugin.rs
+++ b/src/chain_parsers/visualsign-near/src/cli_plugin.rs
@@ -110,9 +110,10 @@ fn parse_near_mapping(mapping_str: &str) -> Result<MappingComponents, String> {
 /// Load token-metadata JSON files and build mappings for
 /// `NearMetadata.token_mappings`. Each entry is signed with the CLI's local
 /// dev key (NEAR-origin ed25519) so it extracts as verified rather than
-/// dropped by the strict posture [`cli_trust_policy`] installs; if signing is
-/// unavailable (binary built without `dev-signing`), the entry is registered
-/// unsigned instead of dropped here.
+/// dropped by the strict posture [`cli_trust_policy`] installs; a signing
+/// failure rejects the entry, matching Ethereum's `--abi-json-mappings` flow,
+/// since an unsigned entry cannot pass that posture anyway and would
+/// otherwise be logged and counted as loaded despite being dead weight.
 ///
 /// The load/dedupe/count/report loop is `load_mappings`, shared with the ABI
 /// and IDL flags, so the three chains cannot drift on what a duplicate or an
@@ -136,26 +137,15 @@ fn build_token_mappings_from_files(
         // and `parse_near_mapping` has already rejected an empty component.
         |_| Ok(()),
         |components, json| {
-            // Unlike the ABI and IDL flags, a signing failure is not a
-            // rejection: the entry is still worth rendering as an unsigned
-            // gap-fill, and a build without `dev-signing` cannot sign at all.
-            let signature = match sign_token_metadata_for_cli(
+            let signature = sign_token_metadata_for_cli(
                 signing_network.network_id(),
                 &components.identifier,
                 &json,
-            ) {
-                Ok(sig) => Some(sig),
-                Err(e) => {
-                    eprintln!(
-                        "  Warning: '{}' could not be signed ({e}); registering unsigned",
-                        components.name
-                    );
-                    None
-                }
-            };
+            )
+            .map_err(|e| format!("failed to sign token metadata: {e}"))?;
             Ok(TokenMetadataEntry {
                 value: json,
-                signature,
+                signature: Some(signature),
                 origin_chain: None,
             })
         },

--- a/src/chain_parsers/visualsign-near/tests/token_metadata_signing_required.rs
+++ b/src/chain_parsers/visualsign-near/tests/token_metadata_signing_required.rs
@@ -12,11 +12,11 @@
 //! excludes `parser_cli`, the only crate that enables `dev-signing`, so feature
 //! unification cannot switch it back on here.
 //!
-//! Scope is the half that nothing else covers -- that an entry is registered
-//! *unsigned* rather than dropped when signing is unavailable. What happens to
-//! an unsigned entry afterwards (refused under `RequireAllowlistedSigner`,
-//! accepted only as a gap-fill under `AcceptUnsigned`) is covered by
-//! `token_signature.rs`'s own tests, which don't depend on this feature.
+//! Scope is the half that nothing else covers -- that an entry is dropped,
+//! not registered unsigned, when signing is unavailable, matching Ethereum's
+//! `--abi-json-mappings` flow: an unsigned entry can never pass the strict
+//! `RequireAllowlistedSigner` posture `register` installs, so counting it as
+//! loaded would be misleading.
 
 #![cfg(all(feature = "cli-plugin", not(feature = "dev-signing")))]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
@@ -28,7 +28,7 @@ const ASSET_ID: &str = "nep141:not-a-seeded-asset.near";
 const VALUE: &str = r#"{"symbol":"GAP","decimals":6}"#;
 
 #[test]
-fn without_dev_signing_the_cli_registers_the_entry_unsigned() {
+fn without_dev_signing_the_cli_drops_the_entry_instead_of_registering_it_unsigned() {
     let dir = std::env::temp_dir().join("vsp_near_no_dev_signing");
     std::fs::create_dir_all(&dir).expect("temp dir");
     let file = dir.join("token.json");
@@ -40,23 +40,18 @@ fn without_dev_signing_the_cli_registers_the_entry_unsigned() {
     let metadata = plugin
         .create_metadata(Some("NEAR_MAINNET".to_string()))
         .expect("metadata builds")
-        .expect("a loadable mapping yields metadata");
+        .expect("the network flag alone yields metadata even with no token mappings");
 
     let Some(generated::parser::chain_metadata::Metadata::Near(near)) = metadata.metadata.as_ref()
     else {
         panic!("expected NEAR chain metadata, got {:?}", metadata.metadata);
     };
-    let entry = near
-        .token_mappings
-        .get(ASSET_ID)
-        .expect("the mapping registers even though signing was unavailable");
 
-    assert_eq!(entry.value, VALUE, "the file contents are carried verbatim");
     assert!(
-        entry.signature.is_none(),
-        "a binary built without dev-signing must register the entry unsigned \
-         rather than attaching a signature, got {:?}",
-        entry.signature
+        !near.token_mappings.contains_key(ASSET_ID),
+        "a binary built without dev-signing must drop the entry rather than \
+         registering it unsigned, got {:?}",
+        near.token_mappings.get(ASSET_ID)
     );
 
     std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
## Summary

1. `build_token_mappings_from_files` (`src/chain_parsers/visualsign-near/src/cli_plugin.rs`) now rejects a `--near-token-metadata-mappings` entry when `sign_token_metadata_for_cli` fails, instead of registering it unsigned and still counting it as loaded. This matches Ethereum's `--abi-json-mappings` flow, and an unsigned entry can never pass the strict `RequireAllowlistedSigner` posture the CLI installs, so counting it as loaded was misleading.
2. Renamed `tests/unsigned_without_dev_signing.rs` to `tests/token_metadata_signing_required.rs` and updated its assertion: without the `dev-signing` feature, the entry is now dropped (absent from `token_mappings`) rather than registered with `signature: None`.

Addresses https://github.com/anchorageoss/visualsign-parser/pull/437#discussion_r3915293176.

## Test plan

- [x] `cargo test -p visualsign-near --features cli-plugin` (unit + the renamed integration test, built without `dev-signing`)
- [x] `cargo clippy -p visualsign-near --features cli-plugin --all-targets -- -D warnings`
- [x] `cargo fmt -p visualsign-near -- --check`
- [x] Manual smoke test of `parser_cli decode --chain near --near-token-metadata-mappings ...` confirms the success-count line stays accurate on a successful sign

🤖 Generated with [Claude Code](https://claude.com/claude-code)