### PR TITLE
Revert "ci(cli): publish parser_cli as a release asset"

### DIFF
--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -134,33 +134,6 @@ jobs:
           done
           docker image push --all-tags "ghcr.io/anchorageoss/${{ matrix.target.name }}"
 
-      - name: Upload CLI binary to release
-        # parser_cli is also usable standalone (no Docker required), so
-        # attach the static binary we already built as a release asset
-        # alongside the OCI image. images/parser_cli/Containerfile builds
-        # this image with only `--features solana` (see the "parser_cli
-        # (Solana)" matrix label above), so the asset name says so rather
-        # than implying it covers every chain parser_cli can be built with.
-        # Only meaningful on a release build -- SEMVER_TAG is empty for
-        # PR/branch builds, and (per the TVC step's comment above) a
-        # push-to-main run can compute a SEMVER_TAG before release.yml has
-        # actually created that release, so this is a no-op in that race;
-        # the tag-dispatched stagex run created afterward picks it up.
-        if: matrix.target.name == 'parser_cli' && steps.build.outputs.semver_tag != ''
-        env:
-          SEMVER_TAG: ${{ steps.build.outputs.semver_tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ! gh release view "$SEMVER_TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "No release $SEMVER_TAG yet; skipping CLI binary upload."
-            exit 0
-          fi
-          docker create --name tmp-extract-cli "ghcr.io/anchorageoss/parser_cli:${SEMVER_TAG}" /bin/true
-          asset="parser_cli-solana-${SEMVER_TAG}-x86_64-unknown-linux-musl"
-          docker cp tmp-extract-cli:/usr/local/bin/parser_cli "$asset"
-          docker rm tmp-extract-cli
-          gh release upload "$SEMVER_TAG" "$asset" --clobber --repo "${GITHUB_REPOSITORY}"
-
       - name: TVC deployment details
         if: matrix.target.name == 'parser_app'
         shell: bash


### PR DESCRIPTION
Reverts the **release-asset half of #480 only**. The narrow feature-build check from the same PR stays — it earned its place within hours by catching a bug latent since #439 (fixed in #484).

## What happened

Immutable releases were enabled on this repo today, on the reasonable expectation that it would be a no-op. It isn't, for this one step: publishing a release now freezes its assets, and `release.yml:114` is

```
gh release create "$TAG" --generate-notes
```

which creates **and publishes** in the same call. By the time stagex has built the image and reaches `gh release upload`, the release can no longer accept an asset:

```
HTTP 422: Cannot upload assets to an immutable release.
.../releases/384760827/assets?name=parser_cli-solana-v0.949.0-x86_64-unknown-linux-musl
```

So this is **not a flaw in #480** — it was written against a repo where publishing didn't freeze assets, and the setting changed underneath it. It is also not the race its comment anticipates: the step says "the tag-dispatched stagex run created afterward picks it up," but that run gets the same 422, because the release is frozen rather than absent. Its guard (`if ! gh release view … skip`) covers absence, and `--clobber` cannot help.

## Why revert rather than fix forward

**Immutability stays** — that is the decision, confirmed. It is a supply-chain guarantee on a parser that sits on a signing path and is heading into external audit, and it is worth more than a download convenience.

Making the asset work under it needs the release created as a **draft**, assets attached, and only then published — which reorders work across `release.yml` and `stagex.yml` and wants the TVC notes edit to land pre-publish too. That is #485, filed with the design and the hard parts (who flips `--draft=false` when the two uploads are different matrix targets; what a mid-flight failure leaves behind given `release.yml`'s `release_exists` retry assumes published releases; draft invisibility for the length of the stagex build). Too much to land inline while `main` is red, hence: revert now, do it properly next.

## Worth recording: why nothing caught this

Immutability freezes **assets and the tag** but **not the body**. The adjacent TVC-details step mutates the same release with `gh release edit --notes-file` and still works fine — v0.946.0, v0.903.0 and v0.929.0 all carry their mirrored TVC details. So the asset step sat next to a release mutation that immutability happens to permit, and nothing in either diff signalled that one of them would break and the other wouldn't.

## Scope

One step removed, 27 lines, nothing else touched:

- `contents: write` stays — it predates #480 and its comment cites the TVC `gh release edit`.
- No docs referenced the asset (grepped `.md`/`.mdx`/`.yml`; only hits were the step's own lines).
- #480's other half — the `parser-cli-narrow-build-check` target, its `main.yml` job, the `cli_test.rs` change — untouched.
- YAML re-parsed after the edit; the `parser` job still has its remaining 7 steps in order.

## Note on `main`

`main` @ `5f44ab68` is red on **two independent** checks. This PR fixes `Build parser_cli (Solana)`. The `ubuntu` failure is a separate bug fixed by **#484**; both need to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)