### PR TITLE
fix(near): resolve an MT withdraw that wraps a known NEP-141 balance

### DIFF
--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -1083,6 +1083,10 @@ mod tests {
                 true,
             ),
             (
+                r#"{"intent":"mt_withdraw","token":"mt.near","receiver_id":"bob.near","token_ids":["1"],"amounts":["1"]}"#,
+                true,
+            ),
+            (
                 r#"{"intent":"native_withdraw","receiver_id":"bob.near","amount":"1"}"#,
                 false,
             ),

--- a/src/chain_parsers/visualsign-near/src/convert.rs
+++ b/src/chain_parsers/visualsign-near/src/convert.rs
@@ -329,7 +329,7 @@ impl VisualSignConverterFromString<NearTransaction> for NearVisualSignConverter 
 
 /// The intents verifier contract, and the method on it that carries a signed
 /// intent batch.
-const INTENTS_RECEIVER: &str = "intents.near";
+pub(crate) const INTENTS_RECEIVER: &str = "intents.near";
 const EXECUTE_INTENTS_METHOD: &str = "execute_intents";
 
 /// The call on this action that a decoder resolving token amounts will handle,

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -1092,12 +1092,6 @@ mod tests {
             r#"{"intent":"token_diff","diff":{"nep245:evil.near:nep141:wrap.near":"-2000000000000000000000000"}}"#,
         );
         let fields = render_intent(&intent, &empty_reg()).expect("render");
