### PR TITLE
fix(cli): keep the display fixtures diagnostics-agnostic in narrow builds

### DIFF
--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -121,15 +121,24 @@ fn test_cli_with_fixtures() {
         // Try JSON parsing; fall back to string comparison for text/human output
         match serde_json::from_str::<serde_json::Value>(actual_output.trim()) {
             Ok(actual_json) => {
-                // JSON output: filter diagnostics and check membership
-                #[cfg_attr(not(feature = "diagnostics"), allow(unused_mut))]
+                // JSON output: filter diagnostics and check membership.
+                //
+                // Diagnostics reach the payload in one of two shapes depending
+                // on the `diagnostics` feature, and the display fixtures pin
+                // neither: with the feature on a diagnostic is its own
+                // `diagnostic` field, with it off the renderer degrades it to a
+                // `text_v2` field labelled "Warning" (see visualsign-near's
+                // `presets::intents::render::diagnostic`). Dropping both keeps
+                // one display fixture valid in every feature configuration --
+                // including the single-chain builds
+                // `parser-cli-narrow-build-check` runs, where `diagnostics` is
+                // off because `--no-default-features` excludes it.
                 let mut display_payload = actual_json.clone();
-                #[cfg(feature = "diagnostics")]
                 if let Some(fields) = display_payload
                     .get_mut("Fields")
                     .and_then(|f| f.as_array_mut())
                 {
-                    fields.retain(|f| f.get("Type").and_then(|t| t.as_str()) != Some("diagnostic"));
+                    fields.retain(|f| !is_diagnostic_field(f));
                 }
 
                 let expected_json: serde_json::Value =
@@ -327,6 +336,20 @@ fn assert_strings_match(test_name: &str, fixture_type: &str, expected: &str, act
 
         panic!("Test case '{test_name}' ({fixture_type}) failed:\n{diff_output}");
     }
+}
+
+/// Is this payload field a rendered diagnostic rather than transaction content?
+///
+/// Both renderings count: the `diagnostic` field type the `diagnostics` feature
+/// produces, and the "Warning" `text_v2` field a renderer degrades to when the
+/// feature is off. Display fixtures describe transaction content only, so both
+/// are filtered before comparing.
+fn is_diagnostic_field(field: &serde_json::Value) -> bool {
+    let field_type = field.get("Type").and_then(|t| t.as_str());
+    if field_type == Some("diagnostic") {
+        return true;
+    }
+    field_type == Some("text_v2") && field.get("Label").and_then(|l| l.as_str()) == Some("Warning")
 }
 
 /// Recursively checks that every field in `expected` is present in `actual`.

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -344,12 +344,71 @@ fn assert_strings_match(test_name: &str, fixture_type: &str, expected: &str, act
 /// produces, and the "Warning" `text_v2` field a renderer degrades to when the
 /// feature is off. Display fixtures describe transaction content only, so both
 /// are filtered before comparing.
+///
+/// The degraded rendering is matched on the label *and* the `<rule>: <message>`
+/// text shape it is built with, not on the label alone -- a chain is free to
+/// label real transaction content "Warning", and dropping such a field would
+/// quietly stop the fixture pinning it. Erring narrow is the safe direction: a
+/// diagnostic this misses fails the comparison loudly, whereas content this
+/// wrongly drops goes unnoticed. Mirrors visualsign-near's own
+/// `presets::intents` test helper, which pairs the label with the rule prefix.
 fn is_diagnostic_field(field: &serde_json::Value) -> bool {
     let field_type = field.get("Type").and_then(|t| t.as_str());
     if field_type == Some("diagnostic") {
         return true;
     }
-    field_type == Some("text_v2") && field.get("Label").and_then(|l| l.as_str()) == Some("Warning")
+    if field_type != Some("text_v2")
+        || field.get("Label").and_then(|l| l.as_str()) != Some("Warning")
+    {
+        return false;
+    }
+    field
+        .get("TextV2")
+        .and_then(|t| t.get("Text"))
+        .and_then(|t| t.as_str())
+        .is_some_and(has_rule_prefix)
+}
+
+/// Does `text` carry the `<rule>: <message>` shape a degraded diagnostic is
+/// formatted with?
+///
+/// `rule` is a bare literal at every call site (`deadline`,
+/// `rejected-token-metadata`), so it never contains whitespace; a message that
+/// happens to contain ": " later on cannot be mistaken for the separator,
+/// since only the first one is considered.
+fn has_rule_prefix(text: &str) -> bool {
+    text.split_once(": ").is_some_and(|(rule, message)| {
+        !rule.is_empty() && !rule.contains(char::is_whitespace) && !message.is_empty()
+    })
+}
+
+#[test]
+fn is_diagnostic_field_matches_both_renderings_but_not_warning_content() {
+    let diagnostic = serde_json::json!({ "Type": "diagnostic", "Label": "Deadline" });
+    assert!(is_diagnostic_field(&diagnostic));
+
+    let degraded = serde_json::json!({
+        "Type": "text_v2",
+        "Label": "Warning",
+        "TextV2": { "Text": "deadline: deadline has passed; the intents would be rejected" },
+    });
+    assert!(is_diagnostic_field(&degraded));
+
+    // A chain labelling real content "Warning" must still be pinned by the
+    // fixture -- no rule prefix, so it is not a degraded diagnostic.
+    let content = serde_json::json!({
+        "Type": "text_v2",
+        "Label": "Warning",
+        "TextV2": { "Text": "this transfer cannot be reversed" },
+    });
+    assert!(!is_diagnostic_field(&content));
+
+    let ordinary = serde_json::json!({
+        "Type": "text_v2",
+        "Label": "To",
+        "TextV2": { "Text": "bob.near" },
+    });
+    assert!(!is_diagnostic_field(&ordinary));
 }
 
 /// Recursively checks that every field in `expected` is present in `actual`.


### PR DESCRIPTION
## `main` is red

`parser-cli-narrow-build-check` fails on the `near` chain at `main` @ `5f44ab68`:

```
==> parser_cli --features near
test test_cli_with_fixtures ... FAILED
thread 'test_cli_with_fixtures' panicked at parser/cli/tests/cli_test.rs:357:13:
assertion `left == right` failed: Test 'near-json': array length mismatch at 'Fields'
  left: 8
 right: 9
make: *** [Makefile:135: parser-cli-narrow-build-check] Error 101
```

Nobody broke it: #480 added the narrow check at 13:36:40 and #459 merged at 13:27:17 — nine minutes apart, so neither PR's CI ever ran against the other, and both were green on their own branch.

## Cause

A diagnostic reaches the payload in one of two shapes:

| `diagnostics` feature | shape |
|---|---|
| on | its own `diagnostic` field |
| off | a `text_v2` field labelled `"Warning"` (`visualsign-near`'s `presets::intents::render::diagnostic`) |

`near-json.display.expected` pins neither — it describes transaction content — but the test filtered only the first shape, and did so behind `#[cfg(feature = "diagnostics")]`. `parser-cli-narrow-build-check` builds `--no-default-features --features <chain>`, which excludes `diagnostics`, so the fixture met the degraded Warning field with no filter in front of it:

```
5 text_v2 | Warning | deadline: deadline has passed; the intents would be rejected   <-- the 9th field
```

NEAR is the only chain that degrades a diagnostic this way, which is why only `near-json` fails. Note this configuration is not hypothetical — `images/parser_cli/Containerfile` ships `--no-default-features --features solana`, so diagnostics-off is a real shipped build; it just skips the NEAR fixture.

## Fix

Filter both shapes, unconditionally, so one display fixture stays valid in every feature configuration. `visualsign-near`'s own `presets/intents/mod.rs:221` already identifies the degraded rendering the same way (label `"Warning"` plus the rule prefix), so this matches existing practice rather than inventing a heuristic.

## Verification

- All four chains of `make parser-cli-narrow-build-check` pass (`ethereum`, `near`, `solana`, `tron`).
- `make lint` clean; `make test` green — 43 suites, 2187 tests, 0 failures.
- **The fixture check is not made vacuous.** With the fix in place, mutating `near-json.display.expected` still fails: changing a content value fails on `Fields[6].FallbackText`, and removing a content field fails on array length. Only the diagnostic shapes are filtered.

## Not changed

The non-JSON (`{:#?}`) branch strips `Diagnostic { ... }` blocks under the same `#[cfg]`, so it carries the same latent gap. No chain that degrades diagnostics has a text fixture today, so there is nothing to reproduce against — left alone rather than fixed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)