### PR TITLE
ci(cli): run parser_cli's narrow feature builds, publish it as a release asset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,3 +62,5 @@ jobs:
         run: make -C src test
       - name: Check parser_app narrow feature builds
         run: make -C src narrow-build-check
+      - name: Check parser_cli narrow feature builds
+        run: make -C src parser-cli-narrow-build-check

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -137,12 +137,15 @@ jobs:
       - name: Upload CLI binary to release
         # parser_cli is also usable standalone (no Docker required), so
         # attach the static binary we already built as a release asset
-        # alongside the OCI image. Only meaningful on a release build --
-        # SEMVER_TAG is empty for PR/branch builds, and (per the TVC step's
-        # comment above) a push-to-main run can compute a SEMVER_TAG before
-        # release.yml has actually created that release, so this is a no-op
-        # in that race; the tag-dispatched stagex run created afterward
-        # picks it up.
+        # alongside the OCI image. images/parser_cli/Containerfile builds
+        # this image with only `--features solana` (see the "parser_cli
+        # (Solana)" matrix label above), so the asset name says so rather
+        # than implying it covers every chain parser_cli can be built with.
+        # Only meaningful on a release build -- SEMVER_TAG is empty for
+        # PR/branch builds, and (per the TVC step's comment above) a
+        # push-to-main run can compute a SEMVER_TAG before release.yml has
+        # actually created that release, so this is a no-op in that race;
+        # the tag-dispatched stagex run created afterward picks it up.
         if: matrix.target.name == 'parser_cli' && steps.build.outputs.semver_tag != ''
         env:
           SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
@@ -153,7 +156,7 @@ jobs:
             exit 0
           fi
           docker create --name tmp-extract-cli "ghcr.io/anchorageoss/parser_cli:${SEMVER_TAG}" /bin/true
-          asset="parser_cli-${SEMVER_TAG}-x86_64-unknown-linux-musl"
+          asset="parser_cli-solana-${SEMVER_TAG}-x86_64-unknown-linux-musl"
           docker cp tmp-extract-cli:/usr/local/bin/parser_cli "$asset"
           docker rm tmp-extract-cli
           gh release upload "$SEMVER_TAG" "$asset" --clobber --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -134,6 +134,30 @@ jobs:
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
 
+      - name: Upload CLI binary to release
+        # parser_cli is also usable standalone (no Docker required), so
+        # attach the static binary we already built as a release asset
+        # alongside the OCI image. Only meaningful on a release build --
+        # SEMVER_TAG is empty for PR/branch builds, and (per the TVC step's
+        # comment above) a push-to-main run can compute a SEMVER_TAG before
+        # release.yml has actually created that release, so this is a no-op
+        # in that race; the tag-dispatched stagex run created afterward
+        # picks it up.
+        if: matrix.target.name == 'parser_cli' && steps.build.outputs.semver_tag != ''
+        env:
+          SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$SEMVER_TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "No release $SEMVER_TAG yet; skipping CLI binary upload."
+            exit 0
+          fi
+          docker create --name tmp-extract-cli "ghcr.io/anchorageoss/parser_cli:${SEMVER_TAG}" /bin/true
+          asset="parser_cli-${SEMVER_TAG}-x86_64-unknown-linux-musl"
+          docker cp tmp-extract-cli:/usr/local/bin/parser_cli "$asset"
+          docker rm tmp-extract-cli
+          gh release upload "$SEMVER_TAG" "$asset" --clobber --repo "${GITHUB_REPOSITORY}"
+
       - name: TVC deployment details
         if: matrix.target.name == 'parser_app'
         shell: bash

--- a/src/Makefile
+++ b/src/Makefile
@@ -126,9 +126,11 @@ parser-cli-narrow-build-check:
 	@# compiled binary panicking or misbehaving against real fixtures
 	@# (tests/cli_test.rs runs CARGO_BIN_EXE_parser_cli end to end), not
 	@# just a compile error.
+	@# `--locked`: matches the release container's flags and keeps this
+	@# check from silently updating Cargo.lock instead of failing.
 	@set -e; for c in $(PARSER_CLI_CHAINS); do \
 		echo "==> parser_cli --features $$c"; \
