### PR TITLE
fix(near): recognize the Warning-labelled diagnostic fallback in CLI fixture tests

### DIFF
--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -132,10 +132,10 @@ fn test_cli_with_fixtures() {
                     .and_then(|f| f.as_array_mut())
                 {
                     fields.retain(|f| {
-                        let is_diagnostic =
-                            f.get("Type").and_then(|t| t.as_str()) == Some("diagnostic");
-                        let is_warning_fallback =
-                            f.get("Label").and_then(|l| l.as_str()) == Some("Warning");
+                        let field_type = f.get("Type").and_then(|t| t.as_str());
+                        let is_diagnostic = field_type == Some("diagnostic");
+                        let is_warning_fallback = field_type == Some("text_v2")
+                            && f.get("Label").and_then(|l| l.as_str()) == Some("Warning");
                         !is_diagnostic && !is_warning_fallback
                     });
                 }

--- a/src/parser/cli/tests/cli_test.rs
+++ b/src/parser/cli/tests/cli_test.rs
@@ -121,15 +121,23 @@ fn test_cli_with_fixtures() {
         // Try JSON parsing; fall back to string comparison for text/human output
         match serde_json::from_str::<serde_json::Value>(actual_output.trim()) {
             Ok(actual_json) => {
-                // JSON output: filter diagnostics and check membership
-                #[cfg_attr(not(feature = "diagnostics"), allow(unused_mut))]
+                // JSON output: filter soft-finding fields and check membership.
+                // A soft finding renders as the structured `Diagnostic` (diagnostics
+                // feature) or, in a build without that feature, as a `Warning`-labelled
+                // text_v2 fallback carrying the same information (see `diagnostic()` in
+                // visualsign-near's render.rs) -- both shapes are display noise here.
                 let mut display_payload = actual_json.clone();
-                #[cfg(feature = "diagnostics")]
                 if let Some(fields) = display_payload
                     .get_mut("Fields")
                     .and_then(|f| f.as_array_mut())
                 {
-                    fields.retain(|f| f.get("Type").and_then(|t| t.as_str()) != Some("diagnostic"));
+                    fields.retain(|f| {
+                        let is_diagnostic =
+                            f.get("Type").and_then(|t| t.as_str()) == Some("diagnostic");
+                        let is_warning_fallback =
+                            f.get("Label").and_then(|l| l.as_str()) == Some("Warning");
+                        !is_diagnostic && !is_warning_fallback
+                    });
                 }
 
                 let expected_json: serde_json::Value =


### PR DESCRIPTION
## Summary

`make -C src parser-cli-narrow-build-check` (CI-only, builds `parser_cli` with a single chain feature and no `diagnostics` feature) fails on `main`: `visualsign-near`'s `diagnostic()` shim renders a soft finding as a plain `Warning`-labelled `text_v2` field when the `diagnostics` feature is off, instead of a structured `Diagnostic`, but `cli_test.rs` only ever filtered `Type == "diagnostic"` fields out of the display comparison before checking membership against `*.display.expected` fixtures.

Any fixture that legitimately triggers a diagnostic (e.g. `near-json`, whose deadline is deliberately expired to also exercise the `deadline` diagnostic) breaks the exact field-count assertion once the diagnostics-off build is exercised, even though nothing about the fixture or the rendered production payload changed.

Broadens the filter to recognize both shapes the `diagnostic()` shim can produce, mirroring the matcher `visualsign-near`'s own `test_support::is_warning_diagnostic` already uses internally for the same purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)