-        assert!(
-            fields
-                .iter()
-                .all(|f| !matches!(f, SignablePayloadField::AmountV2 { .. })),
-            "expected no resolved AmountV2, got {fields:?}"
-        );
         match fields.iter().find(|f| label_of(f) == Some("Send")) {
             Some(SignablePayloadField::TextV2 { text_v2, .. }) => {
                 assert!(

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -338,7 +338,7 @@ fn render_intent_body(intent: &Intent, registry: &Reg) -> Result<Fields, VisualS
         Intent::Transfer(t) => render_transfer(t, registry),
         Intent::FtWithdraw(w) => render_ft_withdraw(w, registry),
         Intent::NftWithdraw(w) => render_nft_withdraw(w),
-        Intent::MtWithdraw(w) => render_mt_withdraw(w),
+        Intent::MtWithdraw(w) => render_mt_withdraw(w, registry),
         Intent::NativeWithdraw(w) => render_native_withdraw(w),
         Intent::AddPublicKey(a) => Ok(vec![
             create_text_field("Add Public Key", &a.public_key.to_string())?.signable_payload_field,
@@ -380,9 +380,11 @@ fn render_intent_body(intent: &Intent, registry: &Reg) -> Result<Fields, VisualS
 /// rather than silently drifting out of step.
 pub(crate) fn intent_consumes_token_registry(intent: &Intent) -> bool {
     match intent {
-        Intent::TokenDiff(_) | Intent::Transfer(_) | Intent::FtWithdraw(_) => true,
+        Intent::TokenDiff(_)
+        | Intent::Transfer(_)
+        | Intent::FtWithdraw(_)
+        | Intent::MtWithdraw(_) => true,
         Intent::NftWithdraw(_)
-        | Intent::MtWithdraw(_)
         | Intent::NativeWithdraw(_)
         | Intent::AddPublicKey(_)
         | Intent::RemovePublicKey(_)
@@ -532,7 +534,13 @@ fn render_nft_withdraw(w: &NftWithdraw) -> Result<Fields, VisualSignError> {
     Ok(fields)
 }
 
-fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
+/// Each `token_id` here is scoped to `w.token`, the multi-token contract --
+/// `nep245:<w.token>:<token_id>` is the same asset-id shape `TokenDiff`/
+/// `Transfer` already produce for an MT entry in their maps, so it reaches
+/// `token_amount_field` through the identical registry lookup (including its
+/// `tokens::mt_underlying_nep141` fallback to a wrapped NEP-141 balance)
+/// rather than a bespoke one for this withdraw shape alone.
+fn render_mt_withdraw(w: &MtWithdraw, registry: &Reg) -> Result<Fields, VisualSignError> {
     if w.token_ids.len() != w.amounts.len() {
         return Err(VisualSignError::ValidationError(format!(
             "mt_withdraw token_ids/amounts length mismatch: {} token_ids vs {} amounts",
@@ -546,12 +554,15 @@ fn render_mt_withdraw(w: &MtWithdraw) -> Result<Fields, VisualSignError> {
     ];
     for (id, amount) in w.token_ids.iter().zip(w.amounts.iter()) {
         // As with `nft_withdraw`'s `token_id`, an MT token id is a plain
-        // `String` (`defuse_nep245::TokenId`); filter it before it joins the
-        // composite, so the amount half cannot be pushed onto its own line.
-        fields.push(
-            create_text_field("MT Token", &format!("{} x{}", charset_safe(id), amount.0))?
-                .signable_payload_field,
-        );
+        // `String` (`defuse_nep245::TokenId`), so it carries whatever bytes
+        // the sender chose and must be filtered before it reaches field text.
+        fields.push(create_text_field("MT Token", &charset_safe(id))?.signable_payload_field);
+        fields.extend(token_amount_field(
+            "Amount",
+            &format!("nep245:{}:{id}", w.token),
+            amount.0,
+            registry,
+        )?);
     }
     push_withdraw_call_details(&mut fields, &w.memo, &w.msg, w.storage_deposit)?;
     Ok(fields)
@@ -1334,6 +1345,46 @@ mod tests {
         assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
     }
 
+    /// An MT withdraw whose token_id names a NEP-141 balance a defuse-style
+    /// contract represents as a multi-token (the same convention
+    /// `tokens::mt_underlying_nep141` recognizes) must resolve through the
+    /// registry, not render the raw base-unit amount an unresolved asset
+    /// would.
+    #[test]
+    fn mt_withdraw_resolves_a_wrapped_nep141_balance() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"defuse.near","receiver_id":"alice.near","token_ids":["nep141:wrap.near"],"amounts":["2000000000000000000000000"]}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        match fields.iter().find(|f| label_of(f) == Some("Amount")) {
+            Some(SignablePayloadField::AmountV2 { amount_v2, .. }) => {
+                assert_eq!(amount_v2.amount, "2");
+                assert_eq!(amount_v2.abbreviation.as_deref(), Some("wNEAR"));
+            }
+            other => panic!("expected resolved AmountV2, got {other:?}"),
+        }
+    }
+
+    /// An MT withdraw on an independent, unrelated multi-token contract --
+    /// one whose token_id has no relation to any known asset -- must still
+    /// render honestly as unresolved, not silently misattribute an amount.
+    #[test]
+    fn mt_withdraw_with_an_unrelated_token_id_is_unresolved() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"market.near","receiver_id":"alice.near","token_ids":["gold-sword-42"],"amounts":["5"]}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        match fields.iter().find(|f| label_of(f) == Some("Amount")) {
+            Some(SignablePayloadField::TextV2 { text_v2, .. }) => {
+                assert!(
+                    text_v2.text.contains("unresolved"),
+                    "expected an unresolved amount, got {text_v2:?}"
+                );
+            }
+            other => panic!("expected an unresolved text field, got {other:?}"),
+        }
+    }
+
     /// A NEP-616 `state_init` attached to an intent, in defuse's JSON shape:
     /// an externally-tagged `StateInit::V1` wrapping a global-contract id.
     const STATE_INIT: &str =
@@ -1547,7 +1598,7 @@ mod tests {
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         assert_eq!(
             text_at(&fields, "MT Token"),
-            "innocent?To: alice.near?Amount: 0.001 SOL x5"
+            "innocent?To: alice.near?Amount: 0.001 SOL"
         );
     }
 

--- a/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/render.rs
@@ -1080,6 +1080,35 @@ mod tests {
         assert_eq!(wnear.abbreviation.as_deref(), Some("wNEAR"));
     }
 
+    /// A `token_diff` entry keyed by an MT asset id whose contract is NOT the
+    /// intents verifier, but whose inner token_id is spelled to round-trip as
+    /// a seeded NEP-141 id, must render unresolved -- this shape shows no
+    /// contract on screen at all (unlike `mt_withdraw`'s separate `Token`
+    /// field), so a misresolution here would give the signer nothing to
+    /// notice.
+    #[test]
+    fn token_diff_with_an_untrusted_mt_contract_is_unresolved() {
+        let intent = intent_from(
+            r#"{"intent":"token_diff","diff":{"nep245:evil.near:nep141:wrap.near":"-2000000000000000000000000"}}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        assert!(
+            fields
+                .iter()
+                .all(|f| !matches!(f, SignablePayloadField::AmountV2 { .. })),
+            "expected no resolved AmountV2, got {fields:?}"
+        );
+        match fields.iter().find(|f| label_of(f) == Some("Send")) {
+            Some(SignablePayloadField::TextV2 { text_v2, .. }) => {
+                assert!(
+                    text_v2.text.contains("unresolved"),
+                    "expected an unresolved amount, got {text_v2:?}"
+                );
+            }
+            other => panic!("expected an unresolved text field, got {other:?}"),
+        }
+    }
+
     #[test]
     fn token_diff_refuses_a_zero_delta_entry() {
         let intent = intent_from(
@@ -1345,15 +1374,15 @@ mod tests {
         assert!(labels.contains(&"Storage Deposit"), "labels: {labels:?}");
     }
 
-    /// An MT withdraw whose token_id names a NEP-141 balance a defuse-style
-    /// contract represents as a multi-token (the same convention
+    /// An MT withdraw whose token_id names a NEP-141 balance the intents
+    /// verifier contract represents as a multi-token (the same convention
     /// `tokens::mt_underlying_nep141` recognizes) must resolve through the
     /// registry, not render the raw base-unit amount an unresolved asset
     /// would.
     #[test]
     fn mt_withdraw_resolves_a_wrapped_nep141_balance() {
         let intent = intent_from(
-            r#"{"intent":"mt_withdraw","token":"defuse.near","receiver_id":"alice.near","token_ids":["nep141:wrap.near"],"amounts":["2000000000000000000000000"]}"#,
+            r#"{"intent":"mt_withdraw","token":"intents.near","receiver_id":"alice.near","token_ids":["nep141:wrap.near"],"amounts":["2000000000000000000000000"]}"#,
         );
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         match fields.iter().find(|f| label_of(f) == Some("Amount")) {
@@ -1372,6 +1401,30 @@ mod tests {
     fn mt_withdraw_with_an_unrelated_token_id_is_unresolved() {
         let intent = intent_from(
             r#"{"intent":"mt_withdraw","token":"market.near","receiver_id":"alice.near","token_ids":["gold-sword-42"],"amounts":["5"]}"#,
+        );
+        let fields = render_intent(&intent, &empty_reg()).expect("render");
+        match fields.iter().find(|f| label_of(f) == Some("Amount")) {
+            Some(SignablePayloadField::TextV2 { text_v2, .. }) => {
+                assert!(
+                    text_v2.text.contains("unresolved"),
+                    "expected an unresolved amount, got {text_v2:?}"
+                );
+            }
+            other => panic!("expected an unresolved text field, got {other:?}"),
+        }
+    }
+
+    /// An MT withdraw whose contract is NOT the intents verifier, but whose
+    /// token_id is spelled to round-trip as a seeded NEP-141 id anyway, must
+    /// still render as unresolved. `token_id` is a plain string the deployer
+    /// of `token` fully controls, so it cannot by itself prove the balance is
+    /// the intents verifier's own wNEAR -- only the trusted `contract` half
+    /// can. Without the contract check, this would misrender as a fully
+    /// verified `2 wNEAR`.
+    #[test]
+    fn mt_withdraw_on_an_untrusted_contract_is_unresolved_even_with_a_seeded_token_id() {
+        let intent = intent_from(
+            r#"{"intent":"mt_withdraw","token":"evil.near","receiver_id":"alice.near","token_ids":["nep141:wrap.near"],"amounts":["2000000000000000000000000"]}"#,
         );
         let fields = render_intent(&intent, &empty_reg()).expect("render");
         match fields.iter().find(|f| label_of(f) == Some("Amount")) {

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -1587,6 +1587,39 @@ mod tests {
         );
     }
 
+    // The gap-fill rule must see through the MT alias, not just the direct
+    // key: an unsigned entry keyed by an MT asset that itself wraps an
+    // already-seeded NEP-141 balance (tokens::mt_underlying_nep141) must be
+    // rejected the same as one keyed by that NEP-141 id directly -- otherwise
+    // an unauthenticated caller could smuggle the wrong decimals in through
+    // the MT-shaped key while the direct key stays protected.
+    #[test]
+    fn extract_unsigned_entry_for_mt_wrapped_seeded_asset_rejected() {
+        let mt_asset_id = format!("nep245:defuse.near:{ASSET_ID}");
+        let metadata = ChainMetadata {
+            metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
+                network_id: Some("NEAR_MAINNET".to_string()),
+                token_mappings: make_mappings(vec![(
+                    &mt_asset_id,
+                    TokenMetadataEntry {
+                        value: r#"{"symbol":"USDC.e","decimals":30}"#.to_string(),
+                        signature: None,
+                        origin_chain: None,
+                    },
+                )]),
+            })),
+        };
+        assert!(
+            extract_registry(
+                Some(&metadata),
+                NETWORK,
+                &near_allowlist(),
+                &accept_unsigned_policy()
+            )
+            .is_none()
+        );
+    }
+
     // Regression coverage for the trust posture: an unsigned entry
     // for an asset SEEDS doesn't cover -- normally accepted (see
     // extract_unsigned_entry_accepted) -- must be rejected outright once the

--- a/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/token_signature.rs
@@ -1595,7 +1595,7 @@ mod tests {
     // the MT-shaped key while the direct key stays protected.
     #[test]
     fn extract_unsigned_entry_for_mt_wrapped_seeded_asset_rejected() {
-        let mt_asset_id = format!("nep245:defuse.near:{ASSET_ID}");
+        let mt_asset_id = format!("nep245:intents.near:{ASSET_ID}");
         let metadata = ChainMetadata {
             metadata: Some(chain_metadata::Metadata::Near(NearMetadata {
                 network_id: Some("NEAR_MAINNET".to_string()),

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -1,5 +1,6 @@
 //! Seeded NEP-141 token table + amount formatting.
 
+use defuse_core::token_id::TokenId;
 use visualsign::registry::LayeredRegistry;
 
 use super::{NearTokenRegistry, TokenMeta};
@@ -114,18 +115,39 @@ fn usable(meta: TokenMeta) -> Option<TokenMeta> {
     (meta.decimals <= MAX_DECIMALS).then_some(meta)
 }
 
+/// If `asset_id` is `nep245:<contract>:<mt_token_id>` and `mt_token_id`
+/// itself round-trips as a NEP-141 [`TokenId`] -- the convention a
+/// defuse-style contract uses when it represents one of its own held NEP-141
+/// balances as a multi-token, e.g. `nep245:defuse.near:nep141:wrap.near`
+/// (exercised by `defuse-core`'s own cross-instance MT transfer tests) --
+/// returns that inner asset id so its already-curated metadata can be
+/// borrowed. An independent NEP-245 contract's own token_id convention, or an
+/// inner id that isn't NEP-141 (an NFT, or a nested multi-token), does not
+/// match and returns `None`, leaving the amount unresolved exactly as it does
+/// today. `contract` is a NEAR account id, which cannot itself contain `:`, so
+/// splitting on the first `:` after the `nep245:` prefix cannot mistake part
+/// of `mt_token_id` for it even though `mt_token_id` may contain further `:`s.
+fn mt_underlying_nep141(asset_id: &str) -> Option<String> {
+    let mt_token_id = asset_id.strip_prefix("nep245:")?.split_once(':')?.1;
+    matches!(mt_token_id.parse::<TokenId>(), Ok(TokenId::Nep141(_)))
+        .then(|| mt_token_id.to_string())
+}
+
 /// The curated `decimals` for `asset_id`, or `None` when [`SEEDS`] does not
-/// cover it. A refusal quotes this against the proposed value, so the signer
-/// sees what was attempted rather than only that something was dropped.
+/// cover it (including, for an MT asset, its [`mt_underlying_nep141`]). A
+/// refusal quotes this against the proposed value, so the signer sees what
+/// was attempted rather than only that something was dropped.
 pub(crate) fn seeded_decimals(asset_id: &str) -> Option<u8> {
     SEEDS
         .iter()
         .find(|(id, _, _)| *id == asset_id)
         .map(|(_, _, decimals)| *decimals)
+        .or_else(|| seeded_decimals(&mt_underlying_nep141(asset_id)?))
 }
 
 /// Resolve an asset id to its metadata: request-scoped override layer first
-/// (via the registry), then the compiled-in seed table.
+/// (via the registry), then the compiled-in seed table, then -- for an MT
+/// asset naming a known NEP-141 balance -- that asset's own entry in either.
 pub(crate) fn resolve(
     asset_id: &str,
     registry: &LayeredRegistry<NearTokenRegistry>,
@@ -133,7 +155,7 @@ pub(crate) fn resolve(
     if let Some(meta) = registry.lookup(|r| r.by_asset_id.get(asset_id).cloned()) {
         return usable(meta);
     }
-    SEEDS
+    if let Some(meta) = SEEDS
         .iter()
         .find(|(id, _, _)| *id == asset_id)
         .map(|(_, symbol, decimals)| TokenMeta {
@@ -142,6 +164,10 @@ pub(crate) fn resolve(
             provenance: super::TokenProvenance::Seed,
         })
         .and_then(usable)
+    {
+        return Some(meta);
+    }
+    resolve(&mt_underlying_nep141(asset_id)?, registry)
 }
 
 /// Format `units / 10^decimals` as an exact decimal string, trailing zeros
@@ -193,6 +219,74 @@ mod tests {
     #[test]
     fn unknown_token_is_none() {
         assert!(resolve("nep141:not-a-real-token.near", &empty()).is_none());
+    }
+
+    /// The convention `defuse-core`'s own cross-instance MT transfer tests
+    /// exercise: a defuse-style contract represents a NEP-141 balance it
+    /// holds as a multi-token whose token_id is that asset's own `TokenId`
+    /// string. An MT asset naming a seeded NEP-141 balance this way must
+    /// resolve to that balance's metadata, not sit unresolved just because
+    /// nothing is keyed under the `nep245:...` string itself.
+    #[test]
+    fn mt_asset_wrapping_a_seeded_nep141_balance_resolves() {
+        let meta = resolve("nep245:defuse.near:nep141:wrap.near", &empty()).expect("resolves");
+        assert_eq!(meta.symbol, "wNEAR");
+        assert_eq!(meta.decimals, 24);
+    }
+
+    /// An independent NEP-245 contract's own token_id convention has no
+    /// reason to parse as a `TokenId` at all, so it must not resolve --
+    /// falling through to the honest unresolved form, same as any other
+    /// unseeded asset.
+    #[test]
+    fn mt_asset_with_an_opaque_token_id_is_none() {
+        assert!(resolve("nep245:market.near:gold-sword-42", &empty()).is_none());
+    }
+
+    /// The inner id parses, but not as NEP-141 -- an NFT or a nested
+    /// multi-token has no fungible decimals/symbol to borrow, so this must
+    /// not resolve either, rather than misreading `Nep171`/`Nep245` data as
+    /// if it were an amount.
+    #[test]
+    fn mt_asset_wrapping_a_non_nep141_kind_is_none() {
+        assert!(resolve("nep245:defuse.near:nep171:nft.near:1", &empty()).is_none());
+    }
+
+    /// A registry override keyed by the exact MT asset id must win over the
+    /// underlying NEP-141's metadata -- the same "specific beats borrowed"
+    /// precedence the direct-key/`SEEDS` ordering already has.
+    #[test]
+    fn mt_specific_override_beats_the_underlying_nep141() {
+        let asset_id = "nep245:defuse.near:nep141:wrap.near";
+        let mut request = NearTokenRegistry::default();
+        request.by_asset_id.insert(
+            asset_id.to_string(),
+            TokenMeta {
+                symbol: "WRAPPED-NEAR-SHARE".to_string(),
+                decimals: 8,
+                provenance: TokenProvenance::Unsigned,
+            },
+        );
+        let registry =
+            LayeredRegistry::with_request(Arc::new(NearTokenRegistry::default()), request);
+        let meta = resolve(asset_id, &registry).expect("resolves");
+        assert_eq!(meta.symbol, "WRAPPED-NEAR-SHARE");
+        assert_eq!(meta.decimals, 8);
+    }
+
+    /// The gap-fill rule an unattributed override must respect
+    /// (`token_signature.rs`) checks `seeded_decimals` to decide whether an
+    /// asset is already curated. An MT asset wrapping a seeded NEP-141
+    /// balance must read as covered too, or an unattributed entry could
+    /// smuggle in the wrong decimals for it despite the underlying balance
+    /// being protected.
+    #[test]
+    fn seeded_decimals_sees_through_the_mt_alias() {
+        assert_eq!(
+            seeded_decimals("nep245:defuse.near:nep141:wrap.near"),
+            Some(24)
+        );
+        assert_eq!(seeded_decimals("nep245:market.near:gold-sword-42"), None);
     }
 
     // `format_units` scales by `10^decimals`, which overflows `u128` above 38.

--- a/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
+++ b/src/chain_parsers/visualsign-near/src/presets/intents/tokens.rs
@@ -115,22 +115,31 @@ fn usable(meta: TokenMeta) -> Option<TokenMeta> {
     (meta.decimals <= MAX_DECIMALS).then_some(meta)
 }
 
-/// If `asset_id` is `nep245:<contract>:<mt_token_id>` and `mt_token_id`
-/// itself round-trips as a NEP-141 [`TokenId`] -- the convention a
-/// defuse-style contract uses when it represents one of its own held NEP-141
-/// balances as a multi-token, e.g. `nep245:defuse.near:nep141:wrap.near`
-/// (exercised by `defuse-core`'s own cross-instance MT transfer tests) --
-/// returns that inner asset id so its already-curated metadata can be
-/// borrowed. An independent NEP-245 contract's own token_id convention, or an
+/// If `asset_id` is `nep245:<contract>:<mt_token_id>`, `contract` is the
+/// trusted intents verifier itself ([`INTENTS_RECEIVER`]), and `mt_token_id`
+/// round-trips as a NEP-141 [`TokenId`] -- the convention that contract uses
+/// when it represents one of its own held NEP-141 balances as a multi-token,
+/// e.g. `nep245:intents.near:nep141:wrap.near` (exercised by `defuse-core`'s
+/// own cross-instance MT transfer tests) -- returns that inner asset id so
+/// its already-curated metadata can be borrowed.
+///
+/// `mt_token_id` is a plain string fully controlled by whoever deployed
+/// `contract`, so it cannot itself prove which contract minted it: an
+/// unrelated NEP-245 deployment can mint a `token_id` that spells
+/// `nep141:wrap.near` just as easily as `intents.near` can. Binding to
+/// `INTENTS_RECEIVER` is what makes the borrow trustworthy -- without it, any
+/// deployer could borrow a seeded asset's symbol/decimals for their own
+/// contract's balance. A `contract` other than `INTENTS_RECEIVER`, or an
 /// inner id that isn't NEP-141 (an NFT, or a nested multi-token), does not
-/// match and returns `None`, leaving the amount unresolved exactly as it does
-/// today. `contract` is a NEAR account id, which cannot itself contain `:`, so
-/// splitting on the first `:` after the `nep245:` prefix cannot mistake part
-/// of `mt_token_id` for it even though `mt_token_id` may contain further `:`s.
+/// match and returns `None`, leaving the amount unresolved. `contract` is a
+/// NEAR account id, which cannot itself contain `:`, so splitting on the
+/// first `:` after the `nep245:` prefix cannot mistake part of `mt_token_id`
+/// for it even though `mt_token_id` may contain further `:`s.
 fn mt_underlying_nep141(asset_id: &str) -> Option<String> {
-    let mt_token_id = asset_id.strip_prefix("nep245:")?.split_once(':')?.1;
-    matches!(mt_token_id.parse::<TokenId>(), Ok(TokenId::Nep141(_)))
-        .then(|| mt_token_id.to_string())
+    let (contract, mt_token_id) = asset_id.strip_prefix("nep245:")?.split_once(':')?;
+    (contract == crate::convert::INTENTS_RECEIVER
+        && matches!(mt_token_id.parse::<TokenId>(), Ok(TokenId::Nep141(_))))
+    .then(|| mt_token_id.to_string())
 }
 
 /// The curated `decimals` for `asset_id`, or `None` when [`SEEDS`] does not
@@ -222,14 +231,14 @@ mod tests {
     }
 
     /// The convention `defuse-core`'s own cross-instance MT transfer tests
-    /// exercise: a defuse-style contract represents a NEP-141 balance it
-    /// holds as a multi-token whose token_id is that asset's own `TokenId`
-    /// string. An MT asset naming a seeded NEP-141 balance this way must
-    /// resolve to that balance's metadata, not sit unresolved just because
-    /// nothing is keyed under the `nep245:...` string itself.
+    /// exercise: the intents verifier contract represents a NEP-141 balance
+    /// it holds as a multi-token whose token_id is that asset's own
+    /// `TokenId` string. An MT asset naming a seeded NEP-141 balance this way
+    /// must resolve to that balance's metadata, not sit unresolved just
+    /// because nothing is keyed under the `nep245:...` string itself.
     #[test]
     fn mt_asset_wrapping_a_seeded_nep141_balance_resolves() {
-        let meta = resolve("nep245:defuse.near:nep141:wrap.near", &empty()).expect("resolves");
+        let meta = resolve("nep245:intents.near:nep141:wrap.near", &empty()).expect("resolves");
         assert_eq!(meta.symbol, "wNEAR");
         assert_eq!(meta.decimals, 24);
     }
@@ -249,7 +258,20 @@ mod tests {
     /// if it were an amount.
     #[test]
     fn mt_asset_wrapping_a_non_nep141_kind_is_none() {
-        assert!(resolve("nep245:defuse.near:nep171:nft.near:1", &empty()).is_none());
+        assert!(resolve("nep245:intents.near:nep171:nft.near:1", &empty()).is_none());
+    }
+
+    /// The inner id round-trips as a seeded NEP-141 balance, but `contract`
+    /// is not the trusted intents verifier -- an attacker who deploys their
+    /// own NEP-245 contract can mint a `token_id` that spells
+    /// `nep141:wrap.near` just as easily as `intents.near` can, so this must
+    /// not resolve. Without this check, the borrowed wNEAR symbol/decimals
+    /// would apply to a balance an unrelated, unverified contract claims to
+    /// hold.
+    #[test]
+    fn mt_asset_on_an_untrusted_contract_is_none_even_with_a_seeded_inner_id() {
+        assert!(resolve("nep245:evil.near:nep141:wrap.near", &empty()).is_none());
+        assert_eq!(seeded_decimals("nep245:evil.near:nep141:wrap.near"), None);
     }
 
     /// A registry override keyed by the exact MT asset id must win over the
@@ -257,7 +279,7 @@ mod tests {
     /// precedence the direct-key/`SEEDS` ordering already has.
     #[test]
     fn mt_specific_override_beats_the_underlying_nep141() {
-        let asset_id = "nep245:defuse.near:nep141:wrap.near";
+        let asset_id = "nep245:intents.near:nep141:wrap.near";
         let mut request = NearTokenRegistry::default();
         request.by_asset_id.insert(
             asset_id.to_string(),
@@ -283,7 +305,7 @@ mod tests {
     #[test]
     fn seeded_decimals_sees_through_the_mt_alias() {
         assert_eq!(
-            seeded_decimals("nep245:defuse.near:nep141:wrap.near"),
+            seeded_decimals("nep245:intents.near:nep141:wrap.near"),
             Some(24)
         );
         assert_eq!(seeded_decimals("nep245:market.near:gold-sword-42"), None);


### PR DESCRIPTION
`mt_withdraw` renders every `token_id` as raw base units with no symbol or decimal scaling, unlike its `ft_withdraw`/`transfer`/`token_diff` siblings, which resolve through the token registry. Of the eleven `Intent` kinds, only those three consulted it -- `mt_withdraw` was the odd one out, not a deliberate omission.

## Why it can resolve at all

NEP-245's `token_id` is a fully opaque string (`defuse_nep245::TokenId = String`) -- nothing in the standard lets an arbitrary id be traced back to an underlying asset. `defuse-core`'s own cross-instance MT transfer tests (`tests/src/tests/defuse/tokens/nep245/mod.rs`) exercise a real, code-verified convention: the intents verifier contract represents one of its own held NEP-141 balances as a multi-token by setting `mt_token_id` to that balance's own `TokenId` string verbatim, e.g. `nep245:intents.near:nep141:wrap.near`.

`tokens::mt_underlying_nep141` recognizes exactly this, and only this: it requires the outer `contract` to be `INTENTS_RECEIVER` (`intents.near`) *and* the inner id to parse as `TokenId::Nep141`. The contract check is load-bearing -- `mt_token_id` is a plain string fully controlled by whoever deploys `contract`, so an independent NEP-245 contract could otherwise mint a `token_id` that spells `nep141:wrap.near` and borrow that seeded asset's symbol/decimals for a balance it has no relationship to. Binding to the trusted verifier contract is what makes the borrow self-verifying; the inner id's spelling alone cannot be.

## What changed

- `render_mt_withdraw` builds the same `nep245:<contract>:<token_id>` asset id `TokenDiff`/`Transfer` already produce for an MT entry in their maps, and resolves it through the identical `token_amount_field`/`tokens::resolve` path. No new registry type, no curated table -- it reuses the existing NEP-141 registry/`SEEDS`/signed-metadata machinery entirely.
- `intent_consumes_token_registry`'s `MtWithdraw` arm flips to `true`, so a standalone envelope containing only an `mt_withdraw` now builds the registry too.
- `tokens::seeded_decimals` (the gap-fill check `try_extract_from_chain_metadata` uses to refuse an unattributed override against an already-curated asset) gains the same fallback. Without it, an MT id wrapping a seeded NEP-141 balance would have been exempt from the gap-fill rule even though its direct key is protected -- an unattributed entry could smuggle in the wrong decimals through the MT-shaped key alone.
- `mt_underlying_nep141` binds the alias to `INTENTS_RECEIVER` rather than trusting the inner id's spelling alone.

## Tests

- `tokens.rs`: MT-wraps-a-seeded-balance resolves on the trusted contract; an opaque/unrelated MT token_id doesn't; an inner id that parses but isn't NEP-141 (NFT, nested MT) doesn't; an untrusted contract paired with a seeded-looking inner id doesn't; a registry override keyed by the exact MT asset id wins over the underlying's metadata; `seeded_decimals` sees through the alias.
- `render.rs`: an `mt_withdraw` naming a wrapped `wrap.near` balance on the trusted contract renders a resolved `AmountV2`; one naming an unrelated token_id, or an untrusted contract with a seeded-looking token_id, renders the honest unresolved text; a `token_diff` entry keyed by an untrusted-contract MT id (the shape with no contract visible on screen at all) renders unresolved too.
- `convert.rs`: added to the gate/dispatch parity table (`every_intent_kind_the_registry_gate_recognizes_matches_render_intent`).
- `token_signature.rs`: an unsigned entry keyed by an MT asset wrapping a seeded balance on the trusted contract is rejected by the gap-fill rule, mirroring the existing direct-key regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)