-		cargo test -p parser_cli --no-default-features --features $$c --all-targets; \
+		cargo test -p parser_cli --locked --no-default-features --features $$c --all-targets; \
 	done
 
 .PHONY: dev-signing-absent-check

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,12 @@ ROOT := $(shell git rev-parse --show-toplevel)
 # the PR that introduces it -- which is the right place to catch it.
 PARSER_APP_CHAINS := $(sort $(patsubst visualsign-%,%,$(notdir $(wildcard chain_parsers/visualsign-*))))
 
+# Chains parser_cli can be built with. Unlike PARSER_APP_CHAINS this is not
+# derived from chain_parsers/* -- parser_cli only wires up chains that have a
+# ChainPlugin registered (see parser/cli/src/), which sui and unspecified
+# don't yet, so a subset is the actual rule and a literal list says so.
+PARSER_CLI_CHAINS := ethereum near solana tron
+
 .PHONY: all
 all: generated
 	make build
@@ -104,6 +110,26 @@ narrow-build-check:
 		cargo clippy -p parser_app --no-default-features --features $$c --all-targets -- -D warnings; \
 	done
 	make dev-signing-absent-check
+
+.PHONY: parser-cli-narrow-build-check
+parser-cli-narrow-build-check:
+	@# parser_cli's own release artifact (images/parser_cli/Containerfile)
+	@# builds it with only one chain feature enabled (e.g. --features
+	@# solana) -- a configuration `make test` never exercises, since that
+	@# always builds and tests parser_cli with every default feature on.
+	@# A dependency left unconditional in a chain crate, but gated only
+	@# behind that crate's own default features, compiles fine there and
+	@# breaks silently in this narrower build until someone builds the
+	@# release image (e.g. bs58 in visualsign-solana).
+	@#
+	@# `cargo test`, not `check`: the failure mode of interest is the
+	@# compiled binary panicking or misbehaving against real fixtures
+	@# (tests/cli_test.rs runs CARGO_BIN_EXE_parser_cli end to end), not
+	@# just a compile error.
+	@set -e; for c in $(PARSER_CLI_CHAINS); do \
+		echo "==> parser_cli --features $$c"; \
+		cargo test -p parser_cli --no-default-features --features $$c --all-targets; \
+	done
 
 .PHONY: dev-signing-absent-check
 dev-signing-absent-check:

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -1,4 +1,18 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// Helpers and per-chain fixtures below are shared across this file's tests,
+// so building with only one chain feature (as parser-cli-narrow-build-check
+// in the Makefile does) leaves whatever the other chains' tests alone use
+// genuinely dead. Only enforce dead-code/unused-import lints when every
+// chain feature is on -- the configuration where everything here is used.
+#![cfg_attr(
+    not(all(
+        feature = "ethereum",
+        feature = "solana",
+        feature = "near",
+        feature = "tron"
+    )),
+    allow(dead_code, unused_imports)
+)]
 use parser_cli_core::test_utils::write_temp_json;
 use similar::{ChangeTag, TextDiff};
 use std::fs;


### PR DESCRIPTION
## Summary
1. Adds `make -C src parser-cli-narrow-build-check` (wired into `main.yml` on every PR): builds and runs `parser_cli`'s test suite once per chain feature (`--no-default-features --features <chain>`), the same shape of build `images/parser_cli/Containerfile` ships. `make test` only ever exercises `parser_cli` with every default feature on, so a dependency left unconditional in a chain crate but gated behind that crate's own default features — as `bs58` was in `visualsign-solana` until `be20bcb5` — compiles fine there and only breaks in the narrower release build. This mirrors the existing `narrow-build-check` pattern for `parser_app`.
2. Since `stagex.yml` already builds that exact release binary to catch this class of bug, also attach it to the GitHub Release as a downloadable asset (`parser_cli-<tag>-x86_64-unknown-linux-musl`) alongside the OCI image, so it's usable without Docker.

Closes #477.

## Test plan
- [x] `cargo test -p parser_cli --no-default-features --features {solana,ethereum,near,tron} --all-targets` all pass locally (validated the new Makefile target directly)
- [x] `cargo fmt --check` clean
- [x] Both edited workflow YAML files parse (`yaml.safe_load`)
- [ ] CI on this PR: `main.yml`'s new step runs on every PR by default (no label needed); `stagex.yml`'s new step only exercises on an actual release build, so it can't be exercised from a PR — reviewed by code inspection against the existing TVC-deployment-details step's release-race handling, which it mirrors