### PR TITLE
test(parser_app): guard the dev Makefile target against argument drift

### DIFF
--- a/src/parser/app/src/cli.rs
+++ b/src/parser/app/src/cli.rs
@@ -273,4 +273,120 @@ mod tests {
         let opts = parse(&["--accept-unsigned-abis"]).expect("valid args");
         assert_eq!(opts.host_addr().to_string(), "127.0.0.1:3000");
     }
+
+    /// Extract one target's recipe arguments from a Makefile, as the shell would
+    /// receive them after `cargo run --bin <x> --`.
+    ///
+    /// Deliberately simple: find the target line, take the tab-indented recipe
+    /// lines under it, drop everything through the `--` that separates cargo's own
+    /// arguments from the binary's, and substitute `$(VAR)` references. It does not
+    /// try to be `make` -- if the recipe ever grows conditionals or a `$(shell ...)`
+    /// call this stops reflecting reality, which is what the structural assertions
+    /// in the caller are there to catch: they fail on an unreadable recipe rather
+    /// than letting an empty argument list parse cleanly and prove nothing.
+    fn makefile_target_args(makefile: &str, target: &str) -> Vec<String> {
+        let mut recipe = String::new();
+        let mut in_target = false;
+        for line in makefile.lines() {
+            if in_target {
+                // The recipe ends at the first line that is not tab-indented.
+                let Some(body) = line.strip_prefix('\t') else {
+                    break;
+                };
+                recipe.push(' ');
+                recipe.push_str(body.trim_end().trim_end_matches('\\'));
+            } else if line.starts_with(&format!("{target}:")) {
+                in_target = true;
+            }
+        }
+
+        // `--` separates cargo's arguments from the binary's; everything before it
+        // (`cargo run --bin parser_app`) is not the binary's argv.
+        let after_separator = recipe
+            .split_whitespace()
+            .skip_while(|token| *token != "--")
+            .skip(1);
+
+        after_separator.map(substitute_make_vars).collect()
+    }
+
+    /// Replace every `$(VAR)` in one token with a value the CLI will accept. The
+    /// two that have to look real are the ones `host_addr()` parses; anything else
+    /// is only carried as an opaque string.
+    fn substitute_make_vars(token: &str) -> String {
+        let mut out = String::with_capacity(token.len());
+        let mut rest = token;
+        while let Some(start) = rest.find("$(") {
+            out.push_str(&rest[..start]);
+            let after = &rest[start + 2..];
+            let Some(end) = after.find(')') else {
+                // Unbalanced `$(`: leave it verbatim rather than guessing, so the
+                // caller's parse fails loudly instead of on a silently mangled arg.
+                break;
+            };
+            out.push_str(match &after[..end] {
+                "PARSER_HOST" => "127.0.0.1",
+                "PARSER_PORT" => "3000",
+                _ => "placeholder",
+            });
+            rest = &after[end + 1..];
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// Guards `make -C src parser_app` against argument drift in either direction.
+    ///
+    /// Nothing in CI runs the dev `make` targets -- `make {generated,lint,test,
+    /// narrow-build-check}` is the whole of it -- so an argument this CLI stops
+    /// accepting leaves the target broken with every check green. That is not
+    /// hypothetical: the target passed `--usock` for some time after the flag was
+    /// replaced by `--host-ip`/`--host-port`, and panicked before reaching any of
+    /// the flags this module's other tests cover.
+    ///
+    /// Feeding the Makefile's own arguments to the real parser catches both
+    /// directions: a flag removed from the CLI, and a stale flag left in the
+    /// Makefile. `include_str!` makes the Makefile a compile-time dependency, so
+    /// moving or renaming it is a build failure rather than a test that quietly
+    /// stops checking anything.
+    #[test]
+    fn the_makefile_dev_target_args_are_accepted_by_this_cli() {
+        let makefile = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../Makefile"));
+        let args = makefile_target_args(makefile, "parser_app");
+
+        // A recipe this extractor cannot read would make the parse below vacuous:
+        // an empty argument list parses fine and proves nothing. Pin only the
+        // structure -- some arguments, at least one of them a flag -- and
+        // deliberately not *which* flags, so a legitimate rename does not fail
+        // here with a misleading "the extractor broke" message instead of
+        // reaching the parse that is the actual subject of this test.
+        assert!(
+            !args.is_empty(),
+            "extracted no arguments from the parser_app target; the recipe shape \
+             changed and this guard is no longer reading it"
+        );
+        assert!(
+            args.iter().any(|arg| arg.starts_with("--")),
+            "extracted no flags from the parser_app target, only {args:?}; the \
+             recipe shape changed and this guard is no longer reading it"
+        );
+
+        // `OptionsParser` skips the leading program name, as it does for real argv.
+        let mut with_program_name = vec!["parser_app".to_string()];
+        with_program_name.extend(args.iter().cloned());
+        let parsed =
+            OptionsParser::<ParserParser>::parse(&mut with_program_name).unwrap_or_else(|e| {
+                panic!(
+                    "`make -C src parser_app` passes arguments this CLI rejects, so the \
+                 target cannot start: {e:?}. Extracted args: {args:?}"
+                )
+            });
+
+        // Parsing alone would still pass if the target lost its posture flag, which
+        // `Cli::execute` refuses to start without. Resolve it too, so the guard
+        // covers the whole startup path the target actually takes.
+        ParserOpts { parsed }
+            .abi_trust()
+            .unwrap_or_else(|e| panic!("the parser_app target states no usable ABI posture: {e}"));
+    }
 }


### PR DESCRIPTION
## Why

Nothing in CI runs the dev `make` targets. The `ubuntu` job is `make -C src generated`, `lint`, `test`, `narrow-build-check` — so an argument `parser_app`'s CLI stops accepting leaves `make -C src parser_app` broken with every check green.

That is not hypothetical. The target passed `--usock` for some time after `751118bd` replaced it with `--host-ip`/`--host-port`, and panicked before reaching any flag the existing `cli.rs` tests cover:

```
thread 'main' panicked at parser/app/src/cli.rs:31:33:
Parser: invalid CLI args: found --usock, which was not an expected argument
```

It took someone running the target by hand to find (#454), and then a rebase reintroduced it on another branch (#450). Twice, silently, because no automated check looks.

## What

One test, `parser_app`'s `cli.rs`. It extracts the `parser_app` target's recipe arguments from `src/Makefile`, substitutes `$(VAR)` references, and feeds them to the real `OptionsParser::<ParserParser>` — so it catches drift from either side: a flag removed from the CLI, or a stale flag left in the recipe.

It then resolves the ABI trust posture too. Parsing alone would still pass a target that had lost `--accept-unsigned-abis`, which `Cli::execute` refuses to start without.

Two deliberate choices worth flagging for review:

- **`include_str!` rather than a runtime read**, so the Makefile is a compile-time dependency. Moving or renaming it is a build failure, not a guard that quietly stops checking anything.
- **The structural assertions pin only "some arguments, at least one a flag" — not *which* flags.** They exist because an unreadable recipe yields an empty argument list, which parses cleanly and proves nothing. Pinning specific flag names instead would make a legitimate rename fail with a misleading "the extractor broke" message *before* reaching the parse. I wrote it that way first and it misdiagnosed the `--usock` case, so the ordering here is deliberate: parse first, and let the failure name the offending argument.

## Scope

`parser_app` only, deliberately. Of the five dev run targets, `grpc-server` and `parser_gateway` pass no arguments, `parser_enclave` passes positionals, and `parser_host` is qos_core's binary whose CLI is not ours to test. `parser_app` is the only one with flags this repo owns, and the only one that has actually rotted.

## Verification

Mutated the recipe locally to confirm the guard fails for the right reason in each direction, rather than only that it passes as written:

| Recipe state | Result |
|---|---|
| as written | passes |
| `--usock` restored | fails: `UnexpectedInput("--usock")`, naming the argument |
| `--accept-unsigned-abis` dropped | fails on the posture check |
| target renamed out from under it | fails structurally, not vacuously |

`make -C src fmt`, `lint` (including `-p parser_app --no-default-features`, so `narrow-build-check` is unaffected) and `test` (39 suites, 1674 tests, 0 failures) all green.

## Base

Stacked on #454 because that PR carries the `--usock` fix; on `main` this guard would correctly fail, since `main`'s target still has the broken flag. GitHub will retarget this to `main` when #454 merges. #454's own approval is untouched — this is a child branch, not a push to `prs-556-parser-app`